### PR TITLE
Add whisker-types crate with domain vocabulary types

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -85,6 +85,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
 
 [[package]]
+name = "autocfg"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
+
+[[package]]
+name = "bit-set"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08807e080ed7f9d5433fa9b275196cfc35414f66a0c79d864dc51a0d825231a3"
+dependencies = [
+ "bit-vec",
+]
+
+[[package]]
+name = "bit-vec"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e764a1d40d510daf35e07be9eb06e75770908c27d411ee6c92109c9840eaaf7"
+
+[[package]]
 name = "bitflags"
 version = "2.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -352,7 +373,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -377,6 +398,12 @@ name = "find-msvc-tools"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
+
+[[package]]
+name = "fnv"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
 name = "foldhash"
@@ -792,6 +819,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "num-traits"
+version = "0.2.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
+dependencies = [
+ "autocfg",
+]
+
+[[package]]
 name = "num_cpus"
 version = "1.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -886,6 +922,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "ppv-lite86"
+version = "0.2.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9"
+dependencies = [
+ "zerocopy",
+]
+
+[[package]]
 name = "prettyplease"
 version = "0.2.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -903,6 +948,31 @@ checksum = "8fd00f0bb2e90d81d1044c2b32617f68fcb9fa3bb7640c23e9c748e53fb30934"
 dependencies = [
  "unicode-ident",
 ]
+
+[[package]]
+name = "proptest"
+version = "1.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b45fcc2344c680f5025fe57779faef368840d0bd1f42f216291f0dc4ace4744"
+dependencies = [
+ "bit-set",
+ "bit-vec",
+ "bitflags",
+ "num-traits",
+ "rand",
+ "rand_chacha",
+ "rand_xorshift",
+ "regex-syntax",
+ "rusty-fork",
+ "tempfile",
+ "unarray",
+]
+
+[[package]]
+name = "quick-error"
+version = "1.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1d01941d82fa2ab50be1e79e6714289dd7cde78eba4c074bc5a4374f650dfe0"
 
 [[package]]
 name = "quote"
@@ -924,6 +994,44 @@ name = "r-efi"
 version = "6.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
+
+[[package]]
+name = "rand"
+version = "0.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6db2770f06117d490610c7488547d543617b21bfa07796d7a12f6f1bd53850d1"
+dependencies = [
+ "rand_chacha",
+ "rand_core",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
+dependencies = [
+ "ppv-lite86",
+ "rand_core",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
+dependencies = [
+ "getrandom 0.3.4",
+]
+
+[[package]]
+name = "rand_xorshift"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "513962919efc330f829edb2535844d1b912b0fbe2ca165d613e4e8788bb05a5a"
+dependencies = [
+ "rand_core",
+]
 
 [[package]]
 name = "redox_syscall"
@@ -1006,7 +1114,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1014,6 +1122,18 @@ name = "rustversion"
 version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
+
+[[package]]
+name = "rusty-fork"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc6bf79ff24e648f6da1f8d1f011e9cac26491b619e6b9280f2b47f1774e6ee2"
+dependencies = [
+ "fnv",
+ "quick-error",
+ "tempfile",
+ "wait-timeout",
+]
 
 [[package]]
 name = "semver"
@@ -1138,7 +1258,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1274,6 +1394,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "unarray"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eaea85b334db583fe3274d12b4cd1880032beab409c0d774be044d4480ab9a94"
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1320,6 +1446,15 @@ name = "vcpkg"
 version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
+
+[[package]]
+name = "wait-timeout"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09ac3b126d3914f9849036f826e054cbabdc8519970b8998ddaf3b5bd3c65f11"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "wasi"
@@ -1377,6 +1512,13 @@ dependencies = [
  "hashbrown 0.15.5",
  "indexmap",
  "semver",
+]
+
+[[package]]
+name = "whisker-types"
+version = "0.1.0"
+dependencies = [
+ "proptest",
 ]
 
 [[package]]
@@ -1650,6 +1792,26 @@ dependencies = [
  "quote",
  "syn",
  "synstructure",
+]
+
+[[package]]
+name = "zerocopy"
+version = "0.8.48"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eed437bf9d6692032087e337407a86f04cd8d6a16a37199ed57949d415bd68e9"
+dependencies = [
+ "zerocopy-derive",
+]
+
+[[package]]
+name = "zerocopy-derive"
+version = "0.8.48"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70e3cd084b1788766f53af483dd21f93881ff30d7320490ec3ef7526d203bad4"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,8 +16,14 @@ repository = "https://github.com/aonyx-ai/whisker.git"
 [workspace.metadata.dylint]
 libraries = [{ path = ".", pattern = "lints/*" }]
 
+[workspace.lints.clippy]
+missing_errors_doc = "warn"
+missing_panics_doc = "warn"
+
 [workspace.dependencies]
 clippy_utils = "0.1.96"
 dylint_linting = "5.0.0"
 dylint_testing = "5.0.0"
 whisker_testing = { path = "crates/whisker_testing", version = "=0.1.0" }
+proptest = "1"
+whisker-types = { path = "crates/whisker-types", version = "=0.1.0" }

--- a/crates/whisker-types/Cargo.toml
+++ b/crates/whisker-types/Cargo.toml
@@ -1,0 +1,12 @@
+[package]
+name = "whisker-types"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+publish = false
+
+[dev-dependencies]
+proptest.workspace = true
+
+[lints]
+workspace = true

--- a/crates/whisker-types/src/diagnostic.rs
+++ b/crates/whisker-types/src/diagnostic.rs
@@ -1,0 +1,275 @@
+use crate::{Location, RuleId, Severity, Span, Suggestion};
+
+/// A diagnostic emitted by a lint rule
+///
+/// Diagnostics are the primary output of the linting pipeline. Each one
+/// identifies a specific issue found in source code, with a severity, a
+/// primary span, and optional supplementary information like origin
+/// locations, related locations, and suggested fixes.
+#[derive(Clone, Debug)]
+pub struct Diagnostic {
+    rule_id: RuleId,
+    severity: Severity,
+    message: String,
+    span: Span,
+    origins: Vec<Location>,
+    related: Vec<Location>,
+    suggestions: Vec<Suggestion>,
+}
+
+impl Diagnostic {
+    /// Creates a new diagnostic with the required fields
+    pub fn new(rule_id: RuleId, severity: Severity, message: String, span: Span) -> Self {
+        Self {
+            rule_id,
+            severity,
+            message,
+            span,
+            origins: Vec::new(),
+            related: Vec::new(),
+            suggestions: Vec::new(),
+        }
+    }
+
+    /// Adds an origin location to this diagnostic
+    pub fn with_origin(mut self, origin: Location) -> Self {
+        self.origins.push(origin);
+        self
+    }
+
+    /// Adds a related location to this diagnostic
+    pub fn with_related(mut self, related: Location) -> Self {
+        self.related.push(related);
+        self
+    }
+
+    /// Adds a suggested fix to this diagnostic
+    pub fn with_suggestion(mut self, suggestion: Suggestion) -> Self {
+        self.suggestions.push(suggestion);
+        self
+    }
+
+    /// Returns the rule that produced this diagnostic
+    pub fn rule_id(&self) -> RuleId {
+        self.rule_id
+    }
+
+    /// Returns the severity of this diagnostic
+    pub fn severity(&self) -> Severity {
+        self.severity
+    }
+
+    /// Returns the human-readable diagnostic message
+    pub fn message(&self) -> &str {
+        &self.message
+    }
+
+    /// Returns the primary source span
+    pub fn span(&self) -> &Span {
+        &self.span
+    }
+
+    /// Returns origin locations that explain where something was defined
+    pub fn origins(&self) -> &[Location] {
+        &self.origins
+    }
+
+    /// Returns related locations that provide additional context
+    pub fn related(&self) -> &[Location] {
+        &self.related
+    }
+
+    /// Returns suggested source code fixes
+    pub fn suggestions(&self) -> &[Suggestion] {
+        &self.suggestions
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::path::PathBuf;
+
+    use super::*;
+
+    fn test_diagnostic() -> Diagnostic {
+        Diagnostic::new(
+            RuleId("lint.test"),
+            Severity::Warn,
+            "test message".into(),
+            Span::new(PathBuf::from("test.rs"), 0, 10),
+        )
+    }
+
+    #[test]
+    fn trait_send() {
+        fn assert_send<T: Send>() {}
+        assert_send::<Diagnostic>();
+    }
+
+    #[test]
+    fn trait_sync() {
+        fn assert_sync<T: Sync>() {}
+        assert_sync::<Diagnostic>();
+    }
+
+    #[test]
+    fn trait_unpin() {
+        fn assert_unpin<T: Unpin>() {}
+        assert_unpin::<Diagnostic>();
+    }
+
+    #[test]
+    fn accessors_return_correct_values() {
+        let diag = test_diagnostic();
+
+        assert_eq!(diag.rule_id(), RuleId("lint.test"));
+        assert_eq!(diag.severity(), Severity::Warn);
+        assert_eq!(diag.message(), "test message");
+        assert_eq!(diag.span().start(), 0);
+        assert_eq!(diag.span().end(), 10);
+    }
+
+    #[test]
+    fn new_diagnostic_has_empty_collections() {
+        let diag = test_diagnostic();
+
+        assert!(diag.origins().is_empty());
+        assert!(diag.related().is_empty());
+        assert!(diag.suggestions().is_empty());
+    }
+
+    #[test]
+    fn with_origin_adds_origin() {
+        let origin = Location::new(
+            Span::new(PathBuf::from("other.rs"), 5, 15),
+            "defined here".into(),
+        );
+        let diag = test_diagnostic().with_origin(origin);
+
+        assert_eq!(diag.origins().len(), 1);
+        assert_eq!(diag.origins()[0].message(), "defined here");
+    }
+
+    #[test]
+    fn with_related_adds_related() {
+        let related = Location::new(
+            Span::new(PathBuf::from("other.rs"), 5, 15),
+            "also used here".into(),
+        );
+        let diag = test_diagnostic().with_related(related);
+
+        assert_eq!(diag.related().len(), 1);
+        assert_eq!(diag.related()[0].message(), "also used here");
+    }
+
+    #[test]
+    fn with_suggestion_adds_suggestion() {
+        let suggestion = Suggestion::new(
+            Span::new(PathBuf::from("test.rs"), 0, 10),
+            "replacement".into(),
+            "try this".into(),
+        );
+        let diag = test_diagnostic().with_suggestion(suggestion);
+
+        assert_eq!(diag.suggestions().len(), 1);
+        assert_eq!(diag.suggestions()[0].replacement(), "replacement");
+    }
+
+    mod prop {
+        use proptest::prelude::*;
+
+        use super::*;
+
+        fn arb_severity() -> impl Strategy<Value = Severity> {
+            prop_oneof![
+                Just(Severity::Help),
+                Just(Severity::Info),
+                Just(Severity::Warn),
+                Just(Severity::Error),
+            ]
+        }
+
+        fn arb_span() -> impl Strategy<Value = Span> {
+            (0..=1000usize, 0..=1000usize).prop_map(|(start, delta)| {
+                Span::new(PathBuf::from("test.rs"), start, start + delta)
+            })
+        }
+
+        proptest! {
+            #[test]
+            fn new_roundtrips_fields(
+                severity in arb_severity(),
+                message in "\\PC{0,50}",
+                span in arb_span(),
+            ) {
+                let diag = Diagnostic::new(
+                    RuleId("lint.prop"),
+                    severity,
+                    message.clone(),
+                    span.clone(),
+                );
+
+                prop_assert_eq!(diag.rule_id(), RuleId("lint.prop"));
+                prop_assert_eq!(diag.severity(), severity);
+                prop_assert_eq!(diag.message(), message);
+                prop_assert_eq!(diag.span(), &span);
+            }
+
+            #[test]
+            fn new_starts_with_empty_collections(
+                severity in arb_severity(),
+            ) {
+                let diag = Diagnostic::new(
+                    RuleId("lint.prop"),
+                    severity,
+                    "msg".into(),
+                    Span::new(PathBuf::from("f.rs"), 0, 1),
+                );
+
+                prop_assert!(diag.origins().is_empty());
+                prop_assert!(diag.related().is_empty());
+                prop_assert!(diag.suggestions().is_empty());
+            }
+
+            #[test]
+            fn with_origin_accumulates(count in 1..=10usize) {
+                let mut diag = test_diagnostic();
+                for i in 0..count {
+                    let origin = Location::new(
+                        Span::new(PathBuf::from("f.rs"), i, i + 1),
+                        format!("origin {i}"),
+                    );
+                    diag = diag.with_origin(origin);
+                }
+                prop_assert_eq!(diag.origins().len(), count);
+            }
+
+            #[test]
+            fn with_related_accumulates(count in 1..=10usize) {
+                let mut diag = test_diagnostic();
+                for i in 0..count {
+                    let related = Location::new(
+                        Span::new(PathBuf::from("f.rs"), i, i + 1),
+                        format!("related {i}"),
+                    );
+                    diag = diag.with_related(related);
+                }
+                prop_assert_eq!(diag.related().len(), count);
+            }
+
+            #[test]
+            fn with_suggestion_accumulates(count in 1..=10usize) {
+                let mut diag = test_diagnostic();
+                for i in 0..count {
+                    let suggestion = Suggestion::new(
+                        Span::new(PathBuf::from("f.rs"), i, i + 1),
+                        format!("fix {i}"),
+                        format!("suggestion {i}"),
+                    );
+                    diag = diag.with_suggestion(suggestion);
+                }
+                prop_assert_eq!(diag.suggestions().len(), count);
+            }
+        }
+    }
+}

--- a/crates/whisker-types/src/language.rs
+++ b/crates/whisker-types/src/language.rs
@@ -1,0 +1,87 @@
+/// Supported source languages
+#[derive(Copy, Clone, Eq, PartialEq, Hash, Debug)]
+pub enum Language {
+    /// The Rust programming language
+    Rust,
+}
+
+impl Language {
+    /// Detects the language from a file extension
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use whisker_types::Language;
+    ///
+    /// assert_eq!(Language::from_extension("rs"), Some(Language::Rust));
+    /// assert_eq!(Language::from_extension("py"), None);
+    /// ```
+    pub fn from_extension(ext: &str) -> Option<Self> {
+        match ext {
+            "rs" => Some(Self::Rust),
+            _ => None,
+        }
+    }
+}
+
+impl std::fmt::Display for Language {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Rust => f.write_str("Rust"),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn trait_send() {
+        fn assert_send<T: Send>() {}
+        assert_send::<Language>();
+    }
+
+    #[test]
+    fn trait_sync() {
+        fn assert_sync<T: Sync>() {}
+        assert_sync::<Language>();
+    }
+
+    #[test]
+    fn trait_unpin() {
+        fn assert_unpin<T: Unpin>() {}
+        assert_unpin::<Language>();
+    }
+
+    #[test]
+    fn from_extension_with_rs_returns_rust() {
+        assert_eq!(Language::from_extension("rs"), Some(Language::Rust));
+    }
+
+    #[test]
+    fn from_extension_with_unknown_returns_none() {
+        assert_eq!(Language::from_extension("py"), None);
+        assert_eq!(Language::from_extension("js"), None);
+        assert_eq!(Language::from_extension(""), None);
+    }
+
+    #[test]
+    fn display_shows_language_name() {
+        assert_eq!(Language::Rust.to_string(), "Rust");
+    }
+
+    mod prop {
+        use proptest::prelude::*;
+
+        use super::*;
+
+        proptest! {
+            #[test]
+            fn non_rs_extension_returns_none(ext in "[a-z]{1,10}") {
+                prop_assume!(ext != "rs");
+                prop_assert_eq!(Language::from_extension(&ext), None);
+            }
+        }
+    }
+}

--- a/crates/whisker-types/src/lib.rs
+++ b/crates/whisker-types/src/lib.rs
@@ -1,0 +1,15 @@
+mod diagnostic;
+mod language;
+mod location;
+mod rule_id;
+mod severity;
+mod span;
+mod suggestion;
+
+pub use diagnostic::Diagnostic;
+pub use language::Language;
+pub use location::Location;
+pub use rule_id::RuleId;
+pub use severity::Severity;
+pub use span::Span;
+pub use suggestion::Suggestion;

--- a/crates/whisker-types/src/location.rs
+++ b/crates/whisker-types/src/location.rs
@@ -1,0 +1,85 @@
+use crate::Span;
+
+/// A source location with an associated message
+///
+/// Used for origin and related annotations on diagnostics. The message
+/// describes the role this location plays in the diagnostic (e.g. "defined
+/// here" or "first occurrence").
+#[derive(Clone, Eq, PartialEq, Hash, Debug)]
+pub struct Location {
+    span: Span,
+    message: String,
+}
+
+impl Location {
+    /// Creates a location with the given span and descriptive message
+    pub fn new(span: Span, message: String) -> Self {
+        Self { span, message }
+    }
+
+    /// Returns the span of this location
+    pub fn span(&self) -> &Span {
+        &self.span
+    }
+
+    /// Returns the descriptive message for this location
+    pub fn message(&self) -> &str {
+        &self.message
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::path::PathBuf;
+
+    use super::*;
+
+    #[test]
+    fn trait_send() {
+        fn assert_send<T: Send>() {}
+        assert_send::<Location>();
+    }
+
+    #[test]
+    fn trait_sync() {
+        fn assert_sync<T: Sync>() {}
+        assert_sync::<Location>();
+    }
+
+    #[test]
+    fn trait_unpin() {
+        fn assert_unpin<T: Unpin>() {}
+        assert_unpin::<Location>();
+    }
+
+    #[test]
+    fn accessors_return_correct_values() {
+        let span = Span::new(PathBuf::from("test.rs"), 0, 10);
+        let location = Location::new(span.clone(), "defined here".into());
+
+        assert_eq!(location.span(), &span);
+        assert_eq!(location.message(), "defined here");
+    }
+
+    mod prop {
+        use proptest::prelude::*;
+
+        use super::*;
+
+        proptest! {
+            #[test]
+            fn new_roundtrips_all_fields(
+                file in "[a-z]+\\.rs",
+                start in 0..=1000usize,
+                delta in 0..=1000usize,
+                message in "\\PC{0,50}",
+            ) {
+                let span = Span::new(PathBuf::from(&file), start, start + delta);
+                let location = Location::new(span.clone(), message.clone());
+
+                prop_assert_eq!(location.span(), &span);
+                prop_assert_eq!(location.message(), message);
+            }
+        }
+    }
+}

--- a/crates/whisker-types/src/rule_id.rs
+++ b/crates/whisker-types/src/rule_id.rs
@@ -1,0 +1,54 @@
+/// Identifies a lint rule
+///
+/// Each rule has a unique static string identifier following the convention
+/// `category.rule-name` (e.g. `lint.wildcard-match-arm`).
+#[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug)]
+pub struct RuleId(pub &'static str);
+
+impl RuleId {
+    /// Returns the string representation of this rule identifier
+    pub fn as_str(&self) -> &'static str {
+        self.0
+    }
+}
+
+impl std::fmt::Display for RuleId {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(self.0)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn trait_send() {
+        fn assert_send<T: Send>() {}
+        assert_send::<RuleId>();
+    }
+
+    #[test]
+    fn trait_sync() {
+        fn assert_sync<T: Sync>() {}
+        assert_sync::<RuleId>();
+    }
+
+    #[test]
+    fn trait_unpin() {
+        fn assert_unpin<T: Unpin>() {}
+        assert_unpin::<RuleId>();
+    }
+
+    #[test]
+    fn as_str_returns_inner() {
+        let id = RuleId("lint.test");
+        assert_eq!(id.as_str(), "lint.test");
+    }
+
+    #[test]
+    fn display_matches_inner() {
+        let id = RuleId("lint.test");
+        assert_eq!(id.to_string(), "lint.test");
+    }
+}

--- a/crates/whisker-types/src/severity.rs
+++ b/crates/whisker-types/src/severity.rs
@@ -1,0 +1,82 @@
+/// Severity level for a diagnostic
+#[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug)]
+pub enum Severity {
+    /// A help message
+    Help,
+    /// An informational note
+    Info,
+    /// A warning that should be addressed
+    Warn,
+    /// An error that must be addressed
+    Error,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn trait_send() {
+        fn assert_send<T: Send>() {}
+        assert_send::<Severity>();
+    }
+
+    #[test]
+    fn trait_sync() {
+        fn assert_sync<T: Sync>() {}
+        assert_sync::<Severity>();
+    }
+
+    #[test]
+    fn trait_unpin() {
+        fn assert_unpin<T: Unpin>() {}
+        assert_unpin::<Severity>();
+    }
+
+    #[test]
+    fn ordering_error_is_greatest() {
+        assert!(Severity::Error > Severity::Warn);
+        assert!(Severity::Warn > Severity::Info);
+        assert!(Severity::Info > Severity::Help);
+    }
+
+    mod prop {
+        use proptest::prelude::*;
+
+        use super::*;
+
+        fn arb_severity() -> impl Strategy<Value = Severity> {
+            prop_oneof![
+                Just(Severity::Help),
+                Just(Severity::Info),
+                Just(Severity::Warn),
+                Just(Severity::Error),
+            ]
+        }
+
+        proptest! {
+            #[test]
+            fn equal_variants_are_equal(a in arb_severity()) {
+                #[allow(clippy::eq_op)]
+                let is_eq = a == a;
+                prop_assert!(is_eq);
+            }
+
+            #[test]
+            fn ordering_is_transitive(
+                a in arb_severity(),
+                b in arb_severity(),
+                c in arb_severity(),
+            ) {
+                if a <= b && b <= c {
+                    prop_assert!(a <= c);
+                }
+            }
+
+            #[test]
+            fn equality_is_reflexive(a in arb_severity()) {
+                prop_assert_eq!(a, a);
+            }
+        }
+    }
+}

--- a/crates/whisker-types/src/span.rs
+++ b/crates/whisker-types/src/span.rs
@@ -1,0 +1,136 @@
+use std::path::Path;
+use std::sync::Arc;
+
+/// A byte range within a source file
+///
+/// Spans identify a contiguous region of source text by file path and byte
+/// offsets. The range is half-open: `[start, end)`. The file path is
+/// reference-counted so that creating spans from a shared source is cheap.
+#[derive(Clone, Eq, PartialEq, Hash, Debug)]
+pub struct Span {
+    file: Arc<Path>,
+    start: usize,
+    end: usize,
+}
+
+impl Span {
+    /// Creates a span covering `[start, end)` in the given file
+    ///
+    /// # Panics
+    ///
+    /// Panics if `start > end`.
+    pub fn new(file: impl Into<Arc<Path>>, start: usize, end: usize) -> Self {
+        let file = file.into();
+        assert!(
+            start <= end,
+            "span start ({start}) must not exceed end ({end})"
+        );
+        Self { file, start, end }
+    }
+
+    /// Returns the file path this span belongs to
+    pub fn file(&self) -> &Path {
+        &self.file
+    }
+
+    /// Returns the shared file path
+    pub fn file_arc(&self) -> &Arc<Path> {
+        &self.file
+    }
+
+    /// Returns the start byte offset (inclusive)
+    pub fn start(&self) -> usize {
+        self.start
+    }
+
+    /// Returns the end byte offset (exclusive)
+    pub fn end(&self) -> usize {
+        self.end
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::path::PathBuf;
+
+    use super::*;
+
+    #[test]
+    fn trait_send() {
+        fn assert_send<T: Send>() {}
+        assert_send::<Span>();
+    }
+
+    #[test]
+    fn trait_sync() {
+        fn assert_sync<T: Sync>() {}
+        assert_sync::<Span>();
+    }
+
+    #[test]
+    fn trait_unpin() {
+        fn assert_unpin<T: Unpin>() {}
+        assert_unpin::<Span>();
+    }
+
+    #[test]
+    fn accessors_return_correct_values() {
+        let span = Span::new(PathBuf::from("test.rs"), 10, 20);
+
+        assert_eq!(span.file(), Path::new("test.rs"));
+        assert_eq!(span.start(), 10);
+        assert_eq!(span.end(), 20);
+    }
+
+    #[test]
+    fn empty_span_is_allowed() {
+        let span = Span::new(PathBuf::from("test.rs"), 5, 5);
+        assert_eq!(span.start(), span.end());
+    }
+
+    #[test]
+    #[should_panic(expected = "span start")]
+    fn new_with_inverted_range_panics() {
+        Span::new(PathBuf::from("test.rs"), 20, 10);
+    }
+
+    #[test]
+    fn file_arc_shares_reference() {
+        let span1 = Span::new(PathBuf::from("test.rs"), 0, 10);
+        let span2 = span1.clone();
+        assert!(Arc::ptr_eq(span1.file_arc(), span2.file_arc()));
+    }
+
+    mod prop {
+        use proptest::prelude::*;
+
+        use super::*;
+
+        proptest! {
+            #[test]
+            fn new_roundtrips_all_fields(
+                file in "[a-z]{1,10}\\.rs",
+                start in 0..=1000usize,
+                delta in 0..=1000usize,
+            ) {
+                let end = start + delta;
+                let span = Span::new(PathBuf::from(&file), start, end);
+
+                prop_assert_eq!(span.file(), Path::new(&file));
+                prop_assert_eq!(span.start(), start);
+                prop_assert_eq!(span.end(), end);
+            }
+
+            #[test]
+            fn start_never_exceeds_end(
+                file in "[a-z]+\\.rs",
+                start in 0..=1000usize,
+                delta in 0..=1000usize,
+            ) {
+                let end = start + delta;
+                let span = Span::new(PathBuf::from(&file), start, end);
+                prop_assert!(span.start() <= span.end());
+            }
+        }
+    }
+}

--- a/crates/whisker-types/src/suggestion.rs
+++ b/crates/whisker-types/src/suggestion.rs
@@ -1,0 +1,96 @@
+use crate::Span;
+
+/// A suggested source code replacement
+///
+/// Represents a machine-applicable fix: replace the text at `span` with
+/// `replacement`. An empty replacement means "delete this span".
+#[derive(Clone, Eq, PartialEq, Hash, Debug)]
+pub struct Suggestion {
+    span: Span,
+    replacement: String,
+    message: String,
+}
+
+impl Suggestion {
+    /// Creates a suggestion to replace the text at `span` with `replacement`
+    pub fn new(span: Span, replacement: String, message: String) -> Self {
+        Self {
+            span,
+            replacement,
+            message,
+        }
+    }
+
+    /// Returns the span of the text to be replaced
+    pub fn span(&self) -> &Span {
+        &self.span
+    }
+
+    /// Returns the replacement text
+    pub fn replacement(&self) -> &str {
+        &self.replacement
+    }
+
+    /// Returns the human-readable description of this suggestion
+    pub fn message(&self) -> &str {
+        &self.message
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::path::PathBuf;
+
+    use super::*;
+
+    #[test]
+    fn trait_send() {
+        fn assert_send<T: Send>() {}
+        assert_send::<Suggestion>();
+    }
+
+    #[test]
+    fn trait_sync() {
+        fn assert_sync<T: Sync>() {}
+        assert_sync::<Suggestion>();
+    }
+
+    #[test]
+    fn trait_unpin() {
+        fn assert_unpin<T: Unpin>() {}
+        assert_unpin::<Suggestion>();
+    }
+
+    #[test]
+    fn accessors_return_correct_values() {
+        let span = Span::new(PathBuf::from("test.rs"), 0, 5);
+        let suggestion = Suggestion::new(span.clone(), "new_text".into(), "try this".into());
+
+        assert_eq!(suggestion.span(), &span);
+        assert_eq!(suggestion.replacement(), "new_text");
+        assert_eq!(suggestion.message(), "try this");
+    }
+
+    mod prop {
+        use proptest::prelude::*;
+
+        use super::*;
+
+        proptest! {
+            #[test]
+            fn new_roundtrips_all_fields(
+                start in 0..=1000usize,
+                delta in 0..=1000usize,
+                replacement in "\\PC{0,50}",
+                message in "\\PC{0,50}",
+            ) {
+                let span = Span::new(PathBuf::from("f.rs"), start, start + delta);
+                let s = Suggestion::new(span.clone(), replacement.clone(), message.clone());
+
+                prop_assert_eq!(s.span(), &span);
+                prop_assert_eq!(s.replacement(), replacement);
+                prop_assert_eq!(s.message(), message);
+            }
+        }
+    }
+}


### PR DESCRIPTION
Introduces the shared vocabulary types that model the linting domain: Diagnostic, Span, Severity, Location, RuleId, Suggestion, and Language.

Span stores Arc<Path> so creating spans from nodes is a cheap reference count bump rather than a PathBuf allocation. All public types have Send, Sync, and Unpin trait tests and property-based tests for constructor roundtrips and builder accumulation.

The workspace gains a clippy lints section enabling missing_errors_doc and missing_panics_doc warnings.

Part of the domain design series. First in the platform crate chain — later PRs build on this.