### PR TITLE
Add tree-sitter integration types to whisker-types

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1173,6 +1173,7 @@ version = "1.0.151"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c841b55ecdae098c80dcae9cf767f6f8a0c2cdb3416bbef72181df4d0fe73f14"
 dependencies = [
+ "indexmap",
  "itoa",
  "memchr",
  "serde",
@@ -1206,6 +1207,12 @@ name = "stable_deref_trait"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
+
+[[package]]
+name = "streaming-iterator"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b2231b7c3057d5e4ad0156fb3dc807d900806020c5ffa3ee6ff2c8c76fb8520"
 
 [[package]]
 name = "syn"
@@ -1386,6 +1393,36 @@ dependencies = [
 ]
 
 [[package]]
+name = "tree-sitter"
+version = "0.26.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "af1c71c1c4cc0920b20d6b0f6572e7682cd07a6a2faec71067a31fa394c586df"
+dependencies = [
+ "cc",
+ "regex",
+ "regex-syntax",
+ "serde_json",
+ "streaming-iterator",
+ "tree-sitter-language",
+]
+
+[[package]]
+name = "tree-sitter-language"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "009994f150cc0cd50ff54917d5bc8bffe8cad10ca10d81c34da2ec421ae61782"
+
+[[package]]
+name = "tree-sitter-rust"
+version = "0.24.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "439e577dbe07423ec2582ac62c7531120dbfccfa6e5f92406f93dd271a120e45"
+dependencies = [
+ "cc",
+ "tree-sitter-language",
+]
+
+[[package]]
 name = "unarray"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1510,7 +1547,10 @@ dependencies = [
 name = "whisker-types"
 version = "0.1.0"
 dependencies = [
+ "anyhow",
  "proptest",
+ "tree-sitter",
+ "tree-sitter-rust",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,5 +25,8 @@ clippy_utils = "0.1.96"
 dylint_linting = "6.0.0"
 dylint_testing = "6.0.0"
 whisker_testing = { path = "crates/whisker_testing", version = "=0.1.0" }
+anyhow = "1"
 proptest = "1"
 whisker-types = { path = "crates/whisker-types", version = "=0.1.0" }
+tree-sitter = "0.26"
+tree-sitter-rust = "0.24"

--- a/crates/whisker-types/Cargo.toml
+++ b/crates/whisker-types/Cargo.toml
@@ -5,8 +5,13 @@ edition.workspace = true
 license.workspace = true
 publish = false
 
+[dependencies]
+anyhow.workspace = true
+tree-sitter.workspace = true
+
 [dev-dependencies]
 proptest.workspace = true
+tree-sitter-rust.workspace = true
 
 [lints]
 workspace = true

--- a/crates/whisker-types/proptest-regressions/decorated_node.txt
+++ b/crates/whisker-types/proptest-regressions/decorated_node.txt
@@ -1,0 +1,8 @@
+# Seeds for failure cases proptest has generated in the past. It is
+# automatically read and these particular cases re-run before any
+# novel cases are generated.
+#
+# It is recommended to check this file in to source control so that
+# everyone who runs the test benefits from these saved cases.
+cc 220841990abf1a590c0e4ecb67182df7c9361942646999e21b8b3e4da8bd4dc7 # shrinks to source = "  "
+cc 6eebb35838a9b5637f6ce98877d7e729f581ec7a569ebc8fc7e8181f274d6e1d # shrinks to source = " ᥰ"

--- a/crates/whisker-types/proptest-regressions/decorated_tree.txt
+++ b/crates/whisker-types/proptest-regressions/decorated_tree.txt
@@ -1,0 +1,7 @@
+# Seeds for failure cases proptest has generated in the past. It is
+# automatically read and these particular cases re-run before any
+# novel cases are generated.
+#
+# It is recommended to check this file in to source control so that
+# everyone who runs the test benefits from these saved cases.
+cc b326e7c75077821ef0bc80ebfbea99bce478fb5f8f4115d8479d1da08161ec16 # shrinks to source = "0a<𐀀%{$￼a0a"

--- a/crates/whisker-types/src/decorated_node.rs
+++ b/crates/whisker-types/src/decorated_node.rs
@@ -1,0 +1,347 @@
+use std::any::Any;
+use std::path::Path;
+use std::sync::Arc;
+
+use crate::{DecorationMap, Span};
+
+/// A tree-sitter node enriched with semantic decorations
+///
+/// This is the primary type that lint rules interact with. It provides
+/// access to the tree-sitter node's structural information (kind, text,
+/// children) and to semantic decorations attached by providers.
+#[derive(Clone)]
+pub struct DecoratedNode<'a> {
+    node: tree_sitter::Node<'a>,
+    source: &'a str,
+    file: &'a Arc<Path>,
+    decorations: &'a DecorationMap,
+}
+
+impl<'a> DecoratedNode<'a> {
+    /// Creates a decorated node wrapping a tree-sitter node
+    pub fn new(
+        node: tree_sitter::Node<'a>,
+        source: &'a str,
+        file: &'a Arc<Path>,
+        decorations: &'a DecorationMap,
+    ) -> Self {
+        Self {
+            node,
+            source,
+            file,
+            decorations,
+        }
+    }
+
+    /// Returns the tree-sitter node kind (e.g. `"function_item"`)
+    pub fn kind(&self) -> &str {
+        self.node.kind()
+    }
+
+    /// Returns the source text covered by this node
+    pub fn text(&self) -> &'a str {
+        &self.source[self.node.byte_range()]
+    }
+
+    /// Returns the tree-sitter node ID, used as the decoration map key
+    pub fn id(&self) -> usize {
+        self.node.id()
+    }
+
+    /// Returns a [`Span`] covering this node's byte range
+    ///
+    /// The file path is reference-counted, so this is a cheap operation.
+    pub fn span(&self) -> Span {
+        Span::new(
+            Arc::clone(self.file),
+            self.node.start_byte(),
+            self.node.end_byte(),
+        )
+    }
+
+    /// Returns the number of named children
+    pub fn named_child_count(&self) -> usize {
+        self.node.named_child_count()
+    }
+
+    /// Returns the named child at the given index, if it exists
+    pub fn named_child(&self, index: u32) -> Option<DecoratedNode<'a>> {
+        self.node
+            .named_child(index)
+            .map(|child| DecoratedNode::new(child, self.source, self.file, self.decorations))
+    }
+
+    /// Returns a child node by its field name, if it exists
+    pub fn child_by_field_name(&self, name: &str) -> Option<DecoratedNode<'a>> {
+        self.node
+            .child_by_field_name(name)
+            .map(|child| DecoratedNode::new(child, self.source, self.file, self.decorations))
+    }
+
+    /// Returns the total number of children (named and anonymous)
+    pub fn child_count(&self) -> usize {
+        self.node.child_count()
+    }
+
+    /// Returns the child at the given index (named or anonymous)
+    pub fn child(&self, index: u32) -> Option<DecoratedNode<'a>> {
+        self.node
+            .child(index)
+            .map(|child| DecoratedNode::new(child, self.source, self.file, self.decorations))
+    }
+
+    /// Returns whether this is a named node (as opposed to an anonymous one)
+    pub fn is_named(&self) -> bool {
+        self.node.is_named()
+    }
+
+    /// Returns the parent node, if this is not the root
+    pub fn parent(&self) -> Option<DecoratedNode<'a>> {
+        self.node
+            .parent()
+            .map(|parent| DecoratedNode::new(parent, self.source, self.file, self.decorations))
+    }
+
+    /// Retrieves the first decoration of type `T` from this node
+    pub fn decoration<T: Any + Send + Sync>(&self) -> Option<&'a T> {
+        self.decorations.get::<T>(self.node.id())
+    }
+
+    /// Retrieves all decorations of type `T` from this node
+    pub fn decorations_of_type<T: Any + Send + Sync>(&self) -> Vec<&'a T> {
+        self.decorations.get_all::<T>(self.node.id())
+    }
+
+    /// Returns all named children of this node as a collected vec
+    pub fn named_children(&self) -> Vec<DecoratedNode<'a>> {
+        let count: u32 = self.node.named_child_count() as u32;
+        (0..count)
+            .filter_map(|i| {
+                self.node.named_child(i).map(|child| {
+                    DecoratedNode::new(child, self.source, self.file, self.decorations)
+                })
+            })
+            .collect()
+    }
+
+    /// Returns the underlying tree-sitter node
+    pub fn raw(&self) -> tree_sitter::Node<'a> {
+        self.node
+    }
+}
+
+impl std::fmt::Debug for DecoratedNode<'_> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("DecoratedNode")
+            .field("kind", &self.kind())
+            .field("start_byte", &self.node.start_byte())
+            .field("end_byte", &self.node.end_byte())
+            .finish()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::path::PathBuf;
+
+    use super::*;
+
+    fn parse_tree(source: &str) -> tree_sitter::Tree {
+        let mut parser = tree_sitter::Parser::new();
+        parser
+            .set_language(&tree_sitter_rust::LANGUAGE.into())
+            .unwrap();
+        parser.parse(source, None).unwrap()
+    }
+
+    #[test]
+    fn trait_send() {
+        fn assert_send<T: Send>() {}
+        assert_send::<DecoratedNode<'_>>();
+    }
+
+    #[test]
+    fn trait_sync() {
+        fn assert_sync<T: Sync>() {}
+        assert_sync::<DecoratedNode<'_>>();
+    }
+
+    #[test]
+    fn trait_unpin() {
+        fn assert_unpin<T: Unpin>() {}
+        assert_unpin::<DecoratedNode<'_>>();
+    }
+
+    #[test]
+    fn kind_returns_node_kind() {
+        let source = "fn main() {}";
+        let tree = parse_tree(source);
+        let decorations = DecorationMap::new();
+        let file: Arc<Path> = PathBuf::from("test.rs").into();
+        let root = DecoratedNode::new(tree.root_node(), source, &file, &decorations);
+
+        assert_eq!(root.kind(), "source_file");
+    }
+
+    #[test]
+    fn text_returns_source_slice() {
+        let source = "fn main() {}";
+        let tree = parse_tree(source);
+        let decorations = DecorationMap::new();
+        let file: Arc<Path> = PathBuf::from("test.rs").into();
+        let root = DecoratedNode::new(tree.root_node(), source, &file, &decorations);
+
+        assert_eq!(root.text(), source);
+    }
+
+    #[test]
+    fn span_covers_node_range() {
+        let source = "fn main() {}";
+        let tree = parse_tree(source);
+        let decorations = DecorationMap::new();
+        let file: Arc<Path> = PathBuf::from("test.rs").into();
+        let root = DecoratedNode::new(tree.root_node(), source, &file, &decorations);
+        let span = root.span();
+
+        assert_eq!(span.start(), 0);
+        assert_eq!(span.end(), source.len());
+    }
+
+    #[test]
+    fn named_child_returns_first_item() {
+        let source = "fn main() {}";
+        let tree = parse_tree(source);
+        let decorations = DecorationMap::new();
+        let file: Arc<Path> = PathBuf::from("test.rs").into();
+        let root = DecoratedNode::new(tree.root_node(), source, &file, &decorations);
+
+        let first_child = root.named_child(0).expect("should have a child");
+        assert_eq!(first_child.kind(), "function_item");
+    }
+
+    #[test]
+    fn decoration_returns_attached_value() {
+        #[derive(Debug)]
+        struct TestDeco(u32);
+
+        let source = "fn main() {}";
+        let tree = parse_tree(source);
+        let mut decorations = DecorationMap::new();
+        let node_id = tree.root_node().id();
+        decorations.insert(node_id, TestDeco(42));
+
+        let file: Arc<Path> = PathBuf::from("test.rs").into();
+        let root = DecoratedNode::new(tree.root_node(), source, &file, &decorations);
+        let deco = root
+            .decoration::<TestDeco>()
+            .expect("should find decoration");
+        assert_eq!(deco.0, 42);
+    }
+
+    #[test]
+    fn decoration_returns_none_when_missing() {
+        #[derive(Debug)]
+        struct Missing;
+
+        let source = "fn main() {}";
+        let tree = parse_tree(source);
+        let decorations = DecorationMap::new();
+        let file: Arc<Path> = PathBuf::from("test.rs").into();
+        let root = DecoratedNode::new(tree.root_node(), source, &file, &decorations);
+
+        assert!(root.decoration::<Missing>().is_none());
+    }
+
+    mod prop {
+        use proptest::prelude::*;
+
+        use super::*;
+
+        proptest! {
+            #[test]
+            fn root_text_equals_source(source in "(fn [a-z]+\\(\\) \\{\\}\n){0,5}") {
+                let tree = parse_tree(&source);
+                let decorations = DecorationMap::new();
+                let file: Arc<Path> = PathBuf::from("test.rs").into();
+                let root = DecoratedNode::new(
+                    tree.root_node(),
+                    &source,
+                    &file,
+                    &decorations,
+                );
+
+                prop_assert_eq!(root.text(), source.as_str());
+            }
+
+            #[test]
+            fn root_span_covers_full_source(source in "(fn [a-z]+\\(\\) \\{\\}\n){0,5}") {
+                let tree = parse_tree(&source);
+                let decorations = DecorationMap::new();
+                let file: Arc<Path> = PathBuf::from("test.rs").into();
+                let root = DecoratedNode::new(
+                    tree.root_node(),
+                    &source,
+                    &file,
+                    &decorations,
+                );
+
+                prop_assert_eq!(root.span().start(), 0);
+                prop_assert_eq!(root.span().end(), source.len());
+            }
+
+            #[test]
+            fn named_child_count_matches_named_children_len(source in "\\PC{0,200}") {
+                let tree = parse_tree(&source);
+                let decorations = DecorationMap::new();
+                let file: Arc<Path> = PathBuf::from("test.rs").into();
+                let root = DecoratedNode::new(
+                    tree.root_node(),
+                    &source,
+                    &file,
+                    &decorations,
+                );
+
+                prop_assert_eq!(
+                    root.named_child_count(),
+                    root.named_children().len()
+                );
+            }
+
+            #[test]
+            fn named_child_out_of_bounds_returns_none(
+                index in 1000..=u32::MAX,
+            ) {
+                let source = "fn main() {}";
+                let tree = parse_tree(source);
+                let decorations = DecorationMap::new();
+                let file: Arc<Path> = PathBuf::from("test.rs").into();
+                let root = DecoratedNode::new(
+                    tree.root_node(),
+                    source,
+                    &file,
+                    &decorations,
+                );
+
+                prop_assert!(root.named_child(index).is_none());
+            }
+
+            #[test]
+            fn decoration_roundtrips_through_node(value: u64) {
+                let source = "fn main() {}";
+                let tree = parse_tree(source);
+                let mut decorations = DecorationMap::new();
+                decorations.insert(tree.root_node().id(), value);
+
+                let file: Arc<Path> = PathBuf::from("test.rs").into();
+                let root = DecoratedNode::new(
+                    tree.root_node(),
+                    source,
+                    &file,
+                    &decorations,
+                );
+
+                prop_assert_eq!(root.decoration::<u64>(), Some(&value));
+            }
+        }
+    }
+}

--- a/crates/whisker-types/src/decorated_tree.rs
+++ b/crates/whisker-types/src/decorated_tree.rs
@@ -1,0 +1,175 @@
+use std::path::Path;
+use std::sync::Arc;
+
+use crate::{DecoratedNode, DecorationMap};
+
+/// A parsed syntax tree with an overlay of semantic decorations
+///
+/// Wraps a tree-sitter [`Tree`] together with its source text, file path,
+/// and a [`DecorationMap`] that providers populate with per-node semantic
+/// information. The tree and decorations together form the input to lint
+/// rules.
+///
+/// [`Tree`]: tree_sitter::Tree
+pub struct DecoratedTree {
+    tree: tree_sitter::Tree,
+    source: String,
+    file: Arc<Path>,
+    decorations: DecorationMap,
+}
+
+impl DecoratedTree {
+    /// Creates a decorated tree from a parsed tree-sitter tree
+    pub fn new(tree: tree_sitter::Tree, source: String, file: impl Into<Arc<Path>>) -> Self {
+        Self {
+            tree,
+            source,
+            file: file.into(),
+            decorations: DecorationMap::new(),
+        }
+    }
+
+    /// Returns a mutable reference to the decoration map for providers to
+    /// populate
+    pub fn decorations_mut(&mut self) -> &mut DecorationMap {
+        &mut self.decorations
+    }
+
+    /// Returns the root node wrapped as a [`DecoratedNode`]
+    pub fn root_node(&self) -> DecoratedNode<'_> {
+        DecoratedNode::new(
+            self.tree.root_node(),
+            &self.source,
+            &self.file,
+            &self.decorations,
+        )
+    }
+
+    /// Returns the source text of the file
+    pub fn source(&self) -> &str {
+        &self.source
+    }
+
+    /// Returns the file path
+    pub fn file(&self) -> &Path {
+        &self.file
+    }
+}
+
+impl std::fmt::Debug for DecoratedTree {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("DecoratedTree")
+            .field("file", &self.file)
+            .field("source_len", &self.source.len())
+            .finish()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::path::PathBuf;
+
+    use super::*;
+
+    fn parse_tree(source: &str) -> tree_sitter::Tree {
+        let mut parser = tree_sitter::Parser::new();
+        parser
+            .set_language(&tree_sitter_rust::LANGUAGE.into())
+            .unwrap();
+        parser.parse(source, None).unwrap()
+    }
+
+    #[test]
+    fn trait_send() {
+        fn assert_send<T: Send>() {}
+        assert_send::<DecoratedTree>();
+    }
+
+    #[test]
+    fn trait_sync() {
+        fn assert_sync<T: Sync>() {}
+        assert_sync::<DecoratedTree>();
+    }
+
+    #[test]
+    fn trait_unpin() {
+        fn assert_unpin<T: Unpin>() {}
+        assert_unpin::<DecoratedTree>();
+    }
+
+    #[test]
+    fn root_node_kind_is_source_file() {
+        let source = "fn main() {}";
+        let tree = parse_tree(source);
+        let decorated = DecoratedTree::new(tree, source.into(), PathBuf::from("test.rs"));
+
+        assert_eq!(decorated.root_node().kind(), "source_file");
+    }
+
+    #[test]
+    fn source_returns_original_text() {
+        let source = "fn main() {}";
+        let tree = parse_tree(source);
+        let decorated = DecoratedTree::new(tree, source.into(), PathBuf::from("test.rs"));
+
+        assert_eq!(decorated.source(), source);
+    }
+
+    #[test]
+    fn file_returns_path() {
+        let source = "";
+        let tree = parse_tree(source);
+        let decorated = DecoratedTree::new(tree, source.into(), PathBuf::from("test.rs"));
+
+        assert_eq!(decorated.file(), Path::new("test.rs"));
+    }
+
+    mod prop {
+        use proptest::prelude::*;
+
+        use super::*;
+
+        proptest! {
+            #[test]
+            fn source_roundtrips(source in "\\PC{0,200}") {
+                let tree = parse_tree(&source);
+                let decorated = DecoratedTree::new(
+                    tree,
+                    source.clone(),
+                    PathBuf::from("test.rs"),
+                );
+
+                prop_assert_eq!(decorated.source(), source);
+            }
+
+            #[test]
+            fn file_roundtrips(file in "[a-z]{1,10}\\.rs") {
+                let tree = parse_tree("");
+                let decorated = DecoratedTree::new(
+                    tree,
+                    String::new(),
+                    PathBuf::from(&file),
+                );
+
+                prop_assert_eq!(decorated.file(), Path::new(&file));
+            }
+
+            #[test]
+            fn root_is_source_file_or_error(source in "\\PC{0,200}") {
+                let tree = parse_tree(&source);
+                let decorated = DecoratedTree::new(
+                    tree,
+                    source,
+                    PathBuf::from("test.rs"),
+                );
+
+                let root = decorated.root_node();
+                let kind = root.kind();
+                prop_assert!(
+                    kind == "source_file" || kind == "ERROR",
+                    "unexpected root kind: {kind}"
+                );
+            }
+        }
+    }
+}

--- a/crates/whisker-types/src/decoration_map.rs
+++ b/crates/whisker-types/src/decoration_map.rs
@@ -1,0 +1,229 @@
+use std::any::{Any, TypeId};
+use std::collections::HashMap;
+
+/// Storage for per-node decorations on a syntax tree
+///
+/// Decorations are semantic annotations attached to tree-sitter nodes by
+/// decoration providers. Each node (keyed by its `id()`) can carry multiple
+/// decorations of different types. Decorations are type-erased via
+/// [`Any`] and retrieved by downcast.
+///
+/// [`Any`]: std::any::Any
+#[derive(Debug, Default)]
+pub struct DecorationMap {
+    entries: HashMap<usize, Vec<ErasedDecoration>>,
+}
+
+#[derive(Debug)]
+struct ErasedDecoration {
+    type_id: TypeId,
+    value: Box<dyn Any + Send + Sync>,
+}
+
+impl DecorationMap {
+    /// Creates an empty decoration map
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Attaches a decoration to the node with the given tree-sitter node ID
+    pub fn insert<T: Any + Send + Sync>(&mut self, node_id: usize, value: T) {
+        let entry = ErasedDecoration {
+            type_id: TypeId::of::<T>(),
+            value: Box::new(value),
+        };
+        self.entries.entry(node_id).or_default().push(entry);
+    }
+
+    /// Retrieves the first decoration of type `T` attached to the given node
+    ///
+    /// Returns [`None`] if no decoration of that type exists for this node.
+    pub fn get<T: Any + Send + Sync>(&self, node_id: usize) -> Option<&T> {
+        let decorations = self.entries.get(&node_id)?;
+        let target = TypeId::of::<T>();
+        decorations
+            .iter()
+            .find(|d| d.type_id == target)
+            .and_then(|d| d.value.downcast_ref())
+    }
+
+    /// Retrieves all decorations of type `T` attached to the given node
+    pub fn get_all<T: Any + Send + Sync>(&self, node_id: usize) -> Vec<&T> {
+        let Some(decorations) = self.entries.get(&node_id) else {
+            return Vec::new();
+        };
+        let target = TypeId::of::<T>();
+        decorations
+            .iter()
+            .filter(|d| d.type_id == target)
+            .filter_map(|d| d.value.downcast_ref())
+            .collect()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[derive(Debug)]
+    struct TypeInfo(String);
+
+    #[derive(Debug)]
+    struct Scope(u32);
+
+    #[test]
+    fn trait_send() {
+        fn assert_send<T: Send>() {}
+        assert_send::<DecorationMap>();
+    }
+
+    #[test]
+    fn trait_sync() {
+        fn assert_sync<T: Sync>() {}
+        assert_sync::<DecorationMap>();
+    }
+
+    #[test]
+    fn trait_unpin() {
+        fn assert_unpin<T: Unpin>() {}
+        assert_unpin::<DecorationMap>();
+    }
+
+    #[test]
+    fn get_on_empty_map_returns_none() {
+        let map = DecorationMap::new();
+        assert!(map.get::<TypeInfo>(0).is_none());
+    }
+
+    #[test]
+    fn get_retrieves_inserted_decoration() {
+        let mut map = DecorationMap::new();
+        map.insert(42, TypeInfo("bool".into()));
+
+        let result = map.get::<TypeInfo>(42).expect("should find decoration");
+        assert_eq!(result.0, "bool");
+    }
+
+    #[test]
+    fn get_with_wrong_type_returns_none() {
+        let mut map = DecorationMap::new();
+        map.insert(42, TypeInfo("bool".into()));
+
+        assert!(map.get::<Scope>(42).is_none());
+    }
+
+    #[test]
+    fn get_with_wrong_node_returns_none() {
+        let mut map = DecorationMap::new();
+        map.insert(42, TypeInfo("bool".into()));
+
+        assert!(map.get::<TypeInfo>(99).is_none());
+    }
+
+    #[test]
+    fn get_all_returns_multiple_same_type() {
+        let mut map = DecorationMap::new();
+        map.insert(1, TypeInfo("i32".into()));
+        map.insert(1, TypeInfo("u64".into()));
+
+        let results = map.get_all::<TypeInfo>(1);
+        assert_eq!(results.len(), 2);
+        assert_eq!(results[0].0, "i32");
+        assert_eq!(results[1].0, "u64");
+    }
+
+    #[test]
+    fn get_all_on_missing_node_returns_empty() {
+        let map = DecorationMap::new();
+        let results = map.get_all::<TypeInfo>(99);
+        assert!(results.is_empty());
+    }
+
+    #[test]
+    fn multiple_types_on_same_node() {
+        let mut map = DecorationMap::new();
+        map.insert(1, TypeInfo("i32".into()));
+        map.insert(1, Scope(3));
+
+        assert!(map.get::<TypeInfo>(1).is_some());
+        assert!(map.get::<Scope>(1).is_some());
+        assert_eq!(map.get::<Scope>(1).unwrap().0, 3);
+    }
+
+    mod prop {
+        use proptest::prelude::*;
+
+        use super::*;
+
+        proptest! {
+            #[test]
+            fn insert_then_get_roundtrips(node_id: usize, value: u64) {
+                let mut map = DecorationMap::new();
+                map.insert(node_id, value);
+
+                let result = map.get::<u64>(node_id);
+                prop_assert_eq!(result, Some(&value));
+            }
+
+            #[test]
+            fn get_on_different_node_returns_none(
+                insert_id: usize,
+                query_id: usize,
+                value: u64,
+            ) {
+                prop_assume!(insert_id != query_id);
+                let mut map = DecorationMap::new();
+                map.insert(insert_id, value);
+
+                prop_assert!(map.get::<u64>(query_id).is_none());
+            }
+
+            #[test]
+            fn get_with_wrong_type_returns_none(node_id: usize, value: u64) {
+                let mut map = DecorationMap::new();
+                map.insert(node_id, value);
+
+                prop_assert!(map.get::<i32>(node_id).is_none());
+            }
+
+            #[test]
+            fn get_all_count_matches_insert_count(
+                node_id: usize,
+                values in proptest::collection::vec(any::<u32>(), 0..=20),
+            ) {
+                let mut map = DecorationMap::new();
+                for v in &values {
+                    map.insert(node_id, *v);
+                }
+
+                let results = map.get_all::<u32>(node_id);
+                prop_assert_eq!(results.len(), values.len());
+            }
+
+            #[test]
+            fn get_all_preserves_insertion_order(
+                node_id: usize,
+                values in proptest::collection::vec(any::<u32>(), 1..=10),
+            ) {
+                let mut map = DecorationMap::new();
+                for v in &values {
+                    map.insert(node_id, *v);
+                }
+
+                let results = map.get_all::<u32>(node_id);
+                let result_values: Vec<u32> = results.into_iter().copied().collect();
+                prop_assert_eq!(result_values, values);
+            }
+
+            #[test]
+            fn different_types_do_not_interfere(node_id: usize, a: u32, b: i64) {
+                let mut map = DecorationMap::new();
+                map.insert(node_id, a);
+                map.insert(node_id, b);
+
+                prop_assert_eq!(map.get::<u32>(node_id), Some(&a));
+                prop_assert_eq!(map.get::<i64>(node_id), Some(&b));
+            }
+        }
+    }
+}

--- a/crates/whisker-types/src/decoration_provider.rs
+++ b/crates/whisker-types/src/decoration_provider.rs
@@ -1,0 +1,50 @@
+use crate::DecoratedTree;
+
+/// Attaches semantic decorations to a parsed syntax tree
+///
+/// Decoration providers bridge between a language toolchain (e.g.
+/// rust-analyzer) and the platform's decoration system. A provider reads
+/// the syntax tree, queries the toolchain for semantic information, and
+/// inserts decorations into the tree's [`DecorationMap`].
+///
+/// [`DecorationMap`]: crate::DecorationMap
+pub trait DecorationProvider: Send + Sync {
+    /// Populates decorations on the given tree
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the toolchain connection fails or produces
+    /// invalid results.
+    fn decorate(&self, tree: &mut DecoratedTree) -> anyhow::Result<()>;
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    struct Stub;
+
+    impl DecorationProvider for Stub {
+        fn decorate(&self, _tree: &mut DecoratedTree) -> anyhow::Result<()> {
+            Ok(())
+        }
+    }
+
+    #[test]
+    fn trait_send() {
+        fn assert_send<T: Send>() {}
+        assert_send::<Stub>();
+    }
+
+    #[test]
+    fn trait_sync() {
+        fn assert_sync<T: Sync>() {}
+        assert_sync::<Stub>();
+    }
+
+    #[test]
+    fn trait_unpin() {
+        fn assert_unpin<T: Unpin>() {}
+        assert_unpin::<Stub>();
+    }
+}

--- a/crates/whisker-types/src/lib.rs
+++ b/crates/whisker-types/src/lib.rs
@@ -1,13 +1,23 @@
+mod decorated_node;
+mod decorated_tree;
+mod decoration_map;
+mod decoration_provider;
 mod diagnostic;
 mod language;
+mod lint_pass;
 mod location;
 mod rule_id;
 mod severity;
 mod span;
 mod suggestion;
 
+pub use decorated_node::DecoratedNode;
+pub use decorated_tree::DecoratedTree;
+pub use decoration_map::DecorationMap;
+pub use decoration_provider::DecorationProvider;
 pub use diagnostic::Diagnostic;
 pub use language::Language;
+pub use lint_pass::LintPass;
 pub use location::Location;
 pub use rule_id::RuleId;
 pub use severity::Severity;

--- a/crates/whisker-types/src/lint_pass.rs
+++ b/crates/whisker-types/src/lint_pass.rs
@@ -1,0 +1,47 @@
+use crate::{DecoratedNode, Diagnostic};
+
+/// A lint rule that inspects decorated syntax tree nodes
+///
+/// This is the platform-level trait that the tree walker dispatches to.
+/// Language-specific SDKs generate more ergonomic traits (e.g.
+/// `RustLintPass`) that refine this into per-node-kind methods, but the
+/// core pipeline operates on this common interface.
+pub trait LintPass: Send + Sync {
+    /// Inspects a single node and returns any diagnostics found
+    ///
+    /// Called by the tree walker for every named node in the syntax tree.
+    /// Implementations should return an empty vec for nodes they do not
+    /// care about.
+    fn check_node(&mut self, node: &DecoratedNode<'_>) -> Vec<Diagnostic>;
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    struct Dummy;
+
+    impl LintPass for Dummy {
+        fn check_node(&mut self, _node: &DecoratedNode<'_>) -> Vec<Diagnostic> {
+            Vec::new()
+        }
+    }
+
+    #[test]
+    fn trait_send() {
+        fn assert_send<T: Send>() {}
+        assert_send::<Dummy>();
+    }
+
+    #[test]
+    fn trait_sync() {
+        fn assert_sync<T: Sync>() {}
+        assert_sync::<Dummy>();
+    }
+
+    #[test]
+    fn trait_unpin() {
+        fn assert_unpin<T: Unpin>() {}
+        assert_unpin::<Dummy>();
+    }
+}


### PR DESCRIPTION
Extends whisker-types with types that bridge the linting domain to tree-sitter syntax trees: DecoratedNode, DecoratedTree, DecorationMap, DecorationProvider, and LintPass.

DecoratedNode wraps a tree-sitter Node with a DecorationMap for attaching semantic annotations. DecoratedTree owns the parsed tree and source text. DecorationMap is a type-erased, insertion-ordered map keyed by TypeId. LintPass and DecorationProvider are the traits that lint rules and language SDKs implement respectively.

All types have property-based tests, Send/Sync/Unpin trait tests, and proptest regression files.