### PR TITLE
Rewrite derive_order lint for tree-sitter platform

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -81,6 +81,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "derive_order"
+version = "0.1.0"
+dependencies = [
+ "whisker-rust",
+ "whisker-testing",
+ "whisker-types",
+]
+
+[[package]]
 name = "equivalent"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [workspace]
-members = ["crates/*", "lints/bool_param"]
+members = ["crates/*", "lints/bool_param", "lints/derive_order"]
 exclude = ["examples/*", "crates/whisker", "lints/*"]
 
 # Opt-in to the new feature resolver introduced in Rust 1.85 and Edition 2024.

--- a/lints/derive_order/Cargo.toml
+++ b/lints/derive_order/Cargo.toml
@@ -5,15 +5,12 @@ edition.workspace = true
 license.workspace = true
 publish = false
 
-[lib]
-crate-type = ["cdylib", "rlib"]
-
 [dependencies]
-clippy_utils.workspace = true
-dylint_linting.workspace = true
+whisker-rust = { path = "../../crates/whisker-rust" }
+whisker-types = { path = "../../crates/whisker-types" }
 
 [dev-dependencies]
-whisker_testing.workspace = true
+whisker-testing = { path = "../../crates/whisker-testing" }
 
-[package.metadata.rust-analyzer]
-rustc_private = true
+[lints]
+workspace = true

--- a/lints/derive_order/src/lib.rs
+++ b/lints/derive_order/src/lib.rs
@@ -1,15 +1,5 @@
-#![feature(rustc_private)]
-#![warn(unused_extern_crates)]
-
-extern crate rustc_ast;
-extern crate rustc_span;
-
-use clippy_utils::diagnostics::span_lint_and_then;
-use rustc_ast::token::TokenKind;
-use rustc_ast::tokenstream::TokenTree;
-use rustc_ast::{AttrArgs, AttrItemKind, AttrKind, Attribute, Item};
-use rustc_lint::{EarlyContext, EarlyLintPass};
-use rustc_span::Span;
+use whisker_rust::{RustLintPass, RustLintPassAdapter};
+use whisker_types::{DecoratedNode, Diagnostic, LintPass, RuleId, Severity};
 
 const STD_DERIVES: &[&str] = &[
     "Copy",
@@ -23,98 +13,64 @@ const STD_DERIVES: &[&str] = &[
     "Default",
 ];
 
-// r[impl lint.derive-order.level]
-dylint_linting::declare_pre_expansion_lint! {
-    /// ### What it does
+/// Enforces canonical ordering of `#[derive(...)]` attributes
+///
+/// Standard library derives must appear first in the prescribed order
+/// (Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug, Default),
+/// followed by third-party derives sorted alphabetically.
+pub struct DeriveOrder;
+
+impl DeriveOrder {
+    /// Creates a boxed [`LintPass`] suitable for the whisker pipeline
     ///
-    /// Enforces a canonical ordering for `#[derive(...)]` attributes: standard
-    /// library derives must appear first in the prescribed order (Copy, Clone,
-    /// Eq, PartialEq, Ord, PartialOrd, Hash, Debug, Default), followed by
-    /// third-party derives sorted alphabetically by crate and then by macro
-    /// name.
+    /// # Examples
     ///
-    /// ### Why is this bad?
-    ///
-    /// Inconsistent derive ordering makes code harder to scan and review.
-    /// A canonical ordering reduces cognitive load and eliminates style
-    /// debates.
-    ///
-    /// ### Known problems
-    ///
-    /// None.
-    ///
-    /// ### Examples
-    ///
-    /// ```rust,ignore
-    /// // Bad:
-    /// #[derive(Debug, Clone, Default)]
-    /// struct Foo;
-    ///
-    /// // Good:
-    /// #[derive(Clone, Debug, Default)]
-    /// struct Foo;
+    /// ```ignore
+    /// let pass = DeriveOrder::into_lint_pass();
     /// ```
-    pub DERIVE_ORDER,
-    Warn,
-    "derive macros are not in canonical order"
+    pub fn into_lint_pass() -> Box<dyn LintPass> {
+        Box::new(RustLintPassAdapter::new(Self))
+    }
 }
 
+/// Returns the positional index of a standard library derive, if any
 fn std_derive_index(name: &str) -> Option<usize> {
     STD_DERIVES.iter().position(|&s| s == name)
 }
 
+/// Extracts the macro name from a potentially qualified path
+///
+/// Given `"serde::Serialize"`, returns `"Serialize"`.
 fn macro_name(full_path: &str) -> &str {
     full_path.rsplit("::").next().unwrap_or(full_path)
 }
 
-fn extract_derive_names(attrs: &[Attribute]) -> Option<(Vec<String>, Span)> {
-    for attr in attrs {
-        let AttrKind::Normal(normal_attr) = &attr.kind else {
-            continue;
-        };
-        let has_derive = normal_attr
-            .item
-            .path
-            .segments
-            .iter()
-            .any(|seg| seg.ident.name.as_str() == "derive");
-        if !has_derive {
-            continue;
-        }
-        let AttrItemKind::Unparsed(AttrArgs::Delimited(delim_args)) = &normal_attr.item.args else {
-            continue;
-        };
-
-        let mut names = Vec::new();
-        let mut current_path = String::new();
-
-        for tt in delim_args.tokens.iter() {
-            let TokenTree::Token(token, _) = tt else {
-                continue;
-            };
-            if let TokenKind::Ident(sym, _) = token.kind {
-                if !current_path.is_empty() {
-                    current_path.push_str("::");
-                }
-                current_path.push_str(sym.as_str());
-            }
-            if let TokenKind::Comma = token.kind
-                && !current_path.is_empty()
-            {
-                names.push(std::mem::take(&mut current_path));
-            }
-        }
-        if !current_path.is_empty() {
-            names.push(current_path);
-        }
-
-        if !names.is_empty() {
-            return Some((names, attr.span));
-        }
+/// Extracts derive names from `#[derive(...)]` attribute text
+///
+/// Returns [`None`] if the text is not a derive attribute or the
+/// derive list is empty.
+fn extract_derive_names(text: &str) -> Option<Vec<String>> {
+    let text = text.trim();
+    let inner = text.strip_prefix("#[derive(")?;
+    let inner = inner.strip_suffix(")]")?;
+    let inner = inner.trim();
+    if inner.is_empty() {
+        return None;
     }
-    None
+
+    let names: Vec<String> = inner.split(',').map(|s| s.trim().to_string()).collect();
+
+    if names.is_empty() {
+        return None;
+    }
+
+    Some(names)
 }
 
+/// Computes the canonical ordering for a list of derive names
+///
+/// Standard derives are placed first in their prescribed order,
+/// followed by third-party derives sorted case-insensitively.
 fn compute_expected_order(names: &[String]) -> Vec<String> {
     let mut std_derives: Vec<&String> = names
         .iter()
@@ -134,37 +90,173 @@ fn compute_expected_order(names: &[String]) -> Vec<String> {
 }
 
 // r[impl lint.derive-order.detect]
-impl EarlyLintPass for DeriveOrder {
-    fn check_item(&mut self, cx: &EarlyContext<'_>, item: &Item) {
-        let Some((names, span)) = extract_derive_names(&item.attrs) else {
-            return;
+impl RustLintPass for DeriveOrder {
+    fn check_attribute_item(&mut self, node: &DecoratedNode<'_>) -> Vec<Diagnostic> {
+        let text = node.text();
+
+        let Some(names) = extract_derive_names(text) else {
+            return Vec::new();
         };
 
         if names.len() <= 1 {
-            return;
+            return Vec::new();
         }
 
         let expected = compute_expected_order(&names);
 
         if names == expected {
-            return;
+            return Vec::new();
         }
 
         // r[impl lint.derive-order.message]
         let expected_str = expected.join(", ");
-        span_lint_and_then(
-            cx,
-            DERIVE_ORDER,
-            span,
-            "derive macros are not in canonical order",
-            |diag| {
-                diag.help(format!("expected order: {expected_str}"));
-            },
-        );
+        vec![Diagnostic::new(
+            RuleId("lint.derive-order"),
+            Severity::Warn,
+            format!("derive macros are not in canonical order; expected: {expected_str}"),
+            node.span(),
+        )]
     }
 }
 
-#[test]
-fn ui() {
-    whisker_testing::ui_test(env!("CARGO_PKG_NAME"), "ui");
+#[cfg(test)]
+mod tests {
+    use whisker_testing::{assert_diagnostic, assert_no_diagnostics, execute, parse};
+    use whisker_types::{Language, LintPass, Severity};
+
+    use super::*;
+
+    fn adapt() -> Box<dyn LintPass> {
+        DeriveOrder::into_lint_pass()
+    }
+
+    fn run(source: &str) -> Vec<Diagnostic> {
+        let tree = parse(source, Language::Rust);
+        let mut passes = vec![adapt()];
+        execute(&tree, &mut passes)
+    }
+
+    #[test]
+    fn correct_full_std_order_not_flagged() {
+        let diagnostics = run(
+            "#[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug, Default)]\nstruct Foo;",
+        );
+
+        assert_no_diagnostics(&diagnostics);
+    }
+
+    #[test]
+    fn correct_partial_std_order_not_flagged() {
+        let diagnostics = run("#[derive(Clone, Debug)]\nstruct Foo;");
+
+        assert_no_diagnostics(&diagnostics);
+    }
+
+    #[test]
+    fn correct_std_then_third_party_not_flagged() {
+        let diagnostics = run("#[derive(Clone, Debug, Builder, Getters)]\nstruct Foo;");
+
+        assert_no_diagnostics(&diagnostics);
+    }
+
+    #[test]
+    fn correct_third_party_alphabetical_not_flagged() {
+        let diagnostics = run("#[derive(Clone, Debug, Alpha, Beta, Gamma)]\nstruct Foo;");
+
+        assert_no_diagnostics(&diagnostics);
+    }
+
+    #[test]
+    fn empty_derive_not_flagged() {
+        let diagnostics = run("#[derive()]\nstruct Foo;");
+
+        assert_no_diagnostics(&diagnostics);
+    }
+
+    #[test]
+    fn non_derive_attribute_not_flagged() {
+        let diagnostics = run("#[allow(dead_code)]\nstruct Foo;");
+
+        assert_no_diagnostics(&diagnostics);
+    }
+
+    #[test]
+    fn single_derive_not_flagged() {
+        let diagnostics = run("#[derive(Debug)]\nstruct Foo;");
+
+        assert_no_diagnostics(&diagnostics);
+    }
+
+    #[test]
+    fn third_party_before_std_flagged() {
+        let diagnostics = run("#[derive(Builder, Clone, Debug)]\nstruct Foo;");
+
+        assert_eq!(diagnostics.len(), 1);
+        assert_diagnostic(&diagnostics[0])
+            .has_rule_id("lint.derive-order")
+            .has_severity(Severity::Warn)
+            .message_contains("Clone, Debug, Builder");
+    }
+
+    #[test]
+    fn third_party_out_of_alpha_order_flagged() {
+        let diagnostics = run("#[derive(Clone, Debug, Gamma, Alpha)]\nstruct Foo;");
+
+        assert_eq!(diagnostics.len(), 1);
+        assert_diagnostic(&diagnostics[0])
+            .has_rule_id("lint.derive-order")
+            .has_severity(Severity::Warn)
+            .message_contains("Alpha, Gamma");
+    }
+
+    #[test]
+    fn trait_send() {
+        fn assert_send<T: Send>() {}
+        assert_send::<DeriveOrder>();
+    }
+
+    #[test]
+    fn trait_sync() {
+        fn assert_sync<T: Sync>() {}
+        assert_sync::<DeriveOrder>();
+    }
+
+    #[test]
+    fn trait_unpin() {
+        fn assert_unpin<T: Unpin>() {}
+        assert_unpin::<DeriveOrder>();
+    }
+
+    #[test]
+    fn wrong_std_and_third_party_flagged() {
+        let diagnostics = run("#[derive(Debug, Clone, Beta, Alpha)]\nstruct Foo;");
+
+        assert_eq!(diagnostics.len(), 1);
+        assert_diagnostic(&diagnostics[0])
+            .has_rule_id("lint.derive-order")
+            .has_severity(Severity::Warn)
+            .message_contains("Clone, Debug, Alpha, Beta");
+    }
+
+    #[test]
+    fn wrong_std_order_flagged() {
+        let diagnostics = run("#[derive(Debug, Clone, Default)]\nstruct Foo;");
+
+        assert_eq!(diagnostics.len(), 1);
+        assert_diagnostic(&diagnostics[0])
+            .has_rule_id("lint.derive-order")
+            .has_severity(Severity::Warn)
+            .message_contains("Clone, Debug, Default");
+    }
+
+    #[test]
+    fn wrong_std_order_multiple_flagged() {
+        let diagnostics = run("#[derive(Default, Copy, Clone)]\nstruct Foo;");
+
+        assert_eq!(diagnostics.len(), 1);
+        assert_diagnostic(&diagnostics[0])
+            .has_rule_id("lint.derive-order")
+            .has_severity(Severity::Warn)
+            .message_contains("Copy, Clone, Default");
+    }
 }


### PR DESCRIPTION
Rewrites derive_order from Dylint's LateLintPass to the tree-sitter RustLintPass trait. Implements check_attribute_item, which parses #[derive(...)] text to extract and verify canonical ordering of derive macros per the project's conventions.

This is a syntax-only lint — no decoration provider needed. 15 unit tests covering standard derives, third-party derives, mixed ordering, single derives, and empty derive lists.