### PR TITLE
Add prefer-let-else lint

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -820,6 +820,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "prefer_let_else"
+version = "0.1.0"
+dependencies = [
+ "clippy_utils",
+ "dylint_linting",
+ "whisker_testing",
+]
+
+[[package]]
 name = "prettyplease"
 version = "0.2.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/lints/prefer_let_else/.cargo/config.toml
+++ b/lints/prefer_let_else/.cargo/config.toml
@@ -1,0 +1,2 @@
+[target.'cfg(all())']
+rustflags = ["-C", "linker=dylint-link"]

--- a/lints/prefer_let_else/Cargo.toml
+++ b/lints/prefer_let_else/Cargo.toml
@@ -1,0 +1,19 @@
+[package]
+name = "prefer_let_else"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+publish = false
+
+[lib]
+crate-type = ["cdylib"]
+
+[dependencies]
+clippy_utils.workspace = true
+dylint_linting.workspace = true
+
+[dev-dependencies]
+whisker_testing.workspace = true
+
+[package.metadata.rust-analyzer]
+rustc_private = true

--- a/lints/prefer_let_else/src/lib.rs
+++ b/lints/prefer_let_else/src/lib.rs
@@ -1,0 +1,84 @@
+#![feature(rustc_private)]
+#![warn(unused_extern_crates)]
+
+extern crate rustc_hir;
+
+use clippy_utils::diagnostics::span_lint_and_help;
+use rustc_hir::{Expr, ExprKind};
+use rustc_lint::{LateContext, LateLintPass};
+
+// r[impl lint.prefer-let-else.level]
+dylint_linting::declare_late_lint! {
+    /// ### What it does
+    ///
+    /// Flags `if let` expressions where the `else` branch diverges (returns,
+    /// breaks, continues, or panics), and suggests rewriting them using
+    /// `let-else` syntax.
+    ///
+    /// ### Why is this bad?
+    ///
+    /// `let-else` makes the "happy path" obvious and reduces nesting. When the
+    /// `else` branch always diverges, the intent is an early exit on pattern
+    /// mismatch, which `let-else` expresses more directly.
+    ///
+    /// ### Known problems
+    ///
+    /// None.
+    ///
+    /// ### Examples
+    ///
+    /// ```rust
+    /// # fn example(value: Option<i32>) -> Option<i32> {
+    /// // Bad:
+    /// let x = if let Some(v) = value {
+    ///     v
+    /// } else {
+    ///     return None;
+    /// };
+    ///
+    /// // Good:
+    /// let Some(x) = value else {
+    ///     return None;
+    /// };
+    /// # Some(x)
+    /// # }
+    /// ```
+    pub PREFER_LET_ELSE,
+    Warn,
+    "`if let` with a diverging `else` branch can be written as `let-else`"
+}
+
+impl<'tcx> LateLintPass<'tcx> for PreferLetElse {
+    fn check_expr(&mut self, cx: &LateContext<'tcx>, expr: &'tcx Expr<'_>) {
+        // r[impl lint.prefer-let-else.detect]
+        let ExprKind::If(cond, _then_block, Some(else_expr)) = expr.kind else {
+            return;
+        };
+
+        // r[impl lint.prefer-let-else.if-let-only]
+        let ExprKind::Let(..) = cond.kind else {
+            return;
+        };
+
+        // r[impl lint.prefer-let-else.diverging-else]
+        let else_ty = cx.typeck_results().expr_ty(else_expr);
+        if !else_ty.is_never() {
+            return;
+        }
+
+        // r[impl lint.prefer-let-else.message]
+        span_lint_and_help(
+            cx,
+            PREFER_LET_ELSE,
+            expr.span,
+            "`if let` with a diverging `else` can be rewritten as `let-else`",
+            None,
+            "use `let ... else { <diverge> };` instead",
+        );
+    }
+}
+
+#[test]
+fn ui() {
+    whisker_testing::ui_test(env!("CARGO_PKG_NAME"), "ui");
+}

--- a/lints/prefer_let_else/ui/main.rs
+++ b/lints/prefer_let_else/ui/main.rs
@@ -1,0 +1,68 @@
+fn option_value() -> Option<i32> {
+    let value: Option<i32> = Some(42);
+
+    // r[verify lint.prefer-let-else.detect]
+    // r[verify lint.prefer-let-else.diverging-else]
+    // r[verify lint.prefer-let-else.level]
+    // r[verify lint.prefer-let-else.message]
+    let x = if let Some(v) = value { //~ ERROR `if let` with a diverging `else` can be rewritten as `let-else`
+        v
+    } else {
+        return None;
+    };
+
+    Some(x)
+}
+
+fn with_break() {
+    let values = vec![Some(1), None, Some(3)];
+    for item in values {
+        // r[verify lint.prefer-let-else.detect]
+        if let Some(v) = item { //~ ERROR `if let` with a diverging `else` can be rewritten as `let-else`
+            let _ = v;
+        } else {
+            continue;
+        }
+    }
+}
+
+fn with_panic() {
+    let value: Option<i32> = Some(42);
+
+    // r[verify lint.prefer-let-else.detect]
+    let _x = if let Some(v) = value { //~ ERROR `if let` with a diverging `else` can be rewritten as `let-else`
+        v
+    } else {
+        panic!("missing value");
+    };
+}
+
+// r[verify lint.prefer-let-else.if-let-only]
+fn if_let_without_else() {
+    let value: Option<i32> = Some(42);
+    if let Some(v) = value {
+        let _ = v;
+    }
+}
+
+// r[verify lint.prefer-let-else.if-let-only]
+fn if_let_with_non_diverging_else() {
+    let value: Option<i32> = Some(42);
+    if let Some(v) = value {
+        let _ = v;
+    } else {
+        let _ = 0;
+    }
+}
+
+// r[verify lint.prefer-let-else.if-let-only]
+fn regular_if_else() {
+    let condition = true;
+    if condition {
+        let _ = 1;
+    } else {
+        return;
+    }
+}
+
+fn main() {}

--- a/lints/prefer_let_else/ui/main.stderr
+++ b/lints/prefer_let_else/ui/main.stderr
@@ -1,0 +1,41 @@
+warning: `if let` with a diverging `else` can be rewritten as `let-else`
+  --> $DIR/main.rs:8:13
+   |
+LL |       let x = if let Some(v) = value { //~ ERROR `if let` with a diverging `else` can be rewritten as `let-else`
+   |  _____________^
+LL | |         v
+LL | |     } else {
+LL | |         return None;
+LL | |     };
+   | |_____^
+   |
+   = help: use `let ... else { <diverge> };` instead
+   = note: `#[warn(prefer_let_else)]` on by default
+
+warning: `if let` with a diverging `else` can be rewritten as `let-else`
+  --> $DIR/main.rs:21:9
+   |
+LL | /         if let Some(v) = item { //~ ERROR `if let` with a diverging `else` can be rewritten as `let-else`
+LL | |             let _ = v;
+LL | |         } else {
+LL | |             continue;
+LL | |         }
+   | |_________^
+   |
+   = help: use `let ... else { <diverge> };` instead
+
+warning: `if let` with a diverging `else` can be rewritten as `let-else`
+  --> $DIR/main.rs:33:14
+   |
+LL |       let _x = if let Some(v) = value { //~ ERROR `if let` with a diverging `else` can be rewritten as `let-else`
+   |  ______________^
+LL | |         v
+LL | |     } else {
+LL | |         panic!("missing value");
+LL | |     };
+   | |_____^
+   |
+   = help: use `let ... else { <diverge> };` instead
+
+warning: 3 warnings emitted
+

--- a/specs/lints.md
+++ b/specs/lints.md
@@ -24,3 +24,23 @@ The diagnostic must suggest matching each variant explicitly instead of using
 
 r[lint.wildcard-match-arm.level]
 The lint must default to `Warn`.
+
+## Prefer let-else
+
+r[lint.prefer-let-else.detect]
+The lint must flag `if let` expressions where the `else` branch diverges
+(returns, breaks, continues, or calls a diverging function such as `panic!`).
+
+r[lint.prefer-let-else.if-let-only]
+The lint must not fire on regular `if-else` expressions (without a `let`
+pattern), or on `if let` expressions that have no `else` branch.
+
+r[lint.prefer-let-else.diverging-else]
+The lint must not fire when the `else` branch does not diverge (i.e., when the
+`else` branch has a non-`!` return type).
+
+r[lint.prefer-let-else.message]
+The diagnostic must suggest rewriting the `if let` as `let-else` syntax.
+
+r[lint.prefer-let-else.level]
+The lint must default to `Warn`.


### PR DESCRIPTION
Flags if-let expressions where the else branch diverges (return, break, continue, panic) and suggests rewriting to let-else syntax. This is one of the core Aonyx Rust conventions — let-else makes the happy path obvious and the early return explicit.

Non-diverging else branches are deliberately not flagged here; those are covered by #3 (if-let-with-else) which suggests match instead.

All five spec rules have full Tracey coverage.

Closes #2