### PR TITLE
Wire the six lints into the whisker CLI

### DIFF
--- a/crates/whisker/Cargo.lock
+++ b/crates/whisker/Cargo.lock
@@ -74,6 +74,14 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "330a5ed07fa54e4702c9d6c4174f74427fc0ef6e214bbd677ae50a5099946470"
 
 [[package]]
+name = "anyhow_missing_context"
+version = "0.1.0"
+dependencies = [
+ "whisker-rust",
+ "whisker-types",
+]
+
+[[package]]
 name = "arrayvec"
 version = "0.7.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -114,6 +122,14 @@ name = "bitflags"
 version = "2.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "843867be96c8daad0d758b57df9392b6d8d271134fce549de6ce169ff98a92af"
+
+[[package]]
+name = "bool_param"
+version = "0.1.0"
+dependencies = [
+ "whisker-rust",
+ "whisker-types",
+]
 
 [[package]]
 name = "borsh"
@@ -440,6 +456,14 @@ dependencies = [
 ]
 
 [[package]]
+name = "derive_order"
+version = "0.1.0"
+dependencies = [
+ "whisker-rust",
+ "whisker-types",
+]
+
+[[package]]
 name = "difflib"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -688,6 +712,14 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
 
 [[package]]
+name = "if_let_with_else"
+version = "0.1.0"
+dependencies = [
+ "whisker-rust",
+ "whisker-types",
+]
+
+[[package]]
 name = "indexmap"
 version = "2.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -879,6 +911,14 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "536bfad37a309d62069485248eeaba1e8d9853aaf951caaeaed0585a95346f08"
 dependencies = [
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "no_matches_macro"
+version = "0.1.0"
+dependencies = [
+ "whisker-rust",
+ "whisker-types",
 ]
 
 [[package]]
@@ -2652,8 +2692,13 @@ name = "whisker"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "anyhow_missing_context",
  "assert_cmd",
+ "bool_param",
  "clawless",
+ "derive_order",
+ "if_let_with_else",
+ "no_matches_macro",
  "predicates",
  "trycmd",
  "walkdir",
@@ -2661,6 +2706,7 @@ dependencies = [
  "whisker-reporting",
  "whisker-rust",
  "whisker-types",
+ "wildcard_match_arm",
 ]
 
 [[package]]
@@ -2712,6 +2758,14 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "tree-sitter",
+]
+
+[[package]]
+name = "wildcard_match_arm"
+version = "0.1.0"
+dependencies = [
+ "whisker-rust",
+ "whisker-types",
 ]
 
 [[package]]

--- a/crates/whisker/Cargo.toml
+++ b/crates/whisker/Cargo.toml
@@ -14,12 +14,18 @@ path = "src/main.rs"
 
 [dependencies]
 anyhow = "1"
+anyhow_missing_context = { path = "../../lints/anyhow_missing_context" }
+bool_param = { path = "../../lints/bool_param" }
 clawless = "0.5.0"
+derive_order = { path = "../../lints/derive_order" }
+if_let_with_else = { path = "../../lints/if_let_with_else" }
+no_matches_macro = { path = "../../lints/no_matches_macro" }
 walkdir = "2"
 whisker-core = { path = "../whisker-core" }
 whisker-reporting = { path = "../whisker-reporting" }
 whisker-rust = { path = "../whisker-rust" }
 whisker-types = { path = "../whisker-types" }
+wildcard_match_arm = { path = "../../lints/wildcard_match_arm" }
 
 [dev-dependencies]
 assert_cmd = "2"

--- a/crates/whisker/src/commands/check.rs
+++ b/crates/whisker/src/commands/check.rs
@@ -5,8 +5,8 @@ use std::sync::Arc;
 use anyhow::Context as _;
 use clawless::prelude::*;
 use whisker_core::Pipeline;
-use whisker_rust::RustDecorationProvider;
-use whisker_types::{DecorationProvider, Language, Severity};
+use whisker_rust::{RustDecorationProvider, RustLintPassAdapter};
+use whisker_types::{DecorationProvider, Language, LintPass, Severity};
 
 /// Run whisker lints against a project
 #[derive(Debug, Args)]
@@ -25,6 +25,26 @@ pub struct CheckArgs {
     /// Additional arguments forwarded to the analysis pipeline
     #[arg(trailing_var_arg = true, allow_hyphen_values = true)]
     args: Vec<String>,
+}
+
+/// Builds the lint passes the CLI runs
+///
+/// Every rule ships as its own crate and is linked in here. A rule that is
+/// not in this list does not run, however complete its own tests are.
+// r[impl cli.check.passes]
+fn create_lint_passes() -> Vec<Box<dyn LintPass>> {
+    vec![
+        Box::new(RustLintPassAdapter::new(
+            anyhow_missing_context::AnyhowMissingContext,
+        )),
+        Box::new(RustLintPassAdapter::new(bool_param::BoolParam)),
+        Box::new(RustLintPassAdapter::new(derive_order::DeriveOrder)),
+        Box::new(RustLintPassAdapter::new(if_let_with_else::IfLetWithElse)),
+        Box::new(RustLintPassAdapter::new(no_matches_macro::NoMatchesMacro)),
+        Box::new(RustLintPassAdapter::new(
+            wildcard_match_arm::WildcardMatchArm,
+        )),
+    ]
 }
 
 // r[impl cli.check]
@@ -66,7 +86,9 @@ pub async fn check(args: CheckArgs, _context: Context) -> CommandResult {
             }
         };
 
-        match pipeline.run_on_source(&source, file, &providers, &mut Vec::new()) {
+        let mut passes = create_lint_passes();
+
+        match pipeline.run_on_source(&source, file, &providers, &mut passes) {
             Ok(diagnostics) => {
                 if !diagnostics.is_empty() {
                     let arc_path: Arc<Path> = file.clone().into();
@@ -85,13 +107,12 @@ pub async fn check(args: CheckArgs, _context: Context) -> CommandResult {
         }
     }
 
-    whisker_reporting::render_to_string(&all_diagnostics, &sources)
-        .and_then(|output| {
-            if !output.is_empty() {
-                eprint!("{output}");
-            }
-            Ok(())
-        })?;
+    whisker_reporting::render_to_string(&all_diagnostics, &sources).and_then(|output| {
+        if !output.is_empty() {
+            eprint!("{output}");
+        }
+        Ok(())
+    })?;
 
     // r[impl cli.diagnostics.exit-code]
     let has_errors = all_diagnostics
@@ -106,11 +127,7 @@ pub async fn check(args: CheckArgs, _context: Context) -> CommandResult {
 }
 
 fn discover_files(path: &PathBuf) -> anyhow::Result<Vec<PathBuf>> {
-    anyhow::ensure!(
-        path.exists(),
-        "{} does not exist",
-        path.display()
-    );
+    anyhow::ensure!(path.exists(), "{} does not exist", path.display());
 
     if path.is_file() {
         return Ok(vec![path.clone()]);


### PR DESCRIPTION
`whisker check` currently runs no lints at all. It discovers files, builds a pipeline, and then calls:

```rust
pipeline.run_on_source(&source, file, &providers, &mut Vec::new())
```

An empty list of passes. Every rule is implemented, tested, and linked into the workspace, and none of them ever executes, so the command reports no diagnostics on any input.

This links the six rule crates into the binary and hands their passes to the pipeline.

Rules are enumerated explicitly in `create_lint_passes` rather than discovered by any registry. That is a deliberate trade: adding a rule means editing this list, and forgetting to means the rule silently does nothing however green its own tests are. The doc comment says so, because that is the failure this file invites.

This recovers the content of #55, which is marked merged but whose changes never reached main — it merged into `domain-design/testing` rather than main, along with #48 and #56. #48's content was recovered in #188; this is the second of the three. It is rebuilt against current main rather than rebased, because the original commit also carried the six lint rewrites and the decoration work, all of which have since landed through their own pull requests. What remains is only the wiring.

One deliberate difference from the original: it loaded the decoration provider with `unwrap_or_else(|_| RustDecorationProvider::empty())`, falling back to no decorations when rust-analyzer could not load the project. Main currently fails with context instead, which is the behaviour #50 landed. I have kept main's, since changing it is a separate decision about whether syntactic rules should still run when semantic analysis is unavailable — worth deciding deliberately rather than inheriting from a conflict resolution.

Verified with `cargo check --all-targets` and `cargo fmt --check` inside `crates/whisker`. Note that neither runs in CI: `crates/whisker` is excluded from the workspace, so the root `cargo clippy --all-targets` and `cargo test --all-features` never compile it. That is the same blind spot that let a non-compiling `RustDecorationProvider` call site survive into #50, and it is worth closing separately.