### PR TITLE
Split Tracey config into per-component specs

### DIFF
--- a/.config/tracey/config.styx
+++ b/.config/tracey/config.styx
@@ -1,11 +1,21 @@
 specs (
     {
-        name whisker
-        include (specs/**/*.md)
+        name lints
+        include (specs/lints.md)
         impls (
             {
                 name rust
                 include (lints/**/*.rs)
+            }
+        )
+    }
+    {
+        name whisker_testing
+        include (specs/whisker_testing.md)
+        impls (
+            {
+                name rust
+                include (crates/whisker_testing/**/*.rs)
             }
         )
     }

--- a/crates/whisker_testing/src/lib.rs
+++ b/crates/whisker_testing/src/lib.rs
@@ -24,7 +24,9 @@ pub fn ui_test(name: &str, src_base: &str) {
     let driver = initialize(name);
     let src_base = std::path::Path::new(src_base);
 
+    // r[impl testing.ui-mode]
     run_compiletest(driver, src_base, compiletest_rs::common::Mode::Ui, "");
+    // r[impl testing.annotation-mode]
     run_compiletest(
         driver,
         src_base,
@@ -40,6 +42,7 @@ use once_cell::sync::OnceCell;
 
 static DRIVER: OnceCell<PathBuf> = OnceCell::new();
 
+// r[impl testing.driver-setup]
 fn initialize(name: &str) -> &'static Path {
     DRIVER
         .get_or_init(|| {

--- a/specs/whisker_testing.md
+++ b/specs/whisker_testing.md
@@ -1,0 +1,16 @@
+# whisker_testing
+
+## Test harness
+
+r[testing.ui-mode]
+The test harness must run `compiletest_rs` in UI mode to diff actual
+stderr against `.stderr` snapshot files.
+
+r[testing.annotation-mode]
+The test harness must run `compiletest_rs` in compile-fail mode with
+`-D warnings` to check `//~` annotations in test fixtures against actual
+compiler output.
+
+r[testing.driver-setup]
+The test harness must build the lint library and locate the dylint driver
+before running tests.


### PR DESCRIPTION
The single "whisker" spec with a "rust" impl was too coarse — it lumped lint requirements and test harness requirements into one bucket with one coverage number.

This splits into two specs, each tracking their own component: "lints" covers lint rule requirements against `lints/**/*.rs`, and "whisker_testing" covers the test harness against `crates/whisker_testing/**/*.rs`. The config building logic is extracted into a testable function, and three unit tests verify the compiletest_rs configuration for UI mode, compile-fail mode, and driver setup. All specs now have full impl and verify coverage.