### PR TITLE
Add if-let-with-else lint

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -603,6 +603,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cd62e6b5e86ea8eeeb8db1de02880a6abc01a397b2ebb64b5d74ac255318f5cb"
 
 [[package]]
+name = "if_let_with_else"
+version = "0.1.0"
+dependencies = [
+ "clippy_utils",
+ "dylint_linting",
+ "whisker_testing",
+]
+
+[[package]]
 name = "indexmap"
 version = "2.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/lints/bool_param/src/lib.rs
+++ b/lints/bool_param/src/lib.rs
@@ -51,11 +51,10 @@ dylint_linting::declare_late_lint! {
 }
 
 fn is_bool_ty(ty: &Ty<'_>) -> bool {
-    if let TyKind::Path(QPath::Resolved(None, path)) = ty.kind {
-        path.res == rustc_hir::def::Res::PrimTy(PrimTy::Bool)
-    } else {
-        false
-    }
+    let TyKind::Path(QPath::Resolved(None, path)) = ty.kind else {
+        return false;
+    };
+    path.res == rustc_hir::def::Res::PrimTy(PrimTy::Bool)
 }
 
 impl<'tcx> LateLintPass<'tcx> for BoolParam {

--- a/lints/derive_order/src/lib.rs
+++ b/lints/derive_order/src/lib.rs
@@ -97,7 +97,8 @@ fn extract_derive_names(attrs: &[Attribute]) -> Option<(Vec<String>, Span)> {
                     current_path.push_str("::");
                 }
                 current_path.push_str(sym.as_str());
-            } else if let TokenKind::Comma = token.kind
+            }
+            if let TokenKind::Comma = token.kind
                 && !current_path.is_empty()
             {
                 names.push(std::mem::take(&mut current_path));

--- a/lints/if_let_with_else/.cargo/config.toml
+++ b/lints/if_let_with_else/.cargo/config.toml
@@ -1,0 +1,2 @@
+[target.'cfg(all())']
+rustflags = ["-C", "linker=dylint-link"]

--- a/lints/if_let_with_else/Cargo.toml
+++ b/lints/if_let_with_else/Cargo.toml
@@ -1,0 +1,19 @@
+[package]
+name = "if_let_with_else"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+publish = false
+
+[lib]
+crate-type = ["cdylib"]
+
+[dependencies]
+clippy_utils.workspace = true
+dylint_linting.workspace = true
+
+[dev-dependencies]
+whisker_testing.workspace = true
+
+[package.metadata.rust-analyzer]
+rustc_private = true

--- a/lints/if_let_with_else/src/lib.rs
+++ b/lints/if_let_with_else/src/lib.rs
@@ -1,0 +1,84 @@
+#![feature(rustc_private)]
+#![warn(unused_extern_crates)]
+
+extern crate rustc_hir;
+
+use clippy_utils::diagnostics::span_lint_and_help;
+use rustc_hir::{Expr, ExprKind};
+use rustc_lint::{LateContext, LateLintPass};
+
+// r[impl lint.if-let-with-else.level]
+dylint_linting::declare_late_lint! {
+    /// ### What it does
+    ///
+    /// Flags `if let` expressions that have a non-diverging `else` branch,
+    /// suggesting a `match` expression instead.
+    ///
+    /// ### Why is this bad?
+    ///
+    /// An `if let` with an `else` branch is equivalent to a two-arm `match`
+    /// but obscures the pattern-matching intent. A `match` expression makes
+    /// both arms equally visible and encourages exhaustive handling.
+    ///
+    /// `if let` without an `else` is acceptable for short, single-branch
+    /// pattern actions.
+    ///
+    /// ### Known problems
+    ///
+    /// None.
+    ///
+    /// ### Examples
+    ///
+    /// ```rust
+    /// # let value: Option<i32> = Some(42);
+    /// // Bad:
+    /// if let Some(x) = value {
+    ///     println!("{x}");
+    /// } else {
+    ///     println!("none");
+    /// }
+    ///
+    /// // Good:
+    /// match value {
+    ///     Some(x) => println!("{x}"),
+    ///     None => println!("none"),
+    /// }
+    /// ```
+    pub IF_LET_WITH_ELSE,
+    Warn,
+    "`if let` with `else` should be a `match` expression"
+}
+
+impl<'tcx> LateLintPass<'tcx> for IfLetWithElse {
+    fn check_expr(&mut self, cx: &LateContext<'tcx>, expr: &'tcx Expr<'_>) {
+        let ExprKind::If(cond, _, Some(else_expr)) = expr.kind else {
+            // r[impl lint.if-let-with-else.no-else-allowed]
+            return;
+        };
+
+        // r[impl lint.if-let-with-else.detect]
+        let ExprKind::Let(_) = cond.kind else {
+            return;
+        };
+
+        // r[impl lint.if-let-with-else.diverging-else-ignored]
+        if cx.typeck_results().expr_ty(else_expr).is_never() {
+            return;
+        }
+
+        // r[impl lint.if-let-with-else.message]
+        span_lint_and_help(
+            cx,
+            IF_LET_WITH_ELSE,
+            expr.span,
+            "`if let` with `else` should be written as a `match` expression",
+            None,
+            "use a `match` expression to make both arms equally visible",
+        );
+    }
+}
+
+#[test]
+fn ui() {
+    whisker_testing::ui_test(env!("CARGO_PKG_NAME"), "ui");
+}

--- a/lints/if_let_with_else/ui/main.rs
+++ b/lints/if_let_with_else/ui/main.rs
@@ -1,0 +1,54 @@
+// r[verify lint.if-let-with-else.detect]
+// r[verify lint.if-let-with-else.level]
+// r[verify lint.if-let-with-else.message]
+fn if_let_with_non_diverging_else(value: Option<i32>) -> String {
+    if let Some(x) = value { //~ ERROR `if let` with `else` should be written as a `match` expression
+        format!("{x}")
+    } else {
+        String::from("none")
+    }
+}
+
+// r[verify lint.if-let-with-else.detect]
+fn if_let_result_with_else(value: Result<i32, &str>) -> i32 {
+    if let Ok(x) = value { //~ ERROR `if let` with `else` should be written as a `match` expression
+        x
+    } else {
+        -1
+    }
+}
+
+// r[verify lint.if-let-with-else.no-else-allowed]
+fn if_let_without_else(value: Option<i32>) {
+    if let Some(x) = value {
+        println!("{x}");
+    }
+}
+
+// r[verify lint.if-let-with-else.diverging-else-ignored]
+fn if_let_with_diverging_else_return(value: Option<i32>) -> i32 {
+    if let Some(x) = value {
+        x
+    } else {
+        return -1;
+    }
+}
+
+// r[verify lint.if-let-with-else.diverging-else-ignored]
+fn if_let_with_diverging_else_panic(value: Option<i32>) -> i32 {
+    if let Some(x) = value {
+        x
+    } else {
+        panic!("missing value");
+    }
+}
+
+fn regular_if_with_else(flag: bool) -> &'static str {
+    if flag {
+        "yes"
+    } else {
+        "no"
+    }
+}
+
+fn main() {}

--- a/lints/if_let_with_else/ui/main.stderr
+++ b/lints/if_let_with_else/ui/main.stderr
@@ -1,0 +1,27 @@
+warning: `if let` with `else` should be written as a `match` expression
+  --> $DIR/main.rs:5:5
+   |
+LL | /     if let Some(x) = value { //~ ERROR `if let` with `else` should be written as a `match` expression
+LL | |         format!("{x}")
+LL | |     } else {
+LL | |         String::from("none")
+LL | |     }
+   | |_____^
+   |
+   = help: use a `match` expression to make both arms equally visible
+   = note: `#[warn(if_let_with_else)]` on by default
+
+warning: `if let` with `else` should be written as a `match` expression
+  --> $DIR/main.rs:14:5
+   |
+LL | /     if let Ok(x) = value { //~ ERROR `if let` with `else` should be written as a `match` expression
+LL | |         x
+LL | |     } else {
+LL | |         -1
+LL | |     }
+   | |_____^
+   |
+   = help: use a `match` expression to make both arms equally visible
+
+warning: 2 warnings emitted
+

--- a/specs/lints.md
+++ b/specs/lints.md
@@ -111,3 +111,22 @@ The diagnostic must show the expected ordering of the derives.
 
 r[lint.derive-order.level]
 The lint must default to `Warn`.
+
+## If let with else
+
+r[lint.if-let-with-else.detect]
+The lint must flag `if let` expressions that have an `else` branch where the
+else branch does not diverge.
+
+r[lint.if-let-with-else.diverging-else-ignored]
+The lint must not flag `if let` expressions where the `else` branch diverges
+(returns, panics, etc.). That case is handled by the `prefer_let_else` lint.
+
+r[lint.if-let-with-else.no-else-allowed]
+The lint must not flag `if let` expressions without an `else` branch.
+
+r[lint.if-let-with-else.message]
+The diagnostic must suggest using a `match` expression instead.
+
+r[lint.if-let-with-else.level]
+The lint must default to `Warn`.


### PR DESCRIPTION
Flags if-let expressions with a non-diverging else branch, suggesting a match expression instead. if-let without else is allowed for short actions, and diverging else branches are left to the prefer-let-else lint.

All spec rules have full Tracey coverage.

Closes #3