### PR TITLE
Let clippy_utils drive the nightly toolchain

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -1,4 +1,35 @@
 {
   $schema: "https://docs.renovatebot.com/renovate-schema.json",
   extends: ["github>aonyx-ai/renovate-config"],
+
+  packageRules: [
+    {
+      // The nightly channel is not ours to choose: it has to be the exact one
+      // clippy_utils was built against, which
+      // `.github/scripts/sync-toolchain.sh` derives from the clippy_utils
+      // version in `Cargo.toml`. Renovate's `rust-toolchain` manager only
+      // knows how to chase the newest nightly, which produces pull requests
+      // that cannot compile.
+      matchManagers: ["rust-toolchain"],
+      enabled: false,
+    },
+    {
+      // Widen clippy_utils updates from lockfile-only to a `Cargo.toml` edit.
+      // The `Sync rust-toolchain` workflow triggers on changes to
+      // `Cargo.toml`, so this is what lets the nightly move together with
+      // clippy_utils in a single pull request.
+      matchManagers: ["cargo"],
+      matchPackageNames: ["clippy_utils"],
+      rangeStrategy: "bump",
+
+      // rustc 1.99 renamed `LintStore::register_late_pass` to
+      // `register_late_lint_pass` and `register_pre_expansion_pass` to
+      // `register_pre_expansion_lint_pass` (rust-lang/rust@cd8d703f).
+      // `dylint_linting` still emits the old names as of 6.0.2, so every lint
+      // in `lints/` fails to compile on nightly-2026-07-09, the nightly that
+      // clippy_utils 0.1.99 requires. Raise this cap once Dylint supports
+      // rustc 1.99.
+      allowedVersions: "<0.1.99",
+    },
+  ],
 }

--- a/.github/scripts/sync-toolchain.sh
+++ b/.github/scripts/sync-toolchain.sh
@@ -1,15 +1,17 @@
 #!/usr/bin/env bash
 #
-# Syncs rust-toolchain.toml to the nightly date required by the clippy_utils
-# version in Cargo.toml. The nightly date is extracted from the clippy_utils
-# crate README on crates.io.
+# Syncs every rust-toolchain.toml to the nightly date required by the
+# clippy_utils version in Cargo.toml. The nightly date is extracted from the
+# clippy_utils crate README on crates.io.
 #
 # Usage: sync-toolchain.sh [--check]
 #
-# With --check, exits 1 if the toolchain is out of sync (useful in CI).
-# Without --check, updates rust-toolchain.toml in place.
+# With --check, exits 1 if any toolchain is out of sync (useful in CI).
+# Without --check, updates the toolchain files in place.
 
 set -euo pipefail
+
+toolchain_files=(rust-toolchain.toml crates/whisker/rust-toolchain.toml)
 
 check_only=false
 if [ "${1:-}" = "--check" ]; then
@@ -34,17 +36,39 @@ if [ -z "$nightly" ]; then
   exit 1
 fi
 
-current=$(sed -n 's/^channel *= *"\(nightly-[0-9-]*\)"/\1/p' rust-toolchain.toml)
+out_of_sync=false
 
-if [ "$current" = "$nightly" ]; then
-  echo "rust-toolchain.toml already up to date ($nightly)"
-  exit 0
-fi
+for file in "${toolchain_files[@]}"; do
+  if [ ! -f "$file" ]; then
+    echo "$file does not exist; update toolchain_files in $0" >&2
+    exit 1
+  fi
 
-if [ "$check_only" = true ]; then
-  echo "rust-toolchain.toml is out of sync: has $current, expected $nightly" >&2
+  current=$(sed -n 's/^channel *= *"\(nightly-[0-9-]*\)"/\1/p' "$file")
+  if [ -z "$current" ]; then
+    echo "No nightly channel found in $file" >&2
+    exit 1
+  fi
+
+  if [ "$current" = "$nightly" ]; then
+    echo "$file already up to date ($nightly)"
+    continue
+  fi
+
+  if [ "$check_only" = true ]; then
+    echo "$file is out of sync: has $current, expected $nightly" >&2
+    out_of_sync=true
+    continue
+  fi
+
+  # BSD sed reads the argument after `-i` as the backup suffix, so an explicit
+  # suffix plus a delete is the only spelling that behaves the same on both
+  # BSD and GNU sed.
+  sed -i.bak -e "s/$current/$nightly/" "$file"
+  rm -f "$file.bak"
+  echo "Updated $file: $current -> $nightly"
+done
+
+if [ "$out_of_sync" = true ]; then
   exit 1
 fi
-
-sed -i'' -e "s/$current/$nightly/" rust-toolchain.toml
-echo "Updated rust-toolchain.toml: $current -> $nightly"

--- a/.github/workflows/sync-toolchain.yml
+++ b/.github/workflows/sync-toolchain.yml
@@ -19,7 +19,7 @@ jobs:
     if: github.event.pull_request.user.login == 'renovate[bot]'
 
     permissions:
-      contents: write # Required to push the updated rust-toolchain.toml
+      contents: write # Required to push the updated toolchain files
 
     steps:
       - name: Checkout code
@@ -33,13 +33,12 @@ jobs:
 
       - name: Commit and push
         run: |
-          if git diff --quiet rust-toolchain.toml; then
+          if git diff --quiet; then
             echo "No changes to commit"
             exit 0
           fi
 
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-          git add rust-toolchain.toml
-          git commit -m "Sync nightly toolchain with clippy_utils"
+          git commit --all -m "Sync nightly toolchain with clippy_utils"
           git push

--- a/justfile
+++ b/justfile
@@ -30,6 +30,10 @@ check-tracey:
 check-dependencies:
     cargo deny check bans licenses sources
 
+# Check that the pinned nightly matches the clippy_utils version
+check-toolchain:
+    .github/scripts/sync-toolchain.sh --check
+
 # Format JSON files
 format-json fix="false": (prettier fix "{json,json5}")
 


### PR DESCRIPTION
Renovate has been opening pull requests that move `rust-toolchain.toml` to the newest nightly, and every one of them has been unmergeable. The nightly is not a free choice here: it has to be the exact one clippy_utils was built against, which is why `sync-toolchain.sh` exists. #103 is a good illustration — it proposed nightly-2026-07-29, which does not build clippy_utils 0.1.99 at all, let alone the version we pin.

So this disables Renovate's `rust-toolchain` manager and makes clippy_utils the single driver. The piece that was missing is that `Cargo.toml` carried a caret range, so Renovate only ever raised lockfile-only updates for clippy_utils, and the `Sync rust-toolchain` workflow — which triggers on changes to `Cargo.toml` — never actually fired. Switching that dependency to `rangeStrategy: "bump"` connects the two, so a clippy_utils update now brings its nightly with it in the same pull request.

While in there, the sync script only ever touched the root `rust-toolchain.toml`; the one under `crates/whisker` was free to drift and nothing would have noticed. It now covers both, and `just check-toolchain` runs `--check` in CI so the invariant is enforced rather than merely intended. That check earns its keep because the workflow pushes with `GITHUB_TOKEN`, and GitHub deliberately does not re-trigger checks on those pushes — without it, the synced commit could land with no CI attached to it. The in-place edit also grew an explicit backup suffix, since `sed -i'' -e` silently leaves `.toml-e` files behind on BSD sed.

Finally, clippy_utils is capped below 0.1.99 for now. Rust 1.99 renamed `LintStore::register_late_pass` to `register_late_lint_pass` (rust-lang/rust@cd8d703f, 2026-06-18) and `dylint_linting` still emits the old name as of 6.0.2 — and on master — so every lint in `lints/` fails with `E0599` on the nightly 0.1.99 requires. I confirmed 0.1.98 with nightly-2026-05-28 builds clean, so the cap leaves room to move; it should come off once Dylint supports 1.99.

Verified locally with plain cargo against the pinned toolchains, plus the sync script exercised by hand for the in-sync, out-of-sync, missing-file, and idempotent-rerun cases. `just` recipes could not run on my machine (flox cannot activate — the nix daemon is not running), so CI is the real check on the rest.