### PR TITLE
Deny wildcard version requirements

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -31,4 +31,9 @@ allow = [
 # Lint level for when multiple versions of the same crate are detected
 multiple-versions = "warn"
 # Lint level for when a crate version requirement is `*`
-wildcards = "warn"
+wildcards = "deny"
+# The crates in this workspace depend on each other by path without repeating a
+# version, which counts as a wildcard. Every one of them is `publish = false`,
+# and this option exempts path dependencies in private crates while still
+# denying a genuine `*` requirement on anything from a registry.
+allow-wildcard-paths = true


### PR DESCRIPTION
`wildcards` was set to `warn` with the comment "Set to warn because clippy_utils is a git dependency with no version". Dylint is gone, clippy_utils with it, and #193 removed the stale comment — but left the lint level as it was. This finishes that thought.

The check cannot simply be flipped, because cargo-deny counts a path dependency with no `version` as a wildcard, and the six lint crates declare theirs that way:

```toml
whisker-rust = { path = "../../crates/whisker-rust" }
whisker-types = { path = "../../crates/whisker-types" }
```

That is 12 wildcard requirements across six workspace members, so `deny` alone would fail.

`allow-wildcard-paths` is the right instrument. Per the cargo-deny documentation it exempts path and git dependencies in **private** crates, and all path/git dev-dependencies, while continuing to reject them in published crates. Every crate in this workspace is `publish = false` — verified across all 13 — so the exemption covers exactly the intra-workspace links and nothing else. A genuine `*` on a registry crate, which is the case actually worth catching, still fails.

The alternative would be routing the lint crates through `[workspace.dependencies]`, which already pins these with `version = "=0.1.0"`. That is arguably tidier and more consistent with the convention in CLAUDE.md, but it touches six manifests to change nothing about what is built, so it is a separate question from whether the ban should be enforced.

Verified that `deny.toml` parses and that the resulting `[bans]` table is as intended. `cargo deny` itself is not installed locally, so CI runs the real check.