### PR TITLE
Add whisker-testing crate for tree-sitter lint harness

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1619,6 +1619,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "whisker-testing"
+version = "0.1.0"
+dependencies = [
+ "proptest",
+ "tree-sitter",
+ "tree-sitter-rust",
+ "whisker-core",
+ "whisker-rust",
+ "whisker-types",
+]
+
+[[package]]
 name = "whisker-types"
 version = "0.1.0"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,3 +41,4 @@ serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 whisker-codegen = { path = "crates/whisker-codegen", version = "=0.1.0" }
 whisker-rust = { path = "crates/whisker-rust", version = "=0.1.0" }
+whisker-testing = { path = "crates/whisker-testing", version = "=0.1.0" }

--- a/crates/whisker-testing/Cargo.toml
+++ b/crates/whisker-testing/Cargo.toml
@@ -1,0 +1,19 @@
+[package]
+name = "whisker-testing"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+publish = false
+
+[dependencies]
+tree-sitter.workspace = true
+tree-sitter-rust.workspace = true
+whisker-core.workspace = true
+whisker-types.workspace = true
+
+[dev-dependencies]
+proptest.workspace = true
+whisker-rust.workspace = true
+
+[lints]
+workspace = true

--- a/crates/whisker-testing/src/lib.rs
+++ b/crates/whisker-testing/src/lib.rs
@@ -1,0 +1,355 @@
+use std::path::{Path, PathBuf};
+
+use whisker_types::{DecoratedTree, DecorationMap, Diagnostic, Language, LintPass, Severity, Span};
+
+/// Parses source text into a decorated tree for the given language
+///
+/// The returned tree has no decorations attached. Use [`decorate`] to
+/// add manually constructed decorations for testing.
+///
+/// # Panics
+///
+/// Panics if the language is unsupported or if tree-sitter fails to
+/// parse.
+// r[impl testing.parse]
+pub fn parse(source: &str, language: Language) -> DecoratedTree {
+    let ts_language = match language {
+        Language::Rust => tree_sitter_rust::LANGUAGE.into(),
+    };
+
+    let mut parser = tree_sitter::Parser::new();
+    parser
+        .set_language(&ts_language)
+        .expect("failed to set tree-sitter language");
+
+    let tree = parser
+        .parse(source, None)
+        .expect("tree-sitter parse returned None");
+
+    DecoratedTree::new(tree, source.to_string(), PathBuf::from("<test>"))
+}
+
+/// Attaches manual decorations to a parsed tree
+///
+/// Replaces the tree's decoration map with the provided one. This
+/// allows testing rules that depend on semantic information without
+/// running a real language toolchain.
+// r[impl testing.decorate]
+pub fn decorate(tree: &mut DecoratedTree, decorations: DecorationMap) {
+    *tree.decorations_mut() = decorations;
+}
+
+/// Executes lint passes against a decorated tree and returns diagnostics
+// r[impl testing.execute]
+pub fn execute(tree: &DecoratedTree, passes: &mut [Box<dyn LintPass>]) -> Vec<Diagnostic> {
+    whisker_core::walk(tree, passes)
+}
+
+/// Builder for asserting diagnostic properties
+///
+/// # Examples
+///
+/// ```ignore
+/// let diag = &diagnostics[0];
+/// assert_diagnostic(diag)
+///     .has_rule_id("lint.test")
+///     .has_severity(Severity::Warn)
+///     .message_contains("wildcard");
+/// ```
+// r[impl testing.assert-diagnostic]
+pub fn assert_diagnostic(diagnostic: &Diagnostic) -> DiagnosticAssertion<'_> {
+    DiagnosticAssertion { diagnostic }
+}
+
+/// Asserts that no diagnostics were emitted
+///
+/// # Panics
+///
+/// Panics if `diagnostics` is not empty, printing all diagnostics.
+// r[impl testing.assert-no-diagnostic]
+pub fn assert_no_diagnostics(diagnostics: &[Diagnostic]) {
+    assert!(
+        diagnostics.is_empty(),
+        "expected no diagnostics, got {}: {:?}",
+        diagnostics.len(),
+        diagnostics
+    );
+}
+
+/// Loads test fixtures from a directory for the given language
+///
+/// Each source file matching the language's extension becomes a test
+/// case. Returns pairs of `(filename, source_text)` sorted by filename.
+///
+/// # Panics
+///
+/// Panics if the directory cannot be read.
+// r[impl testing.fixture.directory]
+pub fn fixtures(dir: &str, language: Language) -> Vec<(String, String)> {
+    let path = Path::new(dir);
+    let mut cases = Vec::new();
+
+    let entries = std::fs::read_dir(path).unwrap_or_else(|e| panic!("read fixture dir {dir}: {e}"));
+
+    for entry in entries.flatten() {
+        let file_path = entry.path();
+        let Some(ext) = file_path.extension().and_then(|e| e.to_str()) else {
+            continue;
+        };
+        if Language::from_extension(ext) != Some(language) {
+            continue;
+        }
+        let name = file_path.file_name().unwrap().to_string_lossy().to_string();
+        let source = std::fs::read_to_string(&file_path)
+            .unwrap_or_else(|e| panic!("read fixture {}: {e}", file_path.display()));
+        cases.push((name, source));
+    }
+
+    cases.sort_by(|a, b| a.0.cmp(&b.0));
+    cases
+}
+
+/// Fluent assertion helper for [`Diagnostic`] values
+pub struct DiagnosticAssertion<'a> {
+    diagnostic: &'a Diagnostic,
+}
+
+impl DiagnosticAssertion<'_> {
+    /// Asserts the diagnostic has the given rule ID
+    ///
+    /// # Panics
+    ///
+    /// Panics if the rule ID does not match `expected`.
+    pub fn has_rule_id(self, expected: &str) -> Self {
+        assert_eq!(
+            self.diagnostic.rule_id().as_str(),
+            expected,
+            "expected rule_id `{expected}`, got `{}`",
+            self.diagnostic.rule_id()
+        );
+        self
+    }
+
+    /// Asserts the diagnostic has the given severity
+    ///
+    /// # Panics
+    ///
+    /// Panics if the severity does not match `expected`.
+    pub fn has_severity(self, expected: Severity) -> Self {
+        assert_eq!(
+            self.diagnostic.severity(),
+            expected,
+            "expected severity {expected:?}, got {:?}",
+            self.diagnostic.severity()
+        );
+        self
+    }
+
+    /// Asserts the diagnostic message contains the given substring
+    ///
+    /// # Panics
+    ///
+    /// Panics if the message does not contain `substring`.
+    pub fn message_contains(self, substring: &str) -> Self {
+        assert!(
+            self.diagnostic.message().contains(substring),
+            "expected message containing `{substring}`, got `{}`",
+            self.diagnostic.message()
+        );
+        self
+    }
+
+    /// Asserts the diagnostic span covers the given byte range
+    ///
+    /// # Panics
+    ///
+    /// Panics if the span does not match the expected file, start, and end.
+    pub fn has_span(self, file: &str, start: usize, end: usize) -> Self {
+        let expected = Span::new(PathBuf::from(file), start, end);
+        assert_eq!(
+            self.diagnostic.span(),
+            &expected,
+            "expected span {start}..{end} in {file}, got {}..{} in {}",
+            self.diagnostic.span().start(),
+            self.diagnostic.span().end(),
+            self.diagnostic.span().file().display()
+        );
+        self
+    }
+
+    /// Asserts the diagnostic has the given number of origin locations
+    ///
+    /// # Panics
+    ///
+    /// Panics if the origin count does not match `expected`.
+    pub fn has_origin_count(self, expected: usize) -> Self {
+        assert_eq!(
+            self.diagnostic.origins().len(),
+            expected,
+            "expected {expected} origins, got {}",
+            self.diagnostic.origins().len()
+        );
+        self
+    }
+
+    /// Asserts the diagnostic has the given number of related locations
+    ///
+    /// # Panics
+    ///
+    /// Panics if the related location count does not match `expected`.
+    pub fn has_related_count(self, expected: usize) -> Self {
+        assert_eq!(
+            self.diagnostic.related().len(),
+            expected,
+            "expected {expected} related locations, got {}",
+            self.diagnostic.related().len()
+        );
+        self
+    }
+
+    /// Asserts the diagnostic has the given number of suggestions
+    ///
+    /// # Panics
+    ///
+    /// Panics if the suggestion count does not match `expected`.
+    pub fn has_suggestion_count(self, expected: usize) -> Self {
+        assert_eq!(
+            self.diagnostic.suggestions().len(),
+            expected,
+            "expected {expected} suggestions, got {}",
+            self.diagnostic.suggestions().len()
+        );
+        self
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use whisker_types::{DecoratedNode, Diagnostic, RuleId, Severity};
+
+    use super::*;
+
+    #[test]
+    fn trait_send() {
+        fn assert_send<T: Send>() {}
+        assert_send::<DiagnosticAssertion<'_>>();
+    }
+
+    #[test]
+    fn trait_sync() {
+        fn assert_sync<T: Sync>() {}
+        assert_sync::<DiagnosticAssertion<'_>>();
+    }
+
+    #[test]
+    fn trait_unpin() {
+        fn assert_unpin<T: Unpin>() {}
+        assert_unpin::<DiagnosticAssertion<'_>>();
+    }
+
+    #[test]
+    fn parse_returns_tree_with_source_file_root() {
+        let tree = parse("fn main() {}", Language::Rust);
+        assert_eq!(tree.root_node().kind(), "source_file");
+    }
+
+    #[test]
+    fn execute_with_no_passes_returns_empty() {
+        let tree = parse("fn main() {}", Language::Rust);
+        let diagnostics = execute(&tree, &mut Vec::new());
+        assert!(diagnostics.is_empty());
+    }
+
+    #[test]
+    fn execute_collects_diagnostics_from_pass() {
+        struct FnFinder;
+        impl LintPass for FnFinder {
+            fn check_node(&mut self, node: &DecoratedNode<'_>) -> Vec<Diagnostic> {
+                if node.kind() == "function_item" {
+                    vec![Diagnostic::new(
+                        RuleId("test.fn"),
+                        Severity::Warn,
+                        "found fn".into(),
+                        node.span(),
+                    )]
+                } else {
+                    Vec::new()
+                }
+            }
+        }
+
+        let tree = parse("fn main() {}", Language::Rust);
+        let mut passes: Vec<Box<dyn LintPass>> = vec![Box::new(FnFinder)];
+        let diagnostics = execute(&tree, &mut passes);
+
+        assert_eq!(diagnostics.len(), 1);
+        assert_diagnostic(&diagnostics[0])
+            .has_rule_id("test.fn")
+            .has_severity(Severity::Warn)
+            .message_contains("found fn");
+    }
+
+    #[test]
+    fn assert_no_diagnostics_with_empty_slice_succeeds() {
+        assert_no_diagnostics(&[]);
+    }
+
+    #[test]
+    #[should_panic(expected = "expected no diagnostics")]
+    fn assert_no_diagnostics_with_non_empty_slice_panics() {
+        let diag = Diagnostic::new(
+            RuleId("test"),
+            Severity::Warn,
+            "msg".into(),
+            whisker_types::Span::new(std::path::PathBuf::from("f.rs"), 0, 1),
+        );
+        assert_no_diagnostics(&[diag]);
+    }
+
+    #[test]
+    fn decorate_replaces_decoration_map() {
+        let mut tree = parse("fn main() {}", Language::Rust);
+        let mut map = DecorationMap::new();
+        map.insert(0, 42u32);
+        decorate(&mut tree, map);
+
+        assert_eq!(tree.decorations_mut().get::<u32>(0), Some(&42));
+    }
+
+    mod prop {
+        use proptest::prelude::*;
+
+        use super::*;
+
+        proptest! {
+            #[test]
+            fn parse_never_panics(source in "\\PC{0,200}") {
+                let _tree = parse(&source, Language::Rust);
+            }
+
+            #[test]
+            fn parse_root_is_source_file_for_valid_rust(
+                source in "(fn [a-z]+\\(\\) \\{\\}\n){0,5}",
+            ) {
+                let tree = parse(&source, Language::Rust);
+                let root = tree.root_node();
+                prop_assert_eq!(root.kind(), "source_file");
+            }
+
+            #[test]
+            fn parse_preserves_source(source in "\\PC{0,200}") {
+                let tree = parse(&source, Language::Rust);
+                prop_assert_eq!(tree.source(), source.as_str());
+            }
+
+            #[test]
+            fn execute_with_no_passes_always_empty(
+                source in "(fn [a-z]+\\(\\) \\{\\}\n){0,5}",
+            ) {
+                let tree = parse(&source, Language::Rust);
+                let diagnostics = execute(&tree, &mut Vec::new());
+                prop_assert!(diagnostics.is_empty());
+            }
+        }
+    }
+}

--- a/crates/whisker-testing/tests/integration.rs
+++ b/crates/whisker-testing/tests/integration.rs
@@ -1,0 +1,212 @@
+use whisker_rust::{RustLintPass, RustLintPassAdapter};
+use whisker_testing::{assert_diagnostic, assert_no_diagnostics, execute, parse};
+use whisker_types::{DecoratedNode, Diagnostic, Language, LintPass, RuleId, Severity};
+
+fn adapt<P: RustLintPass + Send + Sync + 'static>(pass: P) -> Box<dyn LintPass> {
+    Box::new(RustLintPassAdapter::new(pass))
+}
+
+struct MatchArmWildcardFinder;
+
+impl RustLintPass for MatchArmWildcardFinder {
+    fn check_match_arm(&mut self, node: &DecoratedNode<'_>) -> Vec<Diagnostic> {
+        let text = node.text();
+        if text.starts_with('_') && !text.starts_with("__") {
+            vec![Diagnostic::new(
+                RuleId("lint.wildcard-match-arm"),
+                Severity::Warn,
+                "wildcard match arm".into(),
+                node.span(),
+            )]
+        } else {
+            Vec::new()
+        }
+    }
+}
+
+#[test]
+fn wildcard_finder_detects_wildcard_arm() {
+    let tree = parse("fn f() { match x { 1 => {} _ => {} } }", Language::Rust);
+    let mut passes = vec![adapt(MatchArmWildcardFinder)];
+    let diagnostics = execute(&tree, &mut passes);
+
+    assert_eq!(diagnostics.len(), 1);
+    assert_diagnostic(&diagnostics[0])
+        .has_rule_id("lint.wildcard-match-arm")
+        .has_severity(Severity::Warn)
+        .message_contains("wildcard");
+}
+
+#[test]
+fn wildcard_finder_ignores_named_arms() {
+    let tree = parse("fn f() { match x { Foo => {} Bar => {} } }", Language::Rust);
+    let mut passes = vec![adapt(MatchArmWildcardFinder)];
+    let diagnostics = execute(&tree, &mut passes);
+
+    assert_no_diagnostics(&diagnostics);
+}
+
+struct MacroInvocationFinder;
+
+impl RustLintPass for MacroInvocationFinder {
+    fn check_macro_invocation(&mut self, node: &DecoratedNode<'_>) -> Vec<Diagnostic> {
+        let text = node.text();
+        if text.starts_with("matches!") {
+            vec![Diagnostic::new(
+                RuleId("lint.no-matches-macro"),
+                Severity::Warn,
+                "use of matches! macro".into(),
+                node.span(),
+            )]
+        } else {
+            Vec::new()
+        }
+    }
+}
+
+#[test]
+fn macro_finder_detects_matches_macro() {
+    let tree = parse("fn f() { let _ = matches!(x, 1); }", Language::Rust);
+    let mut passes = vec![adapt(MacroInvocationFinder)];
+    let diagnostics = execute(&tree, &mut passes);
+
+    assert_eq!(diagnostics.len(), 1);
+    assert_diagnostic(&diagnostics[0])
+        .has_rule_id("lint.no-matches-macro")
+        .message_contains("matches!");
+}
+
+#[test]
+fn macro_finder_ignores_println() {
+    let tree = parse("fn f() { println!(\"hello\"); }", Language::Rust);
+    let mut passes = vec![adapt(MacroInvocationFinder)];
+    let diagnostics = execute(&tree, &mut passes);
+
+    assert_no_diagnostics(&diagnostics);
+}
+
+struct BoolParamFinder;
+
+impl RustLintPass for BoolParamFinder {
+    fn check_function_item(&mut self, node: &DecoratedNode<'_>) -> Vec<Diagnostic> {
+        let text = node.text();
+        if text.contains(": bool") {
+            vec![Diagnostic::new(
+                RuleId("lint.bool-param"),
+                Severity::Warn,
+                "bool parameter".into(),
+                node.span(),
+            )]
+        } else {
+            Vec::new()
+        }
+    }
+}
+
+#[test]
+fn bool_finder_detects_bool_param() {
+    let tree = parse("fn f(x: bool) {}", Language::Rust);
+    let mut passes = vec![adapt(BoolParamFinder)];
+    let diagnostics = execute(&tree, &mut passes);
+
+    assert_eq!(diagnostics.len(), 1);
+    assert_diagnostic(&diagnostics[0])
+        .has_rule_id("lint.bool-param")
+        .message_contains("bool");
+}
+
+#[test]
+fn bool_finder_ignores_non_bool_params() {
+    let tree = parse("fn f(x: i32) {}", Language::Rust);
+    let mut passes = vec![adapt(BoolParamFinder)];
+    let diagnostics = execute(&tree, &mut passes);
+
+    assert_no_diagnostics(&diagnostics);
+}
+
+#[test]
+fn multiple_lint_passes_run_together() {
+    let tree = parse(
+        "fn f(x: bool) { let _ = matches!(x, true); }",
+        Language::Rust,
+    );
+    let mut passes = vec![adapt(BoolParamFinder), adapt(MacroInvocationFinder)];
+    let diagnostics = execute(&tree, &mut passes);
+
+    assert_eq!(diagnostics.len(), 2);
+
+    let rule_ids: Vec<&str> = diagnostics.iter().map(|d| d.rule_id().as_str()).collect();
+    assert!(rule_ids.contains(&"lint.bool-param"));
+    assert!(rule_ids.contains(&"lint.no-matches-macro"));
+}
+
+#[test]
+fn diagnostic_spans_point_to_correct_byte_ranges() {
+    let source = "fn main() { let _ = matches!(x, 1); }";
+    let tree = parse(source, Language::Rust);
+    let mut passes = vec![adapt(MacroInvocationFinder)];
+    let diagnostics = execute(&tree, &mut passes);
+
+    assert_eq!(diagnostics.len(), 1);
+    let span = diagnostics[0].span();
+    let spanned_text = &source[span.start()..span.end()];
+    assert!(
+        spanned_text.contains("matches!"),
+        "span should cover the matches! invocation, got: {spanned_text}"
+    );
+}
+
+#[test]
+fn empty_source_produces_no_diagnostics() {
+    let tree = parse("", Language::Rust);
+    let mut passes = vec![
+        adapt(MatchArmWildcardFinder),
+        adapt(MacroInvocationFinder),
+        adapt(BoolParamFinder),
+    ];
+    let diagnostics = execute(&tree, &mut passes);
+    assert_no_diagnostics(&diagnostics);
+}
+
+#[test]
+fn complex_source_does_not_panic() {
+    let source = r#"
+        use std::collections::HashMap;
+
+        #[derive(Debug, Clone)]
+        struct Config {
+            name: String,
+            values: HashMap<String, i32>,
+        }
+
+        impl Config {
+            fn new(name: &str) -> Self {
+                Self {
+                    name: name.to_string(),
+                    values: HashMap::new(),
+                }
+            }
+
+            fn get(&self, key: &str) -> Option<&i32> {
+                self.values.get(key)
+            }
+        }
+
+        fn process(configs: &[Config]) -> Vec<String> {
+            configs
+                .iter()
+                .filter(|c| !c.name.is_empty())
+                .map(|c| c.name.clone())
+                .collect()
+        }
+    "#;
+
+    let tree = parse(source, Language::Rust);
+    let mut passes = vec![
+        adapt(MatchArmWildcardFinder),
+        adapt(MacroInvocationFinder),
+        adapt(BoolParamFinder),
+    ];
+    let diagnostics = execute(&tree, &mut passes);
+    assert_no_diagnostics(&diagnostics);
+}


### PR DESCRIPTION
Replaces the Dylint/compiletest_rs test harness with a tree-sitter based API. The new harness provides parse, decorate, execute, and assertion functions.

The DiagnosticAssertion builder supports fluent assertions for rule ID, severity, message content, span, and collection counts. Integration tests implement three lint pass prototypes using RustLintPassAdapter to verify the full parse-dispatch-assert pipeline end-to-end, including multi-pass composition and span correctness.