### PR TITLE
Allow the licenses the rust-analyzer crates bring in

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -10,7 +10,22 @@ feature-depth = 1
 # List of explicitly allowed licenses
 # See https://spdx.org/licenses/ for list of possible licenses
 # [possible values: any SPDX 3.11 short identifier (+ optional exception)].
-allow = ["Apache-2.0", "Apache-2.0 WITH LLVM-exception", "MIT", "Unicode-3.0"]
+#
+# Zlib, ISC, and CC0-1.0 arrive with the rust-analyzer crates that back the
+# Rust decoration provider, none of them directly: Zlib through `foldhash`,
+# CC0-1.0 through `notify`, and ISC through `inotify` and `inotify-sys` under
+# it. Zlib and ISC are permissive and behave like MIT. CC0-1.0 is a public
+# domain dedication that pointedly does not grant patent rights, which is why
+# it is worth naming here rather than leaving to be discovered later.
+allow = [
+  "Apache-2.0",
+  "Apache-2.0 WITH LLVM-exception",
+  "CC0-1.0",
+  "ISC",
+  "MIT",
+  "Unicode-3.0",
+  "Zlib",
+]
 
 [bans]
 # Lint level for when multiple versions of the same crate are detected


### PR DESCRIPTION
`check-dependencies` fails on #50 through #54 with four rejected licenses. All of them arrive with the rust-analyzer crates behind the Rust decoration provider, and none is a direct dependency:

| crate | license | arrives via |
|---|---|---|
| `foldhash` 0.1.5 | Zlib | `ra_ap_*` hashing |
| `notify` 8.2.0 | CC0-1.0 | `ra_ap_vfs` file watching |
| `inotify` 0.11.4 | ISC | `notify` |
| `inotify-sys` 0.1.8 | ISC | `inotify` |

Zlib and ISC are unremarkable. Both are OSI-approved, both are permissive in the same way MIT is, and both sit comfortably with this project being Apache-2.0 or MIT.

CC0-1.0 deserves to be called out rather than waved through. It is a public domain dedication that expressly declines to grant patent rights, which is precisely why cargo-deny rejects it by default instead of treating it as an ordinary permissive license. Allowing it is a deliberate decision, and since `notify` is transitive, the decision covers the whole language SDK rather than one crate. The comment in `deny.toml` records that reasoning so it does not have to be rediscovered.

The alternative would be keeping rust-analyzer out of the dependency tree, since `notify` is not something the provider selects directly and cannot easily be pinned away from.

`bans` and `sources` already pass; only `licenses` was failing. `deny.toml` is verified to parse; CI runs the real check.