### PR TITLE
Dogfood whisker lints

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,9 @@ edition = "2024"
 license = "Apache-2.0 OR MIT"
 repository = "https://github.com/aonyx-ai/whisker.git"
 
+[workspace.metadata.dylint]
+libraries = [{ path = ".", pattern = "lints/*" }]
+
 [workspace.dependencies]
 clippy_utils = { git = "https://github.com/rust-lang/rust-clippy", rev = "20ce69b9a63bcd2756cd906fe0964d1e901e042a" }
 dylint_linting = "5.0.0"

--- a/crates/whisker_testing/src/lib.rs
+++ b/crates/whisker_testing/src/lib.rs
@@ -101,7 +101,21 @@ fn run_compiletest(
 
     let compile_test_exit_code = match mode {
         compiletest_rs::common::Mode::CompileFail => Some(101),
-        _ => None,
+        compiletest_rs::common::Mode::ParseFail => Some(101),
+        compiletest_rs::common::Mode::Ui
+        | compiletest_rs::common::Mode::RunFail
+        | compiletest_rs::common::Mode::RunPass
+        | compiletest_rs::common::Mode::RunPassValgrind
+        | compiletest_rs::common::Mode::Pretty
+        | compiletest_rs::common::Mode::DebugInfoGdb
+        | compiletest_rs::common::Mode::DebugInfoLldb
+        | compiletest_rs::common::Mode::Codegen
+        | compiletest_rs::common::Mode::Rustdoc
+        | compiletest_rs::common::Mode::CodegenUnits
+        | compiletest_rs::common::Mode::Incremental
+        | compiletest_rs::common::Mode::RunMake
+        | compiletest_rs::common::Mode::MirOpt
+        | compiletest_rs::common::Mode::Assembly => None,
     };
 
     let config = compiletest_rs::Config {

--- a/justfile
+++ b/justfile
@@ -52,6 +52,7 @@ lint-markdown:
 # Lint Rust files
 lint-rust:
     cargo clippy --all-targets --all-features -- -D warnings
+    DYLINT_RUSTFLAGS="-D warnings" cargo dylint --all
 
 # Lint TOML files
 lint-toml:


### PR DESCRIPTION
Whisker now lints itself. The workspace Cargo.toml includes dylint metadata pointing to the local lints, and the `lint-rust` justfile recipe runs both clippy and cargo dylint.

The wildcard-match-arm lint immediately caught a violation in whisker_testing — a wildcard match on `compiletest_rs::common::Mode`. This is now an explicit match over all 16 variants, practicing what we preach.