### PR TITLE
Derive the nightly from the locked clippy_utils

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -14,13 +14,16 @@
       enabled: false,
     },
     {
-      // Widen clippy_utils updates from lockfile-only to a `Cargo.toml` edit.
-      // The `Sync rust-toolchain` workflow triggers on changes to
-      // `Cargo.toml`, so this is what lets the nightly move together with
-      // clippy_utils in a single pull request.
+      // Pin clippy_utils to an exact version. This serves two purposes.
+      // Editing `Cargo.toml` is what triggers the `Sync rust-toolchain`
+      // workflow, so the nightly moves with clippy_utils in one pull request.
+      // Pinning rather than widening the range then keeps the lockfile on the
+      // version we asked for: a caret range of "0.1.98" also admits 0.1.99,
+      // and resolving to it would need a nightly that the manifest, and so
+      // the synced toolchain, knows nothing about.
       matchManagers: ["cargo"],
       matchPackageNames: ["clippy_utils"],
-      rangeStrategy: "bump",
+      rangeStrategy: "pin",
 
       // rustc 1.99 renamed `LintStore::register_late_pass` to
       // `register_late_lint_pass` and `register_pre_expansion_pass` to

--- a/.github/scripts/sync-toolchain.sh
+++ b/.github/scripts/sync-toolchain.sh
@@ -1,8 +1,14 @@
 #!/usr/bin/env bash
 #
 # Syncs every rust-toolchain.toml to the nightly date required by the
-# clippy_utils version in Cargo.toml. The nightly date is extracted from the
+# clippy_utils version in Cargo.lock. The nightly date is extracted from the
 # clippy_utils crate README on crates.io.
+#
+# The version comes from the lockfile rather than Cargo.toml because the
+# manifest holds a range, and the range is not what gets compiled. A caret
+# range of "0.1.98" happily resolves to 0.1.99, which needs a different
+# nightly than the one the manifest implies, so reading the manifest can pin
+# a toolchain that cannot build the code that is actually selected.
 #
 # Usage: sync-toolchain.sh [--check]
 #
@@ -11,17 +17,35 @@
 
 set -euo pipefail
 
-toolchain_files=(rust-toolchain.toml crates/whisker/rust-toolchain.toml)
+# Every toolchain file in the tree, discovered rather than listed, so that
+# adding or removing a crate with its own pinned channel needs no edit here.
+# Read in a loop rather than with `mapfile`, which macOS's bash 3.2 lacks.
+toolchain_files=()
+while IFS= read -r file; do
+  toolchain_files+=("$file")
+done < <(git ls-files '*rust-toolchain.toml')
 
 check_only=false
 if [ "${1:-}" = "--check" ]; then
   check_only=true
 fi
 
-version=$(sed -n 's/^clippy_utils *= *"\([^"]*\)"/\1/p' Cargo.toml)
+version=$(
+  awk '/^name = "clippy_utils"$/ { getline; gsub(/^version = "|"$/, ""); print; exit }' \
+    Cargo.lock
+)
+
+# clippy_utils is what ties this repository to a particular nightly. Once the
+# tree-sitter platform replaces Dylint it stops being a dependency, and with
+# nothing left to pin the toolchain against there is nothing to check.
 if [ -z "$version" ]; then
-  echo "No clippy_utils version found in Cargo.toml" >&2
-  exit 1
+  echo "clippy_utils is not a dependency; nothing to sync"
+  exit 0
+fi
+
+if [ "${#toolchain_files[@]}" -eq 0 ]; then
+  echo "No rust-toolchain.toml found; nothing to sync"
+  exit 0
 fi
 
 nightly=$(
@@ -39,11 +63,6 @@ fi
 out_of_sync=false
 
 for file in "${toolchain_files[@]}"; do
-  if [ ! -f "$file" ]; then
-    echo "$file does not exist; update toolchain_files in $0" >&2
-    exit 1
-  fi
-
   current=$(sed -n 's/^channel *= *"\(nightly-[0-9-]*\)"/\1/p' "$file")
   if [ -z "$current" ]; then
     echo "No nightly channel found in $file" >&2


### PR DESCRIPTION
#168 wired the nightly toolchain to follow clippy_utils, and #171 is the first pull request that mechanism produced. It fails, and the reason is a hole in the config I added.

The sync script read the clippy_utils version out of `Cargo.toml`. A manifest holds a range, and the range is not what gets compiled. Renovate wrote `clippy_utils = "0.1.98"`, which is a caret range that also admits 0.1.99, and cargo resolved the lockfile to 0.1.99. The script then read `0.1.98` and pinned `nightly-2026-05-28`. The build tried to compile clippy_utils 0.1.99 against a 1.98 toolchain and died with nineteen errors inside clippy_utils itself — exactly the mismatch this machinery exists to prevent.

The `allowedVersions: "<0.1.99"` cap did not help, because it constrains the version Renovate proposes as a target, not the version cargo resolves to within the resulting range.

`check-toolchain` passed throughout, which is the part worth dwelling on. It compared the manifest range against the toolchain file, and those two agreed perfectly. Neither of them agreed with the lockfile, and the lockfile is what the compiler reads. The check was validating the wrong half of the invariant.

Two changes, each of which would have caught this on its own. The script now takes the version from `Cargo.lock`, so the toolchain follows the code that is actually selected rather than the code the manifest implies. And Renovate pins clippy_utils to an exact version, so the lockfile cannot drift away from the manifest to begin with. Keeping both means a lockfile touched by something other than Renovate is still covered.

Verified by reproducing #171's exact state locally — manifest at 0.1.98, lockfile at 0.1.99. The old script derived `nightly-2026-05-28` and was satisfied; the new one demands `nightly-2026-07-09`, the nightly 0.1.99 actually needs, and `--check` exits non-zero. On an unmodified tree it stays quiet and both toolchain files report in sync.

Note this does not unblock 0.1.99 itself — Dylint still cannot compile on rustc 1.99, so the cap stays. What it fixes is that the repository now notices when the lockfile and the toolchain disagree, instead of reporting green while the build is guaranteed to fail.