### PR TITLE
Derive Decoration to fix cardinality at the type

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1575,6 +1575,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "whisker-macros"
+version = "0.1.0"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+ "tree-sitter",
+ "tree-sitter-rust",
+ "whisker-types",
+]
+
+[[package]]
 name = "whisker-reporting"
 version = "0.1.0"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,6 +28,10 @@ whisker_testing = { path = "crates/whisker_testing", version = "=0.1.0" }
 anyhow = "1"
 proptest = "1"
 whisker-types = { path = "crates/whisker-types", version = "=0.1.0" }
+proc-macro2 = "1"
+quote = "1"
+syn = { version = "2", features = ["full"] }
+whisker-macros = { path = "crates/whisker-macros", version = "=0.1.0" }
 tree-sitter = "0.26"
 tree-sitter-rust = "0.24"
 whisker-core = { path = "crates/whisker-core", version = "=0.1.0" }

--- a/crates/whisker-macros/Cargo.toml
+++ b/crates/whisker-macros/Cargo.toml
@@ -1,0 +1,22 @@
+[package]
+name = "whisker-macros"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+publish = false
+
+[lib]
+proc-macro = true
+
+[dependencies]
+proc-macro2.workspace = true
+quote.workspace = true
+syn.workspace = true
+
+[dev-dependencies]
+tree-sitter.workspace = true
+tree-sitter-rust.workspace = true
+whisker-types.workspace = true
+
+[lints]
+workspace = true

--- a/crates/whisker-macros/src/decoration.rs
+++ b/crates/whisker-macros/src/decoration.rs
@@ -1,0 +1,167 @@
+use proc_macro2::TokenStream;
+use quote::quote;
+use syn::{DeriveInput, Error, LitStr, Result};
+
+/// How many times a provider may record a decoration on a single node
+#[derive(Copy, Clone, Eq, PartialEq, Debug)]
+enum Cardinality {
+    Many,
+    One,
+}
+
+/// Builds the `Decoration` implementation for a derive input
+///
+/// # Errors
+///
+/// Returns an error if the `decoration` attribute is missing, names an option
+/// other than `cardinality`, is given a cardinality other than `one` or
+/// `many`, or declares a cardinality more than once.
+pub(crate) fn expand(input: &DeriveInput) -> Result<TokenStream> {
+    let cardinality = cardinality(input)?;
+    let name = &input.ident;
+    let (impl_generics, type_generics, where_clause) = input.generics.split_for_impl();
+
+    let (reference, lookup) = match cardinality {
+        Cardinality::Many => (
+            quote!(::std::vec::Vec<&'decoration Self>),
+            quote!(node.decorations_of_type::<Self>()),
+        ),
+        Cardinality::One => (
+            quote!(::core::option::Option<&'decoration Self>),
+            quote!(node.decoration::<Self>()),
+        ),
+    };
+
+    Ok(quote! {
+        #[automatically_derived]
+        impl #impl_generics ::whisker_types::Decoration for #name #type_generics #where_clause {
+            type Ref<'decoration> = #reference;
+
+            fn lookup<'decoration>(
+                node: &::whisker_types::DecoratedNode<'decoration>,
+            ) -> Self::Ref<'decoration> {
+                #lookup
+            }
+        }
+    })
+}
+
+/// Reads the cardinality declared by the type's `decoration` attribute
+fn cardinality(input: &DeriveInput) -> Result<Cardinality> {
+    let mut declared: Option<Cardinality> = None;
+
+    for attr in &input.attrs {
+        if !attr.path().is_ident("decoration") {
+            continue;
+        }
+
+        attr.parse_nested_meta(|meta| {
+            if !meta.path.is_ident("cardinality") {
+                return Err(meta.error("expected `cardinality`"));
+            }
+
+            let value: LitStr = meta.value()?.parse()?;
+            let parsed = match value.value().as_str() {
+                "many" => Cardinality::Many,
+                "one" => Cardinality::One,
+                other => {
+                    return Err(Error::new(
+                        value.span(),
+                        format!("expected `one` or `many`, found `{other}`"),
+                    ));
+                }
+            };
+
+            if declared.replace(parsed).is_some() {
+                return Err(Error::new(value.span(), "cardinality declared twice"));
+            }
+
+            Ok(())
+        })?;
+    }
+
+    declared.ok_or_else(|| {
+        Error::new_spanned(
+            &input.ident,
+            "missing `#[decoration(cardinality = \"one\")]` or \
+             `#[decoration(cardinality = \"many\")]`",
+        )
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn parse(source: &str) -> DeriveInput {
+        syn::parse_str(source).expect("should parse as a derive input")
+    }
+
+    #[test]
+    fn expand_with_generic_type_carries_generics_onto_the_impl() {
+        let input =
+            parse(r#"#[decoration(cardinality = "one")] struct Wrapper<T>(T) where T: Clone;"#);
+
+        let code = expand(&input).expect("should expand").to_string();
+
+        assert!(code.contains("impl < T > :: whisker_types :: Decoration for Wrapper < T >"));
+        assert!(code.contains("where T : Clone"));
+    }
+
+    #[test]
+    fn expand_with_many_cardinality_returns_a_vec() {
+        let input = parse(r#"#[decoration(cardinality = "many")] struct Flag;"#);
+
+        let code = expand(&input).expect("should expand").to_string();
+
+        assert!(code.contains(":: std :: vec :: Vec < & 'decoration Self >"));
+        assert!(code.contains("decorations_of_type :: < Self > ()"));
+    }
+
+    #[test]
+    fn expand_with_one_cardinality_returns_an_option() {
+        let input = parse(r#"#[decoration(cardinality = "one")] struct Flag;"#);
+
+        let code = expand(&input).expect("should expand").to_string();
+
+        assert!(code.contains(":: core :: option :: Option < & 'decoration Self >"));
+        assert!(code.contains("decoration :: < Self > ()"));
+    }
+
+    #[test]
+    fn expand_with_repeated_cardinality_returns_error() {
+        let input =
+            parse(r#"#[decoration(cardinality = "one", cardinality = "many")] struct Flag;"#);
+
+        let error = expand(&input).expect_err("should reject");
+
+        assert!(error.to_string().contains("declared twice"));
+    }
+
+    #[test]
+    fn expand_with_unknown_cardinality_returns_error() {
+        let input = parse(r#"#[decoration(cardinality = "several")] struct Flag;"#);
+
+        let error = expand(&input).expect_err("should reject");
+
+        assert!(error.to_string().contains("expected `one` or `many`"));
+    }
+
+    #[test]
+    fn expand_with_unknown_option_returns_error() {
+        let input = parse(r#"#[decoration(shape = "one")] struct Flag;"#);
+
+        let error = expand(&input).expect_err("should reject");
+
+        assert!(error.to_string().contains("expected `cardinality`"));
+    }
+
+    #[test]
+    fn expand_without_attribute_returns_error() {
+        let input = parse("struct Flag;");
+
+        let error = expand(&input).expect_err("should reject");
+
+        assert!(error.to_string().contains("missing"));
+    }
+}

--- a/crates/whisker-macros/src/lib.rs
+++ b/crates/whisker-macros/src/lib.rs
@@ -1,0 +1,39 @@
+mod decoration;
+
+use proc_macro::TokenStream;
+use syn::{DeriveInput, parse_macro_input};
+
+/// Implements `Decoration` for a type, fixing how it reads back from a node
+///
+/// The cardinality attribute is required and decides the result of
+/// `DecoratedNode::get` for this type: `one` yields `Option<&Self>` for a
+/// decoration a provider records at most once per node, `many` yields
+/// `Vec<&Self>` for one it may record repeatedly. Declaring it on the type
+/// rather than at each call site means a rule cannot read a repeated
+/// decoration as though it were singular.
+///
+/// # Examples
+///
+/// ```
+/// use whisker_macros::Decoration;
+///
+/// #[derive(Decoration)]
+/// #[decoration(cardinality = "one")]
+/// pub struct ResolvedType {
+///     display: String,
+/// }
+///
+/// #[derive(Decoration)]
+/// #[decoration(cardinality = "many")]
+/// pub struct TraitImpl {
+///     name: String,
+/// }
+/// ```
+#[proc_macro_derive(Decoration, attributes(decoration))]
+pub fn derive_decoration(input: TokenStream) -> TokenStream {
+    let input = parse_macro_input!(input as DeriveInput);
+
+    decoration::expand(&input)
+        .unwrap_or_else(syn::Error::into_compile_error)
+        .into()
+}

--- a/crates/whisker-macros/tests/decoration.rs
+++ b/crates/whisker-macros/tests/decoration.rs
@@ -1,0 +1,104 @@
+//! Exercises the derived `Decoration` implementations against a real tree.
+//!
+//! The unit tests in the crate itself check the generated tokens; these check
+//! that the generated code compiles and that a node reads decorations back in
+//! the shape the type declares.
+
+use std::path::PathBuf;
+
+use whisker_macros::Decoration;
+use whisker_types::{DecoratedTree, Decoration};
+
+#[derive(Decoration)]
+#[decoration(cardinality = "one")]
+struct ResolvedType(&'static str);
+
+#[derive(Decoration)]
+#[decoration(cardinality = "many")]
+struct TraitImpl(&'static str);
+
+fn parse(source: &str) -> DecoratedTree {
+    let mut parser = tree_sitter::Parser::new();
+    parser
+        .set_language(&tree_sitter_rust::LANGUAGE.into())
+        .expect("language should be valid");
+    let tree = parser.parse(source, None).expect("should parse");
+
+    DecoratedTree::new(tree, source.to_string(), PathBuf::from("test.rs"))
+}
+
+#[test]
+fn many_cardinality_reads_back_every_instance_in_order() {
+    let mut tree = parse("fn main() {}");
+    let id = tree.root_node().id();
+    tree.decorations_mut().insert(id, TraitImpl("Debug"));
+    tree.decorations_mut().insert(id, TraitImpl("Clone"));
+
+    let found = tree.root_node().get::<TraitImpl>();
+
+    assert_eq!(found.len(), 2);
+    assert_eq!(found[0].0, "Debug");
+    assert_eq!(found[1].0, "Clone");
+}
+
+#[test]
+fn many_cardinality_when_absent_reads_back_empty() {
+    let tree = parse("fn main() {}");
+
+    let found = tree.root_node().get::<TraitImpl>();
+
+    assert!(found.is_empty());
+}
+
+#[test]
+fn one_cardinality_reads_back_a_single_value() {
+    let mut tree = parse("fn main() {}");
+    let id = tree.root_node().id();
+    tree.decorations_mut().insert(id, ResolvedType("u32"));
+
+    let found = tree.root_node().get::<ResolvedType>();
+
+    assert_eq!(found.expect("should be present").0, "u32");
+}
+
+#[test]
+fn one_cardinality_when_absent_reads_back_none() {
+    let tree = parse("fn main() {}");
+
+    let found = tree.root_node().get::<ResolvedType>();
+
+    assert!(found.is_none());
+}
+
+#[test]
+fn decorations_are_keyed_per_node() {
+    let source = "fn main() {}";
+    let mut tree = parse(source);
+    let root_id = tree.root_node().id();
+    tree.decorations_mut().insert(root_id, ResolvedType("root"));
+
+    let child = tree
+        .root_node()
+        .named_child(0)
+        .expect("should have a function item");
+
+    assert_eq!(
+        tree.root_node()
+            .get::<ResolvedType>()
+            .expect("root should be decorated")
+            .0,
+        "root"
+    );
+    assert!(child.get::<ResolvedType>().is_none());
+}
+
+#[test]
+fn lookup_can_be_called_through_the_trait() {
+    let mut tree = parse("fn main() {}");
+    let id = tree.root_node().id();
+    tree.decorations_mut().insert(id, ResolvedType("u32"));
+
+    let found = ResolvedType::lookup(&tree.root_node());
+
+    assert_eq!(found.expect("should be present").0, "u32");
+}

--- a/crates/whisker-types/src/decorated_node.rs
+++ b/crates/whisker-types/src/decorated_node.rs
@@ -2,7 +2,7 @@ use std::any::Any;
 use std::path::Path;
 use std::sync::Arc;
 
-use crate::{DecorationMap, Span};
+use crate::{Decoration, DecorationMap, Span};
 
 /// A tree-sitter node enriched with semantic decorations
 ///
@@ -110,6 +110,20 @@ impl<'a> DecoratedNode<'a> {
     /// Retrieves all decorations of type `T` from this node
     pub fn decorations_of_type<T: Any + Send + Sync>(&self) -> Vec<&'a T> {
         self.decorations.get_all::<T>(self.node.id())
+    }
+
+    /// Reads the decoration `D` from this node
+    ///
+    /// The shape of the result comes from `D` itself, not from this call: a
+    /// decoration declared with cardinality `one` yields [`Option`] and one
+    /// declared `many` yields [`Vec`]. Prefer this over [`decoration`] and
+    /// [`decorations_of_type`], which accept any type and so cannot catch a
+    /// rule reading a repeated decoration as though it were singular.
+    ///
+    /// [`decoration`]: DecoratedNode::decoration
+    /// [`decorations_of_type`]: DecoratedNode::decorations_of_type
+    pub fn get<D: Decoration>(&self) -> D::Ref<'a> {
+        D::lookup(self)
     }
 
     /// Returns all named children of this node as a collected vec

--- a/crates/whisker-types/src/decoration.rs
+++ b/crates/whisker-types/src/decoration.rs
@@ -1,0 +1,137 @@
+use std::any::Any;
+
+use crate::DecoratedNode;
+
+/// A semantic annotation that a provider can attach to syntax nodes
+///
+/// Decorations carry information a syntax tree cannot supply on its own —
+/// resolved types, signatures, trait memberships — which a
+/// [`DecorationProvider`] obtains from a language toolchain and records
+/// against individual nodes.
+///
+/// Implementations fix their own cardinality through [`Ref`]. A decoration a
+/// provider records at most once per node reads back as [`Option`]; one it may
+/// record repeatedly reads back as [`Vec`]. Because that choice travels with
+/// the type rather than the call site, a rule cannot ask for a single value
+/// where the provider records a list, and the mismatch is a compile error
+/// rather than a silently dropped decoration.
+///
+/// Derive this rather than writing it by hand:
+///
+/// ```ignore
+/// #[derive(Decoration)]
+/// #[decoration(cardinality = "one")]
+/// pub struct ResolvedType { /* … */ }
+/// ```
+///
+/// # Examples
+///
+/// ```
+/// use whisker_types::{DecoratedNode, Decoration};
+///
+/// struct Signature(String);
+///
+/// impl Decoration for Signature {
+///     type Ref<'a> = Option<&'a Self>;
+///
+///     fn lookup<'a>(node: &DecoratedNode<'a>) -> Self::Ref<'a> {
+///         node.decoration::<Self>()
+///     }
+/// }
+/// ```
+///
+/// [`DecorationProvider`]: crate::DecorationProvider
+/// [`Ref`]: Decoration::Ref
+pub trait Decoration: Any + Send + Sync + Sized {
+    /// What a lookup of this decoration yields
+    ///
+    /// Use `Option<&'a Self>` for a decoration recorded at most once per node
+    /// and `Vec<&'a Self>` for one recorded any number of times.
+    type Ref<'a>;
+
+    /// Reads this decoration from `node`
+    ///
+    /// Prefer [`DecoratedNode::get`], which calls this.
+    fn lookup<'a>(node: &DecoratedNode<'a>) -> Self::Ref<'a>;
+}
+
+#[cfg(test)]
+mod tests {
+    use std::path::PathBuf;
+
+    use super::*;
+    use crate::DecoratedTree;
+
+    struct Single(u32);
+
+    impl Decoration for Single {
+        type Ref<'a> = Option<&'a Self>;
+
+        fn lookup<'a>(node: &DecoratedNode<'a>) -> Self::Ref<'a> {
+            node.decoration::<Self>()
+        }
+    }
+
+    struct Repeated(u32);
+
+    impl Decoration for Repeated {
+        type Ref<'a> = Vec<&'a Self>;
+
+        fn lookup<'a>(node: &DecoratedNode<'a>) -> Self::Ref<'a> {
+            node.decorations_of_type::<Self>()
+        }
+    }
+
+    fn parse(source: &str) -> DecoratedTree {
+        let mut parser = tree_sitter::Parser::new();
+        parser
+            .set_language(&tree_sitter_rust::LANGUAGE.into())
+            .expect("language should be valid");
+        let tree = parser.parse(source, None).expect("should parse");
+
+        DecoratedTree::new(tree, source.to_string(), PathBuf::from("test.rs"))
+    }
+
+    #[test]
+    fn get_with_many_cardinality_returns_every_instance() {
+        let mut tree = parse("fn main() {}");
+        let id = tree.root_node().id();
+        tree.decorations_mut().insert(id, Repeated(1));
+        tree.decorations_mut().insert(id, Repeated(2));
+
+        let found = tree.root_node().get::<Repeated>();
+
+        assert_eq!(found.len(), 2);
+        assert_eq!(found[0].0, 1);
+        assert_eq!(found[1].0, 2);
+    }
+
+    #[test]
+    fn get_with_many_cardinality_when_absent_returns_empty() {
+        let tree = parse("fn main() {}");
+
+        let found = tree.root_node().get::<Repeated>();
+
+        assert!(found.is_empty());
+    }
+
+    #[test]
+    fn get_with_one_cardinality_returns_the_decoration() {
+        let mut tree = parse("fn main() {}");
+        let id = tree.root_node().id();
+        tree.decorations_mut().insert(id, Single(7));
+
+        let found = tree.root_node().get::<Single>();
+
+        assert_eq!(found.expect("should be present").0, 7);
+    }
+
+    #[test]
+    fn get_with_one_cardinality_when_absent_returns_none() {
+        let tree = parse("fn main() {}");
+
+        let found = tree.root_node().get::<Single>();
+
+        assert!(found.is_none());
+    }
+}

--- a/crates/whisker-types/src/lib.rs
+++ b/crates/whisker-types/src/lib.rs
@@ -1,5 +1,6 @@
 mod decorated_node;
 mod decorated_tree;
+mod decoration;
 mod decoration_map;
 mod decoration_provider;
 mod diagnostic;
@@ -13,6 +14,7 @@ mod suggestion;
 
 pub use decorated_node::DecoratedNode;
 pub use decorated_tree::DecoratedTree;
+pub use decoration::Decoration;
 pub use decoration_map::DecorationMap;
 pub use decoration_provider::DecorationProvider;
 pub use diagnostic::Diagnostic;


### PR DESCRIPTION
Decorations are read through `decoration` and `decorations_of_type` today, and both are generic over any type at all. Nothing connects a decoration to the shape its provider actually records, so a rule can read a repeated decoration as though it were singular and quietly see only the first one, or read a singular one as a list and get a one-element vec. Neither mistake is visible to the compiler, and both fail silently at the point where a lint would otherwise fire.

This moves the choice onto the decoration type itself. A `Decoration` trait carries an associated `Ref` that fixes what a lookup yields, and `DecoratedNode::get` returns whatever the type declares — `Option<&T>` for a decoration recorded at most once per node, `Vec<&T>` for one recorded repeatedly. A rule can no longer ask for the wrong shape because it no longer chooses the shape.

Hand-writing those impls would invite exactly the inconsistency the trait exists to remove, so `#[derive(Decoration)]` generates them from a required cardinality attribute:

```rust
#[derive(Decoration)]
#[decoration(cardinality = "one")]
pub struct ResolvedType { display: String }

#[derive(Decoration)]
#[decoration(cardinality = "many")]
pub struct TraitImpl { name: String }
```

The attribute is required rather than defaulted, so the decision is made explicitly by whoever knows the answer. Omitting it, misspelling the option, giving a cardinality that isn't `one` or `many`, or declaring it twice are each compile errors that name what was expected.

The expansion logic lives in a plain `expand` function rather than in the `#[proc_macro_derive]` entry point, so it is unit-testable inside the crate — seven tests cover both cardinalities, generic types with where-clauses, and each rejection path. Six integration tests then exercise the derived code against a real parsed tree, since token assertions alone cannot show that what is generated compiles or behaves. The doctest on the derive is a real compiled example, not `ignore`d.

This lands as its own crate rather than joining `whisker-codegen`, because Cargo will not allow otherwise: a crate with `proc-macro = true` exports nothing but procedural macros and cannot be depended on as an ordinary library, which is exactly what the visitor generator needs to be so build scripts can call it.

The existing `decoration` and `decorations_of_type` are left in place. Every caller lives on an unmerged branch, so migrating them belongs with those branches; once they move to `get`, the unbounded pair can go.

Verified with clippy under `-D warnings`, `cargo fmt --check`, and the full workspace suite. One note for whoever reviews the CI run: I hit a single transient failure in `anyhow_missing_context`'s UI test during a cold full-workspace build, with `Blocking waiting for file lock on package cache`. It did not reproduce on a second run of this branch or on main, and looks like contention between the new crate compiling and Dylint's UI tests shelling out to cargo, rather than anything this change does.