### PR TITLE
Upgrade to nightly-2026-03-05 and clippy_utils 0.1.96

### DIFF
--- a/.github/scripts/sync-toolchain.sh
+++ b/.github/scripts/sync-toolchain.sh
@@ -1,0 +1,50 @@
+#!/usr/bin/env bash
+#
+# Syncs rust-toolchain.toml to the nightly date required by the clippy_utils
+# version in Cargo.toml. The nightly date is extracted from the clippy_utils
+# crate README on crates.io.
+#
+# Usage: sync-toolchain.sh [--check]
+#
+# With --check, exits 1 if the toolchain is out of sync (useful in CI).
+# Without --check, updates rust-toolchain.toml in place.
+
+set -euo pipefail
+
+check_only=false
+if [ "${1:-}" = "--check" ]; then
+  check_only=true
+fi
+
+version=$(sed -n 's/^clippy_utils *= *"\([^"]*\)"/\1/p' Cargo.toml)
+if [ -z "$version" ]; then
+  echo "No clippy_utils version found in Cargo.toml" >&2
+  exit 1
+fi
+
+nightly=$(
+  curl -sL -H "User-Agent: whisker-ci" \
+    "https://crates.io/api/v1/crates/clippy_utils/$version/download" \
+    | tar xz -O "clippy_utils-$version/README.md" \
+    | grep -oE 'nightly-[0-9]{4}-[0-9]{2}-[0-9]{2}' \
+    | head -1
+)
+if [ -z "$nightly" ]; then
+  echo "Could not find nightly date in clippy_utils $version README" >&2
+  exit 1
+fi
+
+current=$(sed -n 's/^channel *= *"\(nightly-[0-9-]*\)"/\1/p' rust-toolchain.toml)
+
+if [ "$current" = "$nightly" ]; then
+  echo "rust-toolchain.toml already up to date ($nightly)"
+  exit 0
+fi
+
+if [ "$check_only" = true ]; then
+  echo "rust-toolchain.toml is out of sync: has $current, expected $nightly" >&2
+  exit 1
+fi
+
+sed -i'' -e "s/$current/$nightly/" rust-toolchain.toml
+echo "Updated rust-toolchain.toml: $current -> $nightly"

--- a/.github/workflows/sync-toolchain.yml
+++ b/.github/workflows/sync-toolchain.yml
@@ -1,0 +1,45 @@
+---
+name: Sync rust-toolchain
+
+"on":
+  pull_request:
+    paths:
+      - Cargo.toml
+
+permissions: {}
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  sync:
+    name: Sync nightly with clippy_utils
+    runs-on: ubuntu-latest
+    if: github.event.pull_request.user.login == 'renovate[bot]'
+
+    permissions:
+      contents: write # Required to push the updated rust-toolchain.toml
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # 6.0.2
+        with:
+          ref: ${{ github.head_ref }}
+          persist-credentials: true
+
+      - name: Sync rust-toolchain.toml
+        run: .github/scripts/sync-toolchain.sh
+
+      - name: Commit and push
+        run: |
+          if git diff --quiet rust-toolchain.toml; then
+            echo "No changes to commit"
+            exit 0
+          fi
+
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add rust-toolchain.toml
+          git commit -m "Sync nightly toolchain with clippy_utils"
+          git push

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -152,8 +152,9 @@ checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
 name = "clippy_utils"
-version = "0.1.92"
-source = "git+https://github.com/rust-lang/rust-clippy?rev=20ce69b9a63bcd2756cd906fe0964d1e901e042a#20ce69b9a63bcd2756cd906fe0964d1e901e042a"
+version = "0.1.96"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f89a5c65b57b45dfab53e86f7251c89e9112aa445e2596e336f76065e28e14cd"
 dependencies = [
  "arrayvec",
  "itertools",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ repository = "https://github.com/aonyx-ai/whisker.git"
 libraries = [{ path = ".", pattern = "lints/*" }]
 
 [workspace.dependencies]
-clippy_utils = { git = "https://github.com/rust-lang/rust-clippy", rev = "20ce69b9a63bcd2756cd906fe0964d1e901e042a" }
+clippy_utils = "0.1.96"
 dylint_linting = "5.0.0"
 dylint_testing = "5.0.0"
 whisker_testing = { path = "crates/whisker_testing", version = "=0.1.0" }

--- a/lints/anyhow_missing_context/src/lib.rs
+++ b/lints/anyhow_missing_context/src/lib.rs
@@ -117,7 +117,12 @@ fn returns_anyhow_error(cx: &LateContext<'_>) -> bool {
     let owner_id = cx
         .tcx
         .hir_enclosing_body_owner(cx.last_node_with_lint_attrs);
-    let fn_sig = cx.tcx.fn_sig(owner_id).skip_binder().skip_binder();
+    let owner_ty = cx.tcx.type_of(owner_id).skip_binder();
+    let fn_sig = match owner_ty.kind() {
+        ty::FnDef(..) => cx.tcx.fn_sig(owner_id).skip_binder().skip_binder(),
+        ty::Closure(_, args) => args.as_closure().sig().skip_binder(),
+        _ => return false,
+    };
     let ret_ty = fn_sig.output();
 
     let ty::Adt(adt_def, substs) = ret_ty.kind() else {

--- a/lints/derive_order/src/lib.rs
+++ b/lints/derive_order/src/lib.rs
@@ -7,7 +7,7 @@ extern crate rustc_span;
 use clippy_utils::diagnostics::span_lint_and_then;
 use rustc_ast::token::TokenKind;
 use rustc_ast::tokenstream::TokenTree;
-use rustc_ast::{AttrArgs, AttrKind, Attribute, Item};
+use rustc_ast::{AttrArgs, AttrItemKind, AttrKind, Attribute, Item};
 use rustc_lint::{EarlyContext, EarlyLintPass};
 use rustc_span::Span;
 
@@ -81,7 +81,7 @@ fn extract_derive_names(attrs: &[Attribute]) -> Option<(Vec<String>, Span)> {
         if !has_derive {
             continue;
         }
-        let AttrArgs::Delimited(delim_args) = &normal_attr.item.args else {
+        let AttrItemKind::Unparsed(AttrArgs::Delimited(delim_args)) = &normal_attr.item.args else {
             continue;
         };
 

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,5 +1,5 @@
-# This nightly date must match the clippy_utils revision that dylint_linting
-# 5.0.0 was built against. Update both together when upgrading dylint.
+# The nightly channel must match the clippy_utils version: 0.1.XY requires
+# a nightly where `rustc -V` reports 1.XY. clippy_utils is from crates.io.
 [toolchain]
-channel = "nightly-2025-09-18"
+channel = "nightly-2026-03-05"
 components = ["clippy", "llvm-tools-preview", "rustc-dev", "rustfmt"]


### PR DESCRIPTION
This moves clippy_utils from a pinned git revision to crates.io (0.1.96), which simplifies dependency management — no more tracking specific clippy commit hashes. The rust-toolchain comment is updated to reflect the new versioning scheme: clippy_utils 0.1.XY requires a nightly with rustc 1.XY.

The derive_order lint needed a small update for an upstream API rename (`AttrItemKind::Normal` → `AttrItemKind::Unparsed`). The anyhow_missing_context lint now correctly resolves the enclosing body owner's type before extracting the fn signature, which fixes the lint inside closures where `fn_sig` previously couldn't be called directly on the owner `DefId`.

To keep these versions in sync going forward, this also adds a GitHub Actions workflow that runs on Renovate PRs. When Renovate bumps clippy_utils in Cargo.toml, the workflow downloads the crate's README from crates.io, extracts the required nightly date, and pushes a commit updating rust-toolchain.toml. The core logic lives in `.github/scripts/sync-toolchain.sh` and can be run locally with `--check` for dry-run validation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)