### PR TITLE
Report the files whisker could not look at

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,9 +29,17 @@ always checks a path you name on the command line, even when an ignore rule
 matches that path. Ignore rules still apply to files below a named
 directory.
 
-A file that whisker cannot read or analyze ends the run with an error.
-Pass `--keep-going` to report each failure, continue, and still exit
-non-zero.
+A directory that whisker cannot read, or an ignore file that it cannot
+parse, ends the run: each one changes which files whisker inspects. A file
+that whisker cannot read or analyze ends the run too. Pass `--keep-going`
+to report each failure, continue, and still exit non-zero.
+
+A run that finds nothing to check is an error, not a success. An empty run
+usually means a pattern matched too much, and it would otherwise look like
+a clean project.
+
+Whisker refuses a named file that it has no grammar for. A parse with the
+wrong grammar finds nothing and would report the file clean.
 
 ## License
 

--- a/crates/whisker/src/commands/check.rs
+++ b/crates/whisker/src/commands/check.rs
@@ -15,7 +15,7 @@ use whisker_types::{DecorationProvider, Diagnostic, LintPass};
 use self::check_outcome::CheckOutcome;
 use self::error_recovery::ErrorRecovery;
 use self::failure_threshold::FailureThreshold;
-use crate::discovery::Discovery;
+use crate::discovery::{Discovery, WalkErrorPolicy};
 
 /// Run whisker lints against a project
 #[derive(Debug, Args)]
@@ -77,11 +77,29 @@ pub async fn check(args: CheckArgs, _context: Context) -> CommandResult {
 
     anyhow::ensure!(path.exists(), "{} does not exist", path.display());
 
-    let discovery = Discovery::run(&path).context("failed to discover source files")?;
+    let on_error = match keep_going {
+        true => WalkErrorPolicy::ReportAndContinue,
+        false => WalkErrorPolicy::Fail,
+    };
+
+    let discovery = Discovery::run(&path, on_error).context("failed to discover source files")?;
 
     let mut outcome = CheckOutcome::Success;
 
+    for error in discovery.errors() {
+        eprintln!("error: {error:#}");
+        outcome = CheckOutcome::Failure;
+    }
+
     let files = discovery.files();
+
+    anyhow::ensure!(
+        !files.is_empty(),
+        "whisker analyzed no files under {}: either nothing there is written in a language \
+         whisker has a grammar for, or the ignore files and configured patterns excluded all of \
+         it",
+        path.display()
+    );
 
     let mut pipeline =
         Pipeline::new(&whisker_rust::language()).context("failed to initialize pipeline")?;

--- a/crates/whisker/src/discovery.rs
+++ b/crates/whisker/src/discovery.rs
@@ -1,8 +1,14 @@
 use std::path::{Path, PathBuf};
 
 use anyhow::Context as _;
-use ignore::WalkBuilder;
+use ignore::{DirEntry, WalkBuilder};
 use whisker_types::Language;
+
+mod walk_error_policy;
+mod walk_failure;
+
+pub use walk_error_policy::WalkErrorPolicy;
+use walk_failure::WalkFailure;
 
 /// The source files a `whisker check` run inspects
 ///
@@ -14,45 +20,92 @@ use whisker_types::Language;
 #[derive(Debug)]
 pub struct Discovery {
     files: Vec<PathBuf>,
+    errors: Vec<anyhow::Error>,
 }
 
 impl Discovery {
     /// Discovers the files to lint beneath `path`
     ///
     /// A `path` that names one file comes back as-is. Ignore rules do not
-    /// apply to it, because the user already chose the file.
+    /// apply to it, because the user already chose the file. The grammar
+    /// comes from the extension of `path`, not from the name a symlink
+    /// resolves to. Whisker reports the path the user named.
     ///
     /// # Errors
     ///
-    /// Returns an error if `path` cannot be resolved.
+    /// Returns an error if `path` cannot be resolved, if `path` names a file
+    /// with no extension, if `path` names a file written in a language
+    /// whisker has no grammar for, if a configured
+    /// ignore pattern is not valid gitignore syntax, or - under
+    /// [`WalkErrorPolicy::Fail`] - if a directory entry or an ignore file
+    /// cannot be read.
     ///
     /// # Examples
     ///
     /// ```ignore
-    /// let discovery = Discovery::run(Path::new("."))?;
+    /// let discovery = Discovery::run(Path::new("."), WalkErrorPolicy::Fail)?;
     ///
     /// for file in discovery.files() {
     ///     println!("{}", file.display());
     /// }
     /// ```
-    pub fn run(path: &Path) -> anyhow::Result<Self> {
+    pub fn run(path: &Path, on_error: WalkErrorPolicy) -> anyhow::Result<Self> {
         let root = std::fs::canonicalize(path)
             .with_context(|| format!("failed to resolve {}", path.display()))?;
 
         if root.is_file() {
+            let Some(extension) = path.extension() else {
+                anyhow::bail!(
+                    "whisker cannot check {}: it has no file extension, so there is nothing to \
+                     tell whisker which language to parse it as",
+                    path.display()
+                );
+            };
+
+            let extension = extension.to_string_lossy();
+
+            let Some(_language) = Language::from_extension(&extension) else {
+                anyhow::bail!(
+                    "whisker cannot check {}: there is no grammar for `.{extension}` files",
+                    path.display()
+                );
+            };
+
             return Ok(Self {
                 files: vec![path.to_path_buf()],
+                errors: Vec::new(),
             });
         }
 
         let walk = WalkBuilder::new(&root).require_git(false).build();
 
         let mut files = Vec::new();
+        let mut errors = Vec::new();
 
         for entry in walk {
-            let Ok(entry) = entry else {
-                continue;
+            let entry = match entry {
+                Ok(entry) => entry,
+                Err(error) => {
+                    let context = WalkFailure::classify(&error).context();
+                    let error = anyhow::Error::new(error).context(context);
+
+                    match on_error {
+                        WalkErrorPolicy::Fail => return Err(error),
+                        WalkErrorPolicy::ReportAndContinue => {
+                            errors.push(error);
+                            continue;
+                        }
+                    }
+                }
             };
+
+            match attached_error(&entry) {
+                None => {}
+                Some(error) => match on_error {
+                    WalkErrorPolicy::Fail => return Err(error),
+                    WalkErrorPolicy::ReportAndContinue => errors.push(error),
+                },
+            }
 
             let Some(file_type) = entry.file_type() else {
                 continue;
@@ -73,7 +126,7 @@ impl Discovery {
 
         files.sort();
 
-        Ok(Self { files })
+        Ok(Self { files, errors })
     }
 
     /// Returns the discovered files, in a stable order
@@ -86,6 +139,34 @@ impl Discovery {
     pub fn files(&self) -> &[PathBuf] {
         &self.files
     }
+
+    /// Returns the failures the walk survived
+    ///
+    /// The list is always empty under [`WalkErrorPolicy::Fail`], which
+    /// returns the first failure instead of recording it.
+    ///
+    /// # Examples
+    ///
+    /// ```ignore
+    /// for error in discovery.errors() {
+    ///     eprintln!("error: {error:#}");
+    /// }
+    /// ```
+    pub fn errors(&self) -> &[anyhow::Error] {
+        &self.errors
+    }
+}
+
+/// Returns the failure the walker recorded against `entry`, if there was one
+///
+/// An unparsable ignore file inside the tree does not abandon the walk. The
+/// entry arrives intact with the failure attached, and the file's rules are
+/// silently absent. Discovery treats this like an unreadable directory,
+/// because both change the set of linted files.
+fn attached_error(entry: &DirEntry) -> Option<anyhow::Error> {
+    let error = entry.error()?;
+
+    Some(anyhow::Error::msg(error.to_string()).context("failed to read an ignore file"))
 }
 
 /// Rebases `entry` from the resolved `root` onto the `original` argument
@@ -98,9 +179,29 @@ fn rebase(original: &Path, root: &Path, entry: &Path) -> PathBuf {
 
 #[cfg(test)]
 mod tests {
+    #[cfg(unix)]
+    use std::os::unix::fs::PermissionsExt as _;
+
     use tempfile::TempDir;
 
     use super::*;
+
+    /// A directory whose permissions are restored when this value is dropped
+    ///
+    /// A temporary directory left at mode `000` cannot be removed. This
+    /// guard restores the mode even when a test panics, so [`TempDir`]'s
+    /// cleanup still succeeds.
+    #[cfg(unix)]
+    struct Unreadable<'a> {
+        directory: &'a Path,
+    }
+
+    #[cfg(unix)]
+    impl Drop for Unreadable<'_> {
+        fn drop(&mut self) {
+            make_readable(self.directory);
+        }
+    }
 
     /// Panics unless `directory` reads back in unsorted order
     ///
@@ -146,6 +247,40 @@ mod tests {
                     .replace('\\', "/")
             })
             .collect()
+    }
+
+    /// Restores default permissions so the temporary directory can be removed
+    #[cfg(unix)]
+    fn make_readable(directory: &Path) {
+        std::fs::set_permissions(directory, std::fs::Permissions::from_mode(0o755))
+            .expect("permissions should be restored");
+    }
+
+    /// Makes `directory` impossible to read until the returned value is dropped
+    ///
+    /// A privileged process, root in a CI container for example, can still
+    /// read a mode `000` directory. The walk-error tests would then assert
+    /// nothing, so this panics instead of passing silently.
+    ///
+    /// # Panics
+    ///
+    /// Panics if `directory` cannot have its mode cleared, or if it is still
+    /// readable afterwards.
+    #[cfg(unix)]
+    fn make_unreadable(directory: &Path) -> Unreadable<'_> {
+        std::fs::set_permissions(directory, std::fs::Permissions::from_mode(0o000))
+            .expect("permissions should be set");
+
+        let unreadable = Unreadable { directory };
+
+        assert!(
+            std::fs::read_dir(directory).is_err(),
+            "{} is still readable at mode 000, so the walk-error tests cannot exercise anything; \
+             run them without privileges that bypass file permissions",
+            directory.display()
+        );
+
+        unreadable
     }
 
     /// Creates a temporary directory that holds the given relative files
@@ -198,7 +333,8 @@ mod tests {
         ]);
         assert_stored_out_of_order(directory.path());
 
-        let discovery = Discovery::run(directory.path()).expect("discovery should succeed");
+        let discovery = Discovery::run(directory.path(), WalkErrorPolicy::Fail)
+            .expect("discovery should succeed");
 
         assert_eq!(
             discovered(&discovery, directory.path()),
@@ -221,7 +357,8 @@ mod tests {
         std::fs::write(directory.path().join(".ignore"), "generated/\n")
             .expect("ignore file should be written");
 
-        let discovery = Discovery::run(directory.path()).expect("discovery should succeed");
+        let discovery = Discovery::run(directory.path(), WalkErrorPolicy::Fail)
+            .expect("discovery should succeed");
 
         assert_eq!(discovered(&discovery, directory.path()), ["src/main.rs"]);
     }
@@ -236,9 +373,46 @@ mod tests {
             .expect("gitignore should be written");
         let target = directory.path().join("examples");
 
-        let discovery = Discovery::run(&target).expect("discovery should succeed");
+        let discovery =
+            Discovery::run(&target, WalkErrorPolicy::Fail).expect("discovery should succeed");
 
         assert_eq!(discovered(&discovery, &target), ["demo.rs"]);
+    }
+
+    #[test]
+    fn run_with_explicit_extensionless_file_target_returns_error() {
+        let directory = tree(&["LICENSE"]);
+        let target = directory.path().join("LICENSE");
+
+        let error =
+            Discovery::run(&target, WalkErrorPolicy::Fail).expect_err("discovery should fail");
+
+        assert!(
+            format!("{error:#}").contains("no file extension"),
+            "error should explain that the language cannot be told: {error:#}"
+        );
+    }
+
+    /// Pins that a resolved `.rs` target does not rescue an extensionless name
+    ///
+    /// Whisker canonicalizes the path first, and canonicalization resolves
+    /// the symlink. The resolved name must not pick the grammar, because the
+    /// user named `LICENSE`.
+    #[cfg(unix)]
+    #[test]
+    fn run_with_explicit_extensionless_symlink_to_a_rust_file_returns_error() {
+        let directory = tree(&["src/main.rs"]);
+        let link = directory.path().join("LICENSE");
+        std::os::unix::fs::symlink(directory.path().join("src").join("main.rs"), &link)
+            .expect("symlink should be created");
+
+        let error =
+            Discovery::run(&link, WalkErrorPolicy::Fail).expect_err("discovery should fail");
+
+        assert!(
+            format!("{error:#}").contains("no file extension"),
+            "error should explain that the language cannot be told: {error:#}"
+        );
     }
 
     /// A file the user names skips the walk, so no ignore rule reaches it
@@ -249,12 +423,45 @@ mod tests {
             .expect("gitignore should be written");
         let target = directory.path().join("generated").join("schema.rs");
 
-        let discovery = Discovery::run(&target).expect("discovery should succeed");
+        let discovery =
+            Discovery::run(&target, WalkErrorPolicy::Fail).expect("discovery should succeed");
 
         assert_eq!(
             discovered(&discovery, directory.path()),
             ["generated/schema.rs"]
         );
+    }
+
+    #[test]
+    fn run_with_explicit_non_rust_file_target_returns_error() {
+        let directory = tree(&["Cargo.toml"]);
+        let target = directory.path().join("Cargo.toml");
+
+        let error =
+            Discovery::run(&target, WalkErrorPolicy::Fail).expect_err("discovery should fail");
+
+        assert!(
+            format!("{error:#}").contains("no grammar for `.toml` files"),
+            "error should name the extension whisker cannot parse: {error:#}"
+        );
+    }
+
+    /// Pins that a resolved extensionless target does not reject a `.rs` name
+    ///
+    /// The user named `link.rs`, so `.rs` picks the grammar. Whisker reports
+    /// the path the user named, not the resolved one.
+    #[cfg(unix)]
+    #[test]
+    fn run_with_explicit_rust_symlink_to_an_extensionless_file_returns_the_link() {
+        let directory = tree(&["data"]);
+        let link = directory.path().join("link.rs");
+        std::os::unix::fs::symlink(directory.path().join("data"), &link)
+            .expect("symlink should be created");
+
+        let discovery =
+            Discovery::run(&link, WalkErrorPolicy::Fail).expect("discovery should succeed");
+
+        assert_eq!(discovery.files(), vec![link]);
     }
 
     /// The walker reads `.git/info/exclude` only after it recognizes the
@@ -270,7 +477,8 @@ mod tests {
         )
         .expect("exclude file should be written");
 
-        let discovery = Discovery::run(directory.path()).expect("discovery should succeed");
+        let discovery = Discovery::run(directory.path(), WalkErrorPolicy::Fail)
+            .expect("discovery should succeed");
 
         assert_eq!(discovered(&discovery, directory.path()), ["src/main.rs"]);
     }
@@ -281,7 +489,8 @@ mod tests {
         std::fs::write(directory.path().join(".gitignore"), "generated/\n")
             .expect("gitignore should be written");
 
-        let discovery = Discovery::run(directory.path()).expect("discovery should succeed");
+        let discovery = Discovery::run(directory.path(), WalkErrorPolicy::Fail)
+            .expect("discovery should succeed");
 
         assert_eq!(discovered(&discovery, directory.path()), ["src/main.rs"]);
     }
@@ -290,7 +499,8 @@ mod tests {
     fn run_with_hidden_directory_excludes_it() {
         let directory = tree(&["src/main.rs", ".cache/build.rs"]);
 
-        let discovery = Discovery::run(directory.path()).expect("discovery should succeed");
+        let discovery = Discovery::run(directory.path(), WalkErrorPolicy::Fail)
+            .expect("discovery should succeed");
 
         assert_eq!(discovered(&discovery, directory.path()), ["src/main.rs"]);
     }
@@ -299,7 +509,8 @@ mod tests {
     fn run_with_non_rust_files_excludes_them() {
         let directory = tree(&["src/main.rs", "README.md", "Cargo.toml", "LICENSE"]);
 
-        let discovery = Discovery::run(directory.path()).expect("discovery should succeed");
+        let discovery = Discovery::run(directory.path(), WalkErrorPolicy::Fail)
+            .expect("discovery should succeed");
 
         assert_eq!(discovered(&discovery, directory.path()), ["src/main.rs"]);
     }
@@ -308,8 +519,8 @@ mod tests {
     fn run_with_nonexistent_path_returns_error() {
         let directory = tempfile::tempdir().expect("temporary directory should be created");
 
-        let error =
-            Discovery::run(&directory.path().join("missing")).expect_err("discovery should fail");
+        let error = Discovery::run(&directory.path().join("missing"), WalkErrorPolicy::Fail)
+            .expect_err("discovery should fail");
 
         assert!(
             format!("{error:#}").contains("failed to resolve"),
@@ -325,9 +536,136 @@ mod tests {
         std::os::unix::fs::symlink(directory.path().join("src"), &link)
             .expect("symlink should be created");
 
-        let discovery = Discovery::run(&link).expect("discovery should succeed");
+        let discovery =
+            Discovery::run(&link, WalkErrorPolicy::Fail).expect("discovery should succeed");
 
         assert_eq!(discovery.files(), vec![link.join("main.rs")]);
+    }
+
+    /// Pins that an ignore file is named as one wherever the walker found it
+    ///
+    /// An ignore file above the root fails before the walk has an entry, so
+    /// it takes the walker's generic error path. The error must still name
+    /// an ignore file, not a directory entry.
+    #[test]
+    fn run_with_unparsable_ignore_file_above_the_root_returns_error() {
+        let directory = tree(&["proj/src/main.rs"]);
+        std::fs::write(directory.path().join(".gitignore"), "{a,b\n")
+            .expect("gitignore should be written");
+        let target = directory.path().join("proj");
+
+        let error =
+            Discovery::run(&target, WalkErrorPolicy::Fail).expect_err("discovery should fail");
+
+        let error = format!("{error:#}");
+        assert!(
+            error.contains("failed to read an ignore file"),
+            "error should describe the unparsable ignore file: {error}"
+        );
+        assert!(
+            !error.contains("failed to read a directory entry"),
+            "error should not blame the directory walk: {error}"
+        );
+    }
+
+    #[test]
+    fn run_with_unparsable_ignore_file_and_fail_policy_returns_error() {
+        let directory = tree(&["src/main.rs", "generated/schema.rs"]);
+        std::fs::write(
+            directory.path().join("generated").join(".gitignore"),
+            "{a,b\n",
+        )
+        .expect("gitignore should be written");
+
+        let error = Discovery::run(directory.path(), WalkErrorPolicy::Fail)
+            .expect_err("discovery should fail");
+
+        let error = format!("{error:#}");
+        assert!(
+            error.contains("failed to read an ignore file"),
+            "error should describe the unparsable ignore file: {error}"
+        );
+        assert!(
+            error.contains(".gitignore"),
+            "error should name the file the walker could not parse: {error}"
+        );
+        assert!(
+            error.contains("{a,b"),
+            "error should quote the glob the walker could not parse: {error}"
+        );
+    }
+
+    #[test]
+    fn run_with_unparsable_ignore_file_and_keep_going_records_the_error() {
+        let directory = tree(&["src/main.rs", "generated/schema.rs"]);
+        std::fs::write(
+            directory.path().join("generated").join(".gitignore"),
+            "{a,b\n",
+        )
+        .expect("gitignore should be written");
+
+        let discovery = Discovery::run(directory.path(), WalkErrorPolicy::ReportAndContinue)
+            .expect("discovery should succeed");
+
+        assert_eq!(
+            discovered(&discovery, directory.path()),
+            ["generated/schema.rs", "src/main.rs"]
+        );
+        assert_eq!(discovery.errors().len(), 1);
+    }
+
+    #[test]
+    fn run_with_unparsable_root_ignore_file_returns_error() {
+        let directory = tree(&["src/main.rs"]);
+        std::fs::write(directory.path().join(".gitignore"), "{a,b\n")
+            .expect("gitignore should be written");
+
+        let error = Discovery::run(directory.path(), WalkErrorPolicy::Fail)
+            .expect_err("discovery should fail");
+
+        assert!(
+            format!("{error:#}").contains("failed to read an ignore file"),
+            "error should describe the unparsable ignore file: {error:#}"
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn run_with_unreadable_directory_and_fail_policy_returns_error() {
+        let directory = tree(&["src/main.rs", "locked/inner.rs"]);
+        let locked = directory.path().join("locked");
+        let _unreadable = make_unreadable(&locked);
+
+        let error = Discovery::run(directory.path(), WalkErrorPolicy::Fail)
+            .expect_err("discovery should fail");
+
+        let error = format!("{error:#}");
+        assert!(
+            error.contains("failed to read a directory entry"),
+            "error should describe the unreadable entry: {error}"
+        );
+        assert!(
+            error.contains("locked"),
+            "error should name the directory the walker could not read: {error}"
+        );
+        assert!(
+            error.contains("Permission denied"),
+            "error should give the reason the walker reported: {error}"
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn run_with_unreadable_directory_and_keep_going_records_the_error() {
+        let directory = tree(&["src/main.rs", "locked/inner.rs"]);
+        let locked = directory.path().join("locked");
+        let _unreadable = make_unreadable(&locked);
+
+        let discovery = Discovery::run(directory.path(), WalkErrorPolicy::ReportAndContinue)
+            .expect("discovery should succeed");
+
+        assert_eq!(discovered(&discovery, directory.path()), ["src/main.rs"]);
+        assert_eq!(discovery.errors().len(), 1);
     }
 
     #[test]

--- a/crates/whisker/src/discovery/walk_error_policy.rs
+++ b/crates/whisker/src/discovery/walk_error_policy.rs
@@ -1,0 +1,53 @@
+/// How file discovery reacts to a failure the walk survives
+///
+/// An unreadable directory silently narrows the scan, and an unparsable
+/// ignore file silently reshapes it. The policy decides whether the first
+/// failure ends the walk, or whether the walk records it and continues.
+///
+/// # Examples
+///
+/// ```ignore
+/// let policy = match keep_going {
+///     true => WalkErrorPolicy::ReportAndContinue,
+///     false => WalkErrorPolicy::Fail,
+/// };
+/// ```
+#[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug, Default)]
+pub enum WalkErrorPolicy {
+    /// Abandons the walk and returns the first failure
+    #[default]
+    Fail,
+
+    /// Records the failure and keeps walking
+    ReportAndContinue,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn default_is_fail() {
+        let policy = WalkErrorPolicy::default();
+
+        assert_eq!(policy, WalkErrorPolicy::Fail);
+    }
+
+    #[test]
+    fn trait_send() {
+        fn assert_send<T: Send>() {}
+        assert_send::<WalkErrorPolicy>();
+    }
+
+    #[test]
+    fn trait_sync() {
+        fn assert_sync<T: Sync>() {}
+        assert_sync::<WalkErrorPolicy>();
+    }
+
+    #[test]
+    fn trait_unpin() {
+        fn assert_unpin<T: Unpin>() {}
+        assert_unpin::<WalkErrorPolicy>();
+    }
+}

--- a/crates/whisker/src/discovery/walk_failure.rs
+++ b/crates/whisker/src/discovery/walk_failure.rs
@@ -1,0 +1,195 @@
+use ignore::Error;
+
+/// What a step of the walk was unable to read
+///
+/// The `ignore` crate reports an unparsable ignore file in two ways. A file
+/// inside the walk root arrives attached to its directory entry; a file
+/// above the root arrives as a plain walk failure. This type classifies a
+/// plain walk failure, where the error alone must say what failed.
+#[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug)]
+pub enum WalkFailure {
+    /// An entry of the tree could not be read
+    DirectoryEntry,
+
+    /// An ignore file could not be understood
+    IgnoreFile,
+}
+
+impl WalkFailure {
+    /// Returns the kind of failure `error` describes
+    ///
+    /// Glob errors and line-numbered errors only come from parsing an ignore
+    /// file. Everything else, I/O included, counts as a directory-entry
+    /// failure: the walker cannot tell an unreadable directory from an
+    /// unreadable ignore file inside it.
+    pub fn classify(error: &Error) -> Self {
+        match error {
+            Error::Glob { glob: _, err: _ } | Error::WithLineNumber { line: _, err: _ } => {
+                Self::IgnoreFile
+            }
+            Error::WithPath { path: _, err } | Error::WithDepth { depth: _, err } => {
+                Self::classify(err)
+            }
+            Error::Partial(errors) => {
+                let has_ignore_file = errors
+                    .iter()
+                    .any(|error| Self::classify(error) == Self::IgnoreFile);
+
+                match has_ignore_file {
+                    true => Self::IgnoreFile,
+                    false => Self::DirectoryEntry,
+                }
+            }
+            Error::Loop {
+                ancestor: _,
+                child: _,
+            }
+            | Error::Io(_)
+            | Error::UnrecognizedFileType(_)
+            | Error::InvalidDefinition => Self::DirectoryEntry,
+        }
+    }
+
+    /// Returns the context the caller reports this failure under
+    ///
+    /// The caller attaches this string to the walker's own error. That error
+    /// stays the cause, so the path and reason it carries reach the user.
+    pub fn context(self) -> &'static str {
+        match self {
+            Self::DirectoryEntry => "failed to read a directory entry",
+            Self::IgnoreFile => "failed to read an ignore file",
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::io;
+    use std::path::PathBuf;
+
+    use super::*;
+
+    /// Returns a glob failure of the shape an unparsable ignore file produces
+    fn glob_error() -> Error {
+        Error::Glob {
+            glob: Some("{a,b".to_owned()),
+            err: "unclosed alternate group".to_owned(),
+        }
+    }
+
+    #[test]
+    fn classify_with_a_glob_error_returns_ignore_file() {
+        let error = glob_error();
+
+        let failure = WalkFailure::classify(&error);
+
+        assert_eq!(failure, WalkFailure::IgnoreFile);
+    }
+
+    #[test]
+    fn classify_with_a_line_numbered_error_returns_ignore_file() {
+        let error = Error::WithLineNumber {
+            line: 1,
+            err: Box::new(glob_error()),
+        };
+
+        let failure = WalkFailure::classify(&error);
+
+        assert_eq!(failure, WalkFailure::IgnoreFile);
+    }
+
+    #[test]
+    fn classify_with_a_loop_error_returns_directory_entry() {
+        let error = Error::Loop {
+            ancestor: PathBuf::from("/project"),
+            child: PathBuf::from("/project/link"),
+        };
+
+        let failure = WalkFailure::classify(&error);
+
+        assert_eq!(failure, WalkFailure::DirectoryEntry);
+    }
+
+    #[test]
+    fn classify_with_a_nested_glob_error_returns_ignore_file() {
+        let error = Error::WithPath {
+            path: PathBuf::from("/project/.gitignore"),
+            err: Box::new(Error::WithLineNumber {
+                line: 1,
+                err: Box::new(glob_error()),
+            }),
+        };
+
+        let failure = WalkFailure::classify(&error);
+
+        assert_eq!(failure, WalkFailure::IgnoreFile);
+    }
+
+    #[test]
+    fn classify_with_a_nested_io_error_returns_directory_entry() {
+        let error = Error::WithDepth {
+            depth: 2,
+            err: Box::new(Error::WithPath {
+                path: PathBuf::from("/project/locked"),
+                err: Box::new(Error::Io(io::Error::from(io::ErrorKind::PermissionDenied))),
+            }),
+        };
+
+        let failure = WalkFailure::classify(&error);
+
+        assert_eq!(failure, WalkFailure::DirectoryEntry);
+    }
+
+    #[test]
+    fn classify_with_a_partial_error_holding_a_glob_error_returns_ignore_file() {
+        let error = Error::Partial(vec![
+            Error::Io(io::Error::from(io::ErrorKind::NotFound)),
+            glob_error(),
+        ]);
+
+        let failure = WalkFailure::classify(&error);
+
+        assert_eq!(failure, WalkFailure::IgnoreFile);
+    }
+
+    #[test]
+    fn classify_with_a_partial_error_holding_no_glob_error_returns_directory_entry() {
+        let error = Error::Partial(vec![Error::Io(io::Error::from(io::ErrorKind::NotFound))]);
+
+        let failure = WalkFailure::classify(&error);
+
+        assert_eq!(failure, WalkFailure::DirectoryEntry);
+    }
+
+    #[test]
+    fn context_with_directory_entry_names_the_entry() {
+        let context = WalkFailure::DirectoryEntry.context();
+
+        assert_eq!(context, "failed to read a directory entry");
+    }
+
+    #[test]
+    fn context_with_ignore_file_names_the_ignore_file() {
+        let context = WalkFailure::IgnoreFile.context();
+
+        assert_eq!(context, "failed to read an ignore file");
+    }
+
+    #[test]
+    fn trait_send() {
+        fn assert_send<T: Send>() {}
+        assert_send::<WalkFailure>();
+    }
+
+    #[test]
+    fn trait_sync() {
+        fn assert_sync<T: Sync>() {}
+        assert_sync::<WalkFailure>();
+    }
+
+    #[test]
+    fn trait_unpin() {
+        fn assert_unpin<T: Unpin>() {}
+        assert_unpin::<WalkFailure>();
+    }
+}

--- a/crates/whisker/tests/check.rs
+++ b/crates/whisker/tests/check.rs
@@ -4,8 +4,21 @@ use assert_cmd::prelude::*;
 use predicates::prelude::*;
 use tempfile::TempDir;
 
+#[cfg(unix)]
+#[path = "support/unreadable.rs"]
+mod unreadable;
+
+#[cfg(unix)]
+use unreadable::make_unreadable;
+
 /// Source that trips none of the lints the CLI runs
 const CLEAN_SOURCE: &str = "pub fn answer() -> u32 {\n    42\n}\n";
+
+/// An ignore file the walker cannot parse
+///
+/// An unclosed alternate group fails the walk on every platform. The other
+/// trigger, an unreadable directory, does not exist on Windows.
+const UNPARSABLE_IGNORE_FILE: &str = "{a,b\n";
 
 /// A manifest for a standalone package with no dependencies
 const MANIFEST: &str = "[package]\nname = \"target\"\nversion = \"0.1.0\"\nedition = \"2024\"\n";
@@ -59,6 +72,27 @@ fn check_current_directory_succeeds() {
 }
 
 #[test]
+fn check_directory_without_sources_fails() {
+    let directory = tempfile::tempdir().expect("temporary directory should be created");
+
+    whisker()
+        .arg("check")
+        .arg(directory.path())
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains("analyzed no files"));
+}
+
+#[test]
+fn check_non_rust_file_fails() {
+    whisker()
+        .args(["check", "Cargo.toml"])
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains("no grammar for `.toml` files"));
+}
+
+#[test]
 fn check_nonexistent_path_fails() {
     whisker()
         .args(["check", "does/not/exist"])
@@ -77,6 +111,132 @@ fn check_package_directory_succeeds() {
         .assert()
         .success()
         .stderr(predicate::str::is_empty());
+}
+
+#[test]
+fn check_package_whose_sources_a_gitignore_excludes_fails() {
+    let package = package(CLEAN_SOURCE);
+    std::fs::write(package.path().join(".gitignore"), "src/\n")
+        .expect("gitignore should be written");
+
+    whisker()
+        .arg("check")
+        .arg(package.path())
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains("analyzed no files"));
+}
+
+/// Pins the exclusion source that lives entirely outside the project
+///
+/// The test points `GIT_CONFIG_GLOBAL` at a temporary config, so it neither
+/// reads nor disturbs the developer's own settings.
+#[test]
+fn check_package_whose_sources_the_global_gitignore_excludes_fails() {
+    let package = package(CLEAN_SOURCE);
+    let git = tempfile::tempdir().expect("temporary directory should be created");
+    let excludes = git.path().join("ignore");
+    std::fs::write(&excludes, "src/\n").expect("global gitignore should be written");
+    let config = git.path().join("config");
+    std::fs::write(
+        &config,
+        format!("[core]\n\texcludesfile = {}\n", excludes.display()),
+    )
+    .expect("git configuration should be written");
+
+    whisker()
+        .env("GIT_CONFIG_GLOBAL", &config)
+        .arg("check")
+        .arg(package.path())
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains("analyzed no files"));
+}
+
+/// Pins that `--keep-going` survives a walk error and still fails the run
+///
+/// The discovery unit tests pin what each policy does, not which one the
+/// CLI chooses, so only this test covers that wiring.
+#[test]
+fn check_package_with_an_unparsable_ignore_file_and_keep_going_reports_it_and_fails() {
+    let package = package(CLEAN_SOURCE);
+    std::fs::write(
+        package.path().join("src").join(".gitignore"),
+        UNPARSABLE_IGNORE_FILE,
+    )
+    .expect("gitignore should be written");
+
+    whisker()
+        .args(["check", "--keep-going"])
+        .arg(package.path())
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains(
+            "error: failed to read an ignore file",
+        ))
+        .stderr(predicate::str::contains("error parsing glob '{a,b'"))
+        .stderr(predicate::str::contains("failed to discover source files").not());
+}
+
+/// Pins that a walk error ends the run when `--keep-going` is not given
+///
+/// Both policies exit non-zero, so this also asserts the discovery context,
+/// which the `--keep-going` path never prints.
+#[test]
+fn check_package_with_an_unparsable_ignore_file_fails() {
+    let package = package(CLEAN_SOURCE);
+    std::fs::write(
+        package.path().join("src").join(".gitignore"),
+        UNPARSABLE_IGNORE_FILE,
+    )
+    .expect("gitignore should be written");
+
+    whisker()
+        .arg("check")
+        .arg(package.path())
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains("failed to discover source files"))
+        .stderr(predicate::str::contains("failed to read an ignore file"))
+        .stderr(predicate::str::contains("error parsing glob '{a,b'"));
+}
+
+#[cfg(unix)]
+#[test]
+fn check_package_with_an_unreadable_directory_and_keep_going_reports_it_and_fails() {
+    let package = package(CLEAN_SOURCE);
+    let locked = package.path().join("src").join("locked");
+    std::fs::create_dir(&locked).expect("directory should be created");
+    std::fs::write(locked.join("inner.rs"), CLEAN_SOURCE).expect("source should be written");
+    let _unreadable = make_unreadable(&locked);
+
+    whisker()
+        .args(["check", "--keep-going"])
+        .arg(package.path())
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains(
+            "error: failed to read a directory entry",
+        ))
+        .stderr(predicate::str::contains("failed to discover source files").not());
+}
+
+#[cfg(unix)]
+#[test]
+fn check_package_with_an_unreadable_directory_fails() {
+    let package = package(CLEAN_SOURCE);
+    let locked = package.path().join("src").join("locked");
+    std::fs::create_dir(&locked).expect("directory should be created");
+    std::fs::write(locked.join("inner.rs"), CLEAN_SOURCE).expect("source should be written");
+    let _unreadable = make_unreadable(&locked);
+
+    whisker()
+        .arg("check")
+        .arg(package.path())
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains("failed to discover source files"))
+        .stderr(predicate::str::contains("failed to read a directory entry"));
 }
 
 #[test]

--- a/crates/whisker/tests/support/unreadable.rs
+++ b/crates/whisker/tests/support/unreadable.rs
@@ -1,0 +1,49 @@
+use std::os::unix::fs::PermissionsExt as _;
+use std::path::Path;
+
+/// A guard that restores a directory's permissions on drop
+///
+/// A failed test would otherwise leave a mode `000` directory behind, which
+/// `TempDir` cannot remove. The unit tests in `src/discovery.rs` carry the
+/// same guard, because an integration test cannot reach into the binary it
+/// drives.
+pub struct Unreadable<'a> {
+    directory: &'a Path,
+}
+
+impl Drop for Unreadable<'_> {
+    fn drop(&mut self) {
+        make_readable(self.directory);
+    }
+}
+
+/// Restores default permissions so `TempDir` can remove the directory
+fn make_readable(directory: &Path) {
+    std::fs::set_permissions(directory, std::fs::Permissions::from_mode(0o755))
+        .expect("permissions should be restored");
+}
+
+/// Makes `directory` unreadable until the returned guard is dropped
+///
+/// Root, common in CI containers, can read a mode `000` directory anyway.
+/// The CLI tests would then exercise nothing, so this fails loudly.
+///
+/// # Panics
+///
+/// Panics if the mode cannot be cleared, or if `directory` is still readable
+/// afterwards.
+pub fn make_unreadable(directory: &Path) -> Unreadable<'_> {
+    std::fs::set_permissions(directory, std::fs::Permissions::from_mode(0o000))
+        .expect("permissions should be set");
+
+    let unreadable = Unreadable { directory };
+
+    assert!(
+        std::fs::read_dir(directory).is_err(),
+        "{} is still readable at mode 000, so the walk-error tests cannot exercise anything; run \
+         them without privileges that bypass file permissions",
+        directory.display()
+    );
+
+    unreadable
+}


### PR DESCRIPTION
Three ways of finding nothing were indistinguishable from finding nothing
wrong. A directory whisker could not read was dropped by the walk, so it
vanished from the run. A run that discovered no files at all printed nothing
and exited 0, byte-identical to a clean run, which matters more now that
ignore files can legitimately empty the set. And a file named explicitly was
handed to the Rust parser whatever its extension, so `whisker check Cargo.toml`
parsed TOML as Rust, found nothing, and pronounced it clean.

Walk failures now go through a policy the caller chooses, matching
`--keep-going`: report and carry on, or stop at the first one. Each failure is
classified so the message says what could not be read instead of repeating the
walker's own wording, because "IO error" on its own leaves the user nowhere to
go. Discovering zero files is an error naming both causes, and an explicit
target whose extension has no grammar is refused.

The unreadable-directory tests work through a guard that restores the
directory's mode on drop. Without it, a panic between clearing the mode and
restoring it leaves a directory that cannot be removed, so one assertion
failure would be followed by a second, unrelated one from the temporary
directory's own cleanup.
