### PR TITLE
Add derive-order lint

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -170,6 +170,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "derive_order"
+version = "0.1.0"
+dependencies = [
+ "clippy_utils",
+ "dylint_linting",
+ "whisker_testing",
+]
+
+[[package]]
 name = "diff"
 version = "0.1.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/lints/derive_order/.cargo/config.toml
+++ b/lints/derive_order/.cargo/config.toml
@@ -1,0 +1,2 @@
+[target.'cfg(all())']
+rustflags = ["-C", "linker=dylint-link"]

--- a/lints/derive_order/Cargo.toml
+++ b/lints/derive_order/Cargo.toml
@@ -1,0 +1,19 @@
+[package]
+name = "derive_order"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+publish = false
+
+[lib]
+crate-type = ["cdylib"]
+
+[dependencies]
+clippy_utils.workspace = true
+dylint_linting.workspace = true
+
+[dev-dependencies]
+whisker_testing.workspace = true
+
+[package.metadata.rust-analyzer]
+rustc_private = true

--- a/lints/derive_order/src/lib.rs
+++ b/lints/derive_order/src/lib.rs
@@ -1,0 +1,169 @@
+#![feature(rustc_private)]
+#![warn(unused_extern_crates)]
+
+extern crate rustc_ast;
+extern crate rustc_span;
+
+use clippy_utils::diagnostics::span_lint_and_then;
+use rustc_ast::token::TokenKind;
+use rustc_ast::tokenstream::TokenTree;
+use rustc_ast::{AttrArgs, AttrKind, Attribute, Item};
+use rustc_lint::{EarlyContext, EarlyLintPass};
+use rustc_span::Span;
+
+const STD_DERIVES: &[&str] = &[
+    "Copy",
+    "Clone",
+    "Eq",
+    "PartialEq",
+    "Ord",
+    "PartialOrd",
+    "Hash",
+    "Debug",
+    "Default",
+];
+
+// r[impl lint.derive-order.level]
+dylint_linting::declare_pre_expansion_lint! {
+    /// ### What it does
+    ///
+    /// Enforces a canonical ordering for `#[derive(...)]` attributes: standard
+    /// library derives must appear first in the prescribed order (Copy, Clone,
+    /// Eq, PartialEq, Ord, PartialOrd, Hash, Debug, Default), followed by
+    /// third-party derives sorted alphabetically by crate and then by macro
+    /// name.
+    ///
+    /// ### Why is this bad?
+    ///
+    /// Inconsistent derive ordering makes code harder to scan and review.
+    /// A canonical ordering reduces cognitive load and eliminates style
+    /// debates.
+    ///
+    /// ### Known problems
+    ///
+    /// None.
+    ///
+    /// ### Examples
+    ///
+    /// ```rust
+    /// // Bad:
+    /// #[derive(Debug, Clone, Default)]
+    /// struct Foo;
+    ///
+    /// // Good:
+    /// #[derive(Clone, Debug, Default)]
+    /// struct Foo;
+    /// ```
+    pub DERIVE_ORDER,
+    Warn,
+    "derive macros are not in canonical order"
+}
+
+fn std_derive_index(name: &str) -> Option<usize> {
+    STD_DERIVES.iter().position(|&s| s == name)
+}
+
+fn macro_name(full_path: &str) -> &str {
+    full_path.rsplit("::").next().unwrap_or(full_path)
+}
+
+fn extract_derive_names(attrs: &[Attribute]) -> Option<(Vec<String>, Span)> {
+    for attr in attrs {
+        let AttrKind::Normal(normal_attr) = &attr.kind else {
+            continue;
+        };
+        let has_derive = normal_attr
+            .item
+            .path
+            .segments
+            .iter()
+            .any(|seg| seg.ident.name.as_str() == "derive");
+        if !has_derive {
+            continue;
+        }
+        let AttrArgs::Delimited(delim_args) = &normal_attr.item.args else {
+            continue;
+        };
+
+        let mut names = Vec::new();
+        let mut current_path = String::new();
+
+        for tt in delim_args.tokens.iter() {
+            let TokenTree::Token(token, _) = tt else {
+                continue;
+            };
+            if let TokenKind::Ident(sym, _) = token.kind {
+                if !current_path.is_empty() {
+                    current_path.push_str("::");
+                }
+                current_path.push_str(sym.as_str());
+            } else if let TokenKind::Comma = token.kind
+                && !current_path.is_empty()
+            {
+                names.push(std::mem::take(&mut current_path));
+            }
+        }
+        if !current_path.is_empty() {
+            names.push(current_path);
+        }
+
+        if !names.is_empty() {
+            return Some((names, attr.span));
+        }
+    }
+    None
+}
+
+fn compute_expected_order(names: &[String]) -> Vec<String> {
+    let mut std_derives: Vec<&String> = names
+        .iter()
+        .filter(|n| std_derive_index(macro_name(n)).is_some())
+        .collect();
+    std_derives.sort_by_key(|n| std_derive_index(macro_name(n)).unwrap_or(usize::MAX));
+
+    let mut third_party: Vec<&String> = names
+        .iter()
+        .filter(|n| std_derive_index(macro_name(n)).is_none())
+        .collect();
+    third_party.sort_by_key(|a| a.to_lowercase());
+
+    let mut result: Vec<String> = std_derives.into_iter().cloned().collect();
+    result.extend(third_party.into_iter().cloned());
+    result
+}
+
+// r[impl lint.derive-order.detect]
+impl EarlyLintPass for DeriveOrder {
+    fn check_item(&mut self, cx: &EarlyContext<'_>, item: &Item) {
+        let Some((names, span)) = extract_derive_names(&item.attrs) else {
+            return;
+        };
+
+        if names.len() <= 1 {
+            return;
+        }
+
+        let expected = compute_expected_order(&names);
+
+        if names == expected {
+            return;
+        }
+
+        // r[impl lint.derive-order.message]
+        let expected_str = expected.join(", ");
+        span_lint_and_then(
+            cx,
+            DERIVE_ORDER,
+            span,
+            "derive macros are not in canonical order",
+            |diag| {
+                diag.help(format!("expected order: {expected_str}"));
+            },
+        );
+    }
+}
+
+#[test]
+fn ui() {
+    whisker_testing::ui_test(env!("CARGO_PKG_NAME"), "ui");
+}

--- a/lints/derive_order/ui/main.rs
+++ b/lints/derive_order/ui/main.rs
@@ -1,0 +1,53 @@
+// r[verify lint.derive-order.level]
+// r[verify lint.derive-order.std-order]
+#[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug, Default)]
+struct CorrectFullStdOrder;
+
+#[derive(Clone, Debug)]
+struct CorrectPartialStdOrder;
+
+#[derive(Clone, Debug, Default)]
+struct CorrectSubsetStdOrder;
+
+#[derive(Copy, Clone)]
+struct CorrectTwoStdDerives;
+
+// r[verify lint.derive-order.detect]
+// r[verify lint.derive-order.message]
+#[derive(Debug, Clone)] //~ ERROR derive macros are not in canonical order
+struct WrongStdOrder;
+
+#[derive(Default, Copy, Clone)] //~ ERROR derive macros are not in canonical order
+struct WrongStdOrderMultiple;
+
+#[derive(Hash, Debug, Eq, PartialEq)] //~ ERROR derive macros are not in canonical order
+struct WrongStdOrderFour;
+
+// r[verify lint.derive-order.third-party-after-std]
+#[derive(Clone, Debug, MyMacro)] //~ ERROR cannot find derive macro `MyMacro`
+struct CorrectThirdPartyAfterStd;
+
+#[derive(MyMacro, Clone, Debug)] //~ ERROR derive macros are not in canonical order
+//~| ERROR cannot find derive macro `MyMacro`
+struct ThirdPartyBeforeStd;
+
+// r[verify lint.derive-order.third-party-alpha]
+#[derive(Clone, Debug, Alpha, Beta)] //~ ERROR cannot find derive macro `Alpha`
+//~| ERROR cannot find derive macro `Beta`
+struct CorrectThirdPartyAlpha;
+
+#[derive(Clone, Debug, Beta, Alpha)] //~ ERROR derive macros are not in canonical order
+//~| ERROR cannot find derive macro `Beta`
+//~| ERROR cannot find derive macro `Alpha`
+struct WrongThirdPartyAlpha;
+
+// r[verify lint.derive-order.detect]
+#[derive(Debug, Clone, Beta, Alpha)] //~ ERROR derive macros are not in canonical order
+//~| ERROR cannot find derive macro `Beta`
+//~| ERROR cannot find derive macro `Alpha`
+struct WrongStdAndThirdParty;
+
+#[derive(Debug)]
+struct SingleDerive;
+
+fn main() {}

--- a/lints/derive_order/ui/main.stderr
+++ b/lints/derive_order/ui/main.stderr
@@ -1,0 +1,99 @@
+warning: derive macros are not in canonical order
+  --> $DIR/main.rs:17:1
+   |
+LL | #[derive(Debug, Clone)] //~ ERROR derive macros are not in canonical order
+   | ^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = help: expected order: Clone, Debug
+   = note: `#[warn(derive_order)]` on by default
+
+warning: derive macros are not in canonical order
+  --> $DIR/main.rs:20:1
+   |
+LL | #[derive(Default, Copy, Clone)] //~ ERROR derive macros are not in canonical order
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = help: expected order: Copy, Clone, Default
+
+warning: derive macros are not in canonical order
+  --> $DIR/main.rs:23:1
+   |
+LL | #[derive(Hash, Debug, Eq, PartialEq)] //~ ERROR derive macros are not in canonical order
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = help: expected order: Eq, PartialEq, Hash, Debug
+
+warning: derive macros are not in canonical order
+  --> $DIR/main.rs:30:1
+   |
+LL | #[derive(MyMacro, Clone, Debug)] //~ ERROR derive macros are not in canonical order
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = help: expected order: Clone, Debug, MyMacro
+
+warning: derive macros are not in canonical order
+  --> $DIR/main.rs:39:1
+   |
+LL | #[derive(Clone, Debug, Beta, Alpha)] //~ ERROR derive macros are not in canonical order
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = help: expected order: Clone, Debug, Alpha, Beta
+
+warning: derive macros are not in canonical order
+  --> $DIR/main.rs:45:1
+   |
+LL | #[derive(Debug, Clone, Beta, Alpha)] //~ ERROR derive macros are not in canonical order
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = help: expected order: Clone, Debug, Alpha, Beta
+
+error: cannot find derive macro `MyMacro` in this scope
+  --> $DIR/main.rs:27:24
+   |
+LL | #[derive(Clone, Debug, MyMacro)] //~ ERROR cannot find derive macro `MyMacro`
+   |                        ^^^^^^^
+
+error: cannot find derive macro `MyMacro` in this scope
+  --> $DIR/main.rs:30:10
+   |
+LL | #[derive(MyMacro, Clone, Debug)] //~ ERROR derive macros are not in canonical order
+   |          ^^^^^^^
+
+error: cannot find derive macro `Alpha` in this scope
+  --> $DIR/main.rs:35:24
+   |
+LL | #[derive(Clone, Debug, Alpha, Beta)] //~ ERROR cannot find derive macro `Alpha`
+   |                        ^^^^^
+
+error: cannot find derive macro `Beta` in this scope
+  --> $DIR/main.rs:35:31
+   |
+LL | #[derive(Clone, Debug, Alpha, Beta)] //~ ERROR cannot find derive macro `Alpha`
+   |                               ^^^^
+
+error: cannot find derive macro `Beta` in this scope
+  --> $DIR/main.rs:39:24
+   |
+LL | #[derive(Clone, Debug, Beta, Alpha)] //~ ERROR derive macros are not in canonical order
+   |                        ^^^^
+
+error: cannot find derive macro `Alpha` in this scope
+  --> $DIR/main.rs:39:30
+   |
+LL | #[derive(Clone, Debug, Beta, Alpha)] //~ ERROR derive macros are not in canonical order
+   |                              ^^^^^
+
+error: cannot find derive macro `Beta` in this scope
+  --> $DIR/main.rs:45:24
+   |
+LL | #[derive(Debug, Clone, Beta, Alpha)] //~ ERROR derive macros are not in canonical order
+   |                        ^^^^
+
+error: cannot find derive macro `Alpha` in this scope
+  --> $DIR/main.rs:45:30
+   |
+LL | #[derive(Debug, Clone, Beta, Alpha)] //~ ERROR derive macros are not in canonical order
+   |                              ^^^^^
+
+error: aborting due to 8 previous errors; 6 warnings emitted
+

--- a/specs/lints.md
+++ b/specs/lints.md
@@ -44,3 +44,28 @@ The diagnostic must suggest rewriting the `if let` as `let-else` syntax.
 
 r[lint.prefer-let-else.level]
 The lint must default to `Warn`.
+
+## Derive order
+
+r[lint.derive-order.detect]
+The lint must flag `#[derive(...)]` attributes whose derives are not in the
+canonical order.
+
+r[lint.derive-order.std-order]
+Standard library derives must appear first and in the following order: Copy,
+Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug, Default. Only the derives
+that are present need to appear, but their relative order must match this
+sequence.
+
+r[lint.derive-order.third-party-after-std]
+Third-party derives (any derive not in the standard library list) must appear
+after all standard library derives.
+
+r[lint.derive-order.third-party-alpha]
+Third-party derives must be sorted alphabetically by crate, then by macro name.
+
+r[lint.derive-order.message]
+The diagnostic must show the expected ordering of the derives.
+
+r[lint.derive-order.level]
+The lint must default to `Warn`.


### PR DESCRIPTION
Enforces the standard derive ordering convention: std traits in a fixed order (Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug, Default), then third-party derives alphabetically by crate.

All spec rules have full Tracey coverage.

Closes #9