### PR TITLE
Stop hiding failed tool installs in the activation hook

### DIFF
--- a/.flox/env/manifest.toml
+++ b/.flox/env/manifest.toml
@@ -56,10 +56,22 @@ fi
 rustup show > /dev/null 2>&1
 
 # Install dylint tools needed for building and testing lint libraries.
-cargo install --quiet cargo-dylint dylint-link 2> /dev/null
+# Errors are left on stderr: discarding them turns a failed install into a
+# "command not found" several minutes later, which names the tool but not
+# the reason it is missing.
+if ! cargo install --quiet cargo-dylint dylint-link; then
+  echo "warning: failed to install cargo-dylint and dylint-link" >&2
+fi
 
-# Install Tracey for spec coverage tracking.
-cargo binstall --no-confirm --quiet tracey 2> /dev/null
+# Install Tracey for spec coverage tracking. Prefer the prebuilt binary and
+# fall back to building it, so that a transient binstall failure costs time
+# rather than a red build.
+if ! cargo binstall --no-confirm --quiet tracey; then
+  echo "warning: binstall failed for tracey; building it from source" >&2
+  if ! cargo install --quiet tracey; then
+    echo "warning: failed to install tracey" >&2
+  fi
+fi
 '''
 
 [profile]


### PR DESCRIPTION
`check-tracey` failed on #45 with `tracey: not found`, while the same check passed on eight sibling pull requests in the same wave. The cause is not in any of those branches — `.flox/` is byte-identical between them and main.

The activation hook installed its tools like this:

```bash
cargo install --quiet cargo-dylint dylint-link 2> /dev/null
cargo binstall --no-confirm --quiet tracey 2> /dev/null
```

No exit status is checked and stderr is discarded, so a failed install leaves the environment activating cleanly with the tool missing. The failure then appears minutes later as a `command not found` from whichever recipe needed it, naming the tool but not the reason. Anyone debugging it starts from the wrong end.

This lets the errors through and announces each failure, so a bad install is visible where it happens. Tracey additionally falls back to `cargo install` when `cargo binstall` fails, which turns the common case — a transient problem fetching a prebuilt binary — into a slower activation rather than a red build.

Activation still succeeds if an install fails. Making it fatal would convert a missing optional tool into an unusable checkout, including for anyone offline, and the recipes that actually need a tool already fail by themselves. The goal here is a legible failure, not a stricter one.

Verified that the manifest still parses as TOML and that the hook body passes `bash -n`.