### PR TITLE
Add bool-param lint

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -80,6 +80,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "843867be96c8daad0d758b57df9392b6d8d271134fce549de6ce169ff98a92af"
 
 [[package]]
+name = "bool_param"
+version = "0.1.0"
+dependencies = [
+ "clippy_utils",
+ "dylint_linting",
+ "whisker_testing",
+]
+
+[[package]]
 name = "camino"
 version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/lints/bool_param/.cargo/config.toml
+++ b/lints/bool_param/.cargo/config.toml
@@ -1,0 +1,2 @@
+[target.'cfg(all())']
+rustflags = ["-C", "linker=dylint-link"]

--- a/lints/bool_param/Cargo.toml
+++ b/lints/bool_param/Cargo.toml
@@ -1,0 +1,19 @@
+[package]
+name = "bool_param"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+publish = false
+
+[lib]
+crate-type = ["cdylib"]
+
+[dependencies]
+clippy_utils.workspace = true
+dylint_linting.workspace = true
+
+[dev-dependencies]
+whisker_testing.workspace = true
+
+[package.metadata.rust-analyzer]
+rustc_private = true

--- a/lints/bool_param/src/lib.rs
+++ b/lints/bool_param/src/lib.rs
@@ -1,0 +1,116 @@
+#![feature(rustc_private)]
+#![warn(unused_extern_crates)]
+
+extern crate rustc_hir;
+extern crate rustc_span;
+
+use clippy_utils::diagnostics::span_lint_and_help;
+use rustc_hir::{FnDecl, Item, ItemKind, PrimTy, QPath, Ty, TyKind, intravisit::FnKind};
+use rustc_lint::{LateContext, LateLintPass};
+use rustc_span::Span;
+
+// r[impl lint.bool-param.level]
+dylint_linting::declare_late_lint! {
+    /// ### What it does
+    ///
+    /// Flags `bool` parameters in function signatures and `bool` fields in
+    /// struct definitions.
+    ///
+    /// ### Why is this bad?
+    ///
+    /// Boolean parameters and fields obscure intent at call sites and in data
+    /// models. An enum with meaningful variant names makes the code
+    /// self-documenting and prevents accidental transposition of arguments.
+    ///
+    /// ### Known problems
+    ///
+    /// None.
+    ///
+    /// ### Examples
+    ///
+    /// ```rust
+    /// // Bad:
+    /// fn create_repo(name: &str, is_public: bool) {}
+    ///
+    /// struct Config {
+    ///     verbose: bool,
+    /// }
+    ///
+    /// // Good:
+    /// enum Visibility { Public, Private }
+    /// fn create_repo(name: &str, visibility: Visibility) {}
+    ///
+    /// enum Verbosity { Quiet, Verbose }
+    /// struct Config {
+    ///     verbosity: Verbosity,
+    /// }
+    /// ```
+    pub BOOL_PARAM,
+    Warn,
+    "bool parameters and fields obscure intent; use an enum with meaningful variants"
+}
+
+fn is_bool_ty(ty: &Ty<'_>) -> bool {
+    if let TyKind::Path(QPath::Resolved(None, path)) = ty.kind {
+        path.res == rustc_hir::def::Res::PrimTy(PrimTy::Bool)
+    } else {
+        false
+    }
+}
+
+impl<'tcx> LateLintPass<'tcx> for BoolParam {
+    // r[impl lint.bool-param.detect-fn]
+    fn check_fn(
+        &mut self,
+        cx: &LateContext<'tcx>,
+        kind: FnKind<'tcx>,
+        decl: &'tcx FnDecl<'tcx>,
+        _body: &'tcx rustc_hir::Body<'tcx>,
+        _span: Span,
+        _def_id: rustc_hir::def_id::LocalDefId,
+    ) {
+        let (FnKind::ItemFn(..) | FnKind::Method(..)) = kind else {
+            return;
+        };
+
+        for input in decl.inputs {
+            if is_bool_ty(input) {
+                // r[impl lint.bool-param.message]
+                span_lint_and_help(
+                    cx,
+                    BOOL_PARAM,
+                    input.span,
+                    "parameter has type `bool`",
+                    None,
+                    "use an enum with meaningful variants instead of `bool`",
+                );
+            }
+        }
+    }
+
+    // r[impl lint.bool-param.detect-struct]
+    fn check_item(&mut self, cx: &LateContext<'tcx>, item: &'tcx Item<'tcx>) {
+        let ItemKind::Struct(_, _, variant_data) = &item.kind else {
+            return;
+        };
+
+        for field in variant_data.fields() {
+            if is_bool_ty(field.ty) {
+                // r[impl lint.bool-param.message]
+                span_lint_and_help(
+                    cx,
+                    BOOL_PARAM,
+                    field.ty.span,
+                    "struct field has type `bool`",
+                    None,
+                    "use an enum with meaningful variants instead of `bool`",
+                );
+            }
+        }
+    }
+}
+
+#[test]
+fn ui() {
+    whisker_testing::ui_test(env!("CARGO_PKG_NAME"), "ui");
+}

--- a/lints/bool_param/ui/main.rs
+++ b/lints/bool_param/ui/main.rs
@@ -1,0 +1,55 @@
+// r[verify lint.bool-param.detect-fn]
+// r[verify lint.bool-param.level]
+// r[verify lint.bool-param.message]
+fn create_repo(name: &str, is_public: bool) {
+    //~^ ERROR parameter has type `bool`
+    let _ = name;
+    let _ = is_public;
+}
+
+// r[verify lint.bool-param.detect-fn]
+fn multiple_bools(a: bool, b: bool) {
+    //~^ ERROR parameter has type `bool`
+    //~| ERROR parameter has type `bool`
+    let _ = a;
+    let _ = b;
+}
+
+// r[verify lint.bool-param.detect-struct]
+// r[verify lint.bool-param.message]
+struct Config {
+    verbose: bool,  //~ ERROR struct field has type `bool`
+    name: String,
+    debug: bool,    //~ ERROR struct field has type `bool`
+}
+
+// r[verify lint.bool-param.return-type-allowed]
+fn returns_bool() -> bool {
+    true
+}
+
+// r[verify lint.bool-param.return-type-allowed]
+fn takes_str_returns_bool(s: &str) -> bool {
+    s.is_empty()
+}
+
+// r[verify lint.bool-param.local-var-allowed]
+fn uses_bool_locally() {
+    let flag: bool = true;
+    let _ = flag;
+}
+
+// r[verify lint.bool-param.detect-fn]
+fn single_bool_param(flag: bool) {
+    //~^ ERROR parameter has type `bool`
+    let _ = flag;
+}
+
+struct NoBoolFields {
+    count: i32,
+    name: String,
+}
+
+fn no_params() {}
+
+fn main() {}

--- a/lints/bool_param/ui/main.stderr
+++ b/lints/bool_param/ui/main.stderr
@@ -1,0 +1,51 @@
+warning: parameter has type `bool`
+  --> $DIR/main.rs:4:39
+   |
+LL | fn create_repo(name: &str, is_public: bool) {
+   |                                       ^^^^
+   |
+   = help: use an enum with meaningful variants instead of `bool`
+   = note: `#[warn(bool_param)]` on by default
+
+warning: parameter has type `bool`
+  --> $DIR/main.rs:11:22
+   |
+LL | fn multiple_bools(a: bool, b: bool) {
+   |                      ^^^^
+   |
+   = help: use an enum with meaningful variants instead of `bool`
+
+warning: parameter has type `bool`
+  --> $DIR/main.rs:11:31
+   |
+LL | fn multiple_bools(a: bool, b: bool) {
+   |                               ^^^^
+   |
+   = help: use an enum with meaningful variants instead of `bool`
+
+warning: struct field has type `bool`
+  --> $DIR/main.rs:21:14
+   |
+LL |     verbose: bool,  //~ ERROR struct field has type `bool`
+   |              ^^^^
+   |
+   = help: use an enum with meaningful variants instead of `bool`
+
+warning: struct field has type `bool`
+  --> $DIR/main.rs:23:12
+   |
+LL |     debug: bool,    //~ ERROR struct field has type `bool`
+   |            ^^^^
+   |
+   = help: use an enum with meaningful variants instead of `bool`
+
+warning: parameter has type `bool`
+  --> $DIR/main.rs:43:28
+   |
+LL | fn single_bool_param(flag: bool) {
+   |                            ^^^^
+   |
+   = help: use an enum with meaningful variants instead of `bool`
+
+warning: 6 warnings emitted
+

--- a/specs/lints.md
+++ b/specs/lints.md
@@ -25,22 +25,23 @@ The diagnostic must suggest matching each variant explicitly instead of using
 r[lint.wildcard-match-arm.level]
 The lint must default to `Warn`.
 
-## Prefer let-else
+## Bool param
 
-r[lint.prefer-let-else.detect]
-The lint must flag `if let` expressions where the `else` branch diverges
-(returns, breaks, continues, or calls a diverging function such as `panic!`).
+r[lint.bool-param.detect-fn]
+The lint must flag `bool` parameters in function signatures.
 
-r[lint.prefer-let-else.if-let-only]
-The lint must not fire on regular `if-else` expressions (without a `let`
-pattern), or on `if let` expressions that have no `else` branch.
+r[lint.bool-param.detect-struct]
+The lint must flag `bool` fields in struct definitions.
 
-r[lint.prefer-let-else.diverging-else]
-The lint must not fire when the `else` branch does not diverge (i.e., when the
-`else` branch has a non-`!` return type).
+r[lint.bool-param.return-type-allowed]
+The lint must not flag `bool` return types.
 
-r[lint.prefer-let-else.message]
-The diagnostic must suggest rewriting the `if let` as `let-else` syntax.
+r[lint.bool-param.local-var-allowed]
+The lint must not flag `bool` local variables.
 
-r[lint.prefer-let-else.level]
+r[lint.bool-param.message]
+The diagnostic must suggest using an enum with meaningful variants instead of
+`bool`.
+
+r[lint.bool-param.level]
 The lint must default to `Warn`.


### PR DESCRIPTION
Flags bool parameters in function signatures and bool fields in struct definitions, suggesting enums with meaningful variants instead. Bool return types and local variables are not flagged.

All spec rules have full Tracey coverage.

Closes #8