### PR TITLE
Let a workspace configure what whisker ignores

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2824,6 +2824,8 @@ dependencies = [
  "ignore",
  "no_matches_macro",
  "predicates",
+ "serde",
+ "serde_json",
  "tempfile",
  "trycmd",
  "whisker-core",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,16 @@ edition = "2024"
 license = "Apache-2.0 OR MIT"
 repository = "https://github.com/aonyx-ai/whisker.git"
 
+# Whisker's own configuration, read by `whisker check` when it runs against
+# this repository. Every path listed here is deliberately violation-laden
+# fixture material for the lint suite, and none of it belongs to this
+# workspace's crate graph, so rust-analyzer has nothing to say about it.
+[workspace.metadata.whisker]
+ignore = [
+  "/examples/",
+  "crates/whisker-rust/tests/fixtures/",
+]
+
 [workspace.lints.clippy]
 missing_errors_doc = "warn"
 missing_panics_doc = "warn"

--- a/README.md
+++ b/README.md
@@ -41,6 +41,23 @@ a clean project.
 Whisker refuses a named file that it has no grammar for. A parse with the
 wrong grammar finds nothing and would report the file clean.
 
+### Configuration
+
+Whisker reads its configuration from the `[workspace.metadata.whisker]` table
+of the target workspace manifest:
+
+```toml
+[workspace.metadata.whisker]
+ignore = ["/examples/", "crates/whisker-rust/tests/fixtures/"]
+```
+
+`ignore` holds gitignore-syntax patterns. Use it for test fixtures, vendored
+sources, and other code that git tracks on purpose. The patterns behave as
+they would in a `.gitignore` at the workspace root: `crates/app/generated/`
+names one directory relative to that root, `examples/` matches at any depth,
+and `/examples/` anchors to the root. Whisker rejects keys it does not
+recognize, so a typo is an error and not a silent no-op.
+
 ## License
 
 Licensed under either of

--- a/crates/whisker/Cargo.toml
+++ b/crates/whisker/Cargo.toml
@@ -22,6 +22,8 @@ derive_order = { path = "../../lints/derive_order" }
 if_let_with_else = { path = "../../lints/if_let_with_else" }
 ignore.workspace = true
 no_matches_macro = { path = "../../lints/no_matches_macro" }
+serde.workspace = true
+serde_json.workspace = true
 whisker-core = { path = "../whisker-core" }
 whisker-reporting = { path = "../whisker-reporting" }
 whisker-rust = { path = "../whisker-rust" }

--- a/crates/whisker/src/commands/check.rs
+++ b/crates/whisker/src/commands/check.rs
@@ -15,6 +15,7 @@ use whisker_types::{DecorationProvider, Diagnostic, LintPass};
 use self::check_outcome::CheckOutcome;
 use self::error_recovery::ErrorRecovery;
 use self::failure_threshold::FailureThreshold;
+use crate::config::WhiskerConfig;
 use crate::discovery::{Discovery, WalkErrorPolicy};
 
 /// Run whisker lints against a project
@@ -77,12 +78,15 @@ pub async fn check(args: CheckArgs, _context: Context) -> CommandResult {
 
     anyhow::ensure!(path.exists(), "{} does not exist", path.display());
 
+    let config = WhiskerConfig::load(&path).context("failed to load the whisker configuration")?;
+
     let on_error = match keep_going {
         true => WalkErrorPolicy::ReportAndContinue,
         false => WalkErrorPolicy::Fail,
     };
 
-    let discovery = Discovery::run(&path, on_error).context("failed to discover source files")?;
+    let discovery =
+        Discovery::run(&path, &config, on_error).context("failed to discover source files")?;
 
     let mut outcome = CheckOutcome::Success;
 

--- a/crates/whisker/src/config.rs
+++ b/crates/whisker/src/config.rs
@@ -1,0 +1,376 @@
+use std::ffi::OsString;
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+use anyhow::Context as _;
+use serde::Deserialize;
+
+mod ignore_pattern;
+
+pub use ignore_pattern::IgnorePattern;
+
+/// Whisker's configuration for a single target project
+///
+/// Whisker reads its configuration from the `[workspace.metadata.whisker]`
+/// table of the target project's workspace manifest, so there is no separate
+/// configuration file. The table currently holds only the [`IgnorePattern`]s
+/// that exclude files from discovery.
+#[derive(Clone, Eq, PartialEq, Debug)]
+pub struct WhiskerConfig {
+    root: PathBuf,
+    ignore: Vec<IgnorePattern>,
+}
+
+impl WhiskerConfig {
+    /// Creates a configuration whose patterns are anchored at `root`
+    ///
+    /// # Examples
+    ///
+    /// ```ignore
+    /// let config = WhiskerConfig::new(
+    ///     PathBuf::from("/src/project"),
+    ///     vec![IgnorePattern::new("examples/")],
+    /// );
+    /// ```
+    pub fn new(root: PathBuf, ignore: Vec<IgnorePattern>) -> Self {
+        Self { root, ignore }
+    }
+
+    /// Loads the configuration that governs `path`
+    ///
+    /// Whisker asks `cargo metadata` for the workspace root and reads the
+    /// metadata table from its output. Cargo is the authority on the
+    /// workspace root: it follows the `package.workspace` key and applies
+    /// workspace inheritance. A directory outside any Cargo project is a
+    /// supported target with an empty configuration.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if `path` cannot be resolved, if `cargo metadata`
+    /// fails, or if the `[workspace.metadata.whisker]` table cannot be read.
+    /// An unrecognized key in the table is an error, because it is most
+    /// likely a typo.
+    pub fn load(path: &Path) -> anyhow::Result<Self> {
+        let root = search_directory(path)?;
+
+        if !has_manifest(&root) {
+            return Ok(Self::new(root, Vec::new()));
+        }
+
+        let cargo = std::env::var_os("CARGO").unwrap_or_else(|| OsString::from("cargo"));
+
+        let output = Command::new(cargo)
+            .args(["metadata", "--no-deps", "--format-version", "1"])
+            .current_dir(&root)
+            .output()
+            .context("failed to run `cargo metadata` to locate the workspace manifest")?;
+
+        anyhow::ensure!(
+            output.status.success(),
+            "failed to read the Cargo workspace containing {}: {}",
+            root.display(),
+            String::from_utf8_lossy(&output.stderr).trim()
+        );
+
+        let CargoMetadata {
+            workspace_root,
+            metadata,
+        } = serde_json::from_slice(&output.stdout)
+            .context("failed to parse the output of `cargo metadata`")?;
+
+        let root = std::fs::canonicalize(&workspace_root).with_context(|| {
+            format!(
+                "failed to resolve the workspace root at {}",
+                workspace_root.display()
+            )
+        })?;
+
+        let Some(metadata) = metadata else {
+            return Ok(Self::new(root, Vec::new()));
+        };
+
+        let Some(table) = metadata.get("whisker") else {
+            return Ok(Self::new(root, Vec::new()));
+        };
+
+        let ConfigTable { ignore } = ConfigTable::deserialize(table).with_context(|| {
+            format!(
+                "failed to read the [workspace.metadata.whisker] table in {}",
+                root.join("Cargo.toml").display()
+            )
+        })?;
+
+        let ignore = ignore.into_iter().map(IgnorePattern::new).collect();
+
+        Ok(Self::new(root, ignore))
+    }
+
+    /// Returns the directory that anchors the ignore patterns
+    ///
+    /// This is the Cargo workspace root when the target is part of a Cargo
+    /// project, and the target directory itself otherwise.
+    ///
+    /// # Examples
+    ///
+    /// ```ignore
+    /// let config = WhiskerConfig::load(Path::new("."))?;
+    ///
+    /// println!("configured from {}", config.root().display());
+    /// ```
+    pub fn root(&self) -> &Path {
+        &self.root
+    }
+
+    /// Returns the patterns that exclude files from discovery
+    ///
+    /// # Examples
+    ///
+    /// ```ignore
+    /// let config = WhiskerConfig::load(Path::new("."))?;
+    ///
+    /// assert!(config.ignore().is_empty());
+    /// ```
+    pub fn ignore(&self) -> &[IgnorePattern] {
+        &self.ignore
+    }
+}
+
+/// The subset of `cargo metadata` output whisker reads
+///
+/// The workspace metadata stays an untyped map so that other tools' tables
+/// pass through untouched. A malformed whisker table then produces an error
+/// that names the whisker table, not the whole document.
+#[derive(Debug, Deserialize)]
+struct CargoMetadata {
+    workspace_root: PathBuf,
+    metadata: Option<serde_json::Map<String, serde_json::Value>>,
+}
+
+/// The `[workspace.metadata.whisker]` table as written in the manifest
+///
+/// The manifest is a system boundary, so this type holds plain strings.
+/// [`WhiskerConfig::load`] turns them into [`IgnorePattern`]s.
+/// Deserialization rejects unknown keys because a silently ignored key looks
+/// exactly like one that works.
+#[derive(Debug, Default, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct ConfigTable {
+    #[serde(default)]
+    ignore: Vec<String>,
+}
+
+/// Returns whether `directory` or any of its ancestors holds a `Cargo.toml`
+fn has_manifest(directory: &Path) -> bool {
+    directory
+        .ancestors()
+        .any(|ancestor| ancestor.join("Cargo.toml").is_file())
+}
+
+/// Returns the absolute directory to ask Cargo about for `path`
+///
+/// For a file target, this is the directory that holds the file.
+///
+/// # Errors
+///
+/// Returns an error if `path` does not exist or cannot be resolved.
+fn search_directory(path: &Path) -> anyhow::Result<PathBuf> {
+    let path = std::fs::canonicalize(path)
+        .with_context(|| format!("failed to resolve {}", path.display()))?;
+
+    if path.is_dir() {
+        return Ok(path);
+    }
+
+    let directory = path.parent().unwrap_or(&path).to_path_buf();
+
+    Ok(directory)
+}
+
+#[cfg(test)]
+mod tests {
+    use tempfile::TempDir;
+
+    use super::*;
+
+    /// A virtual workspace manifest with no members
+    ///
+    /// Members would have to be built to be useful, and every test here is
+    /// about the metadata table, not the crate graph.
+    const EMPTY_WORKSPACE: &str = "[workspace]\nresolver = \"3\"\nmembers = []\n";
+
+    /// Returns the resolved path of a temporary directory
+    ///
+    /// Temporary directories commonly sit behind a symlink, and Cargo reports
+    /// the resolved workspace root, so comparisons have to resolve too.
+    fn resolved(directory: &TempDir) -> PathBuf {
+        std::fs::canonicalize(directory.path()).expect("temporary directory should resolve")
+    }
+
+    /// Creates a temporary Cargo workspace whose manifest is `manifest`
+    fn workspace(manifest: &str) -> TempDir {
+        let directory = tempfile::tempdir().expect("temporary directory should be created");
+        std::fs::write(directory.path().join("Cargo.toml"), manifest)
+            .expect("manifest should be written");
+        directory
+    }
+
+    #[test]
+    fn load_with_empty_ignore_list_returns_an_empty_configuration() {
+        let directory = workspace(&format!(
+            "{EMPTY_WORKSPACE}\n[workspace.metadata.whisker]\nignore = []\n"
+        ));
+
+        let config = WhiskerConfig::load(directory.path()).expect("configuration should load");
+
+        assert!(config.ignore().is_empty());
+    }
+
+    #[test]
+    fn load_with_file_target_uses_the_workspace_root() {
+        let directory = workspace(&format!(
+            "{EMPTY_WORKSPACE}\n[workspace.metadata.whisker]\nignore = [\"examples/\"]\n"
+        ));
+        std::fs::create_dir(directory.path().join("src")).expect("src should be created");
+        let file = directory.path().join("src").join("main.rs");
+        std::fs::write(&file, "fn main() {}").expect("source should be written");
+
+        let config = WhiskerConfig::load(&file).expect("configuration should load");
+
+        assert_eq!(config.root(), resolved(&directory));
+        assert_eq!(config.ignore(), vec![IgnorePattern::new("examples/")]);
+    }
+
+    #[test]
+    fn load_with_ignore_patterns_returns_them_in_order() {
+        let directory = workspace(&format!(
+            "{EMPTY_WORKSPACE}\n[workspace.metadata.whisker]\nignore = [\"examples/\", \"a/b.rs\"]\n"
+        ));
+
+        let config = WhiskerConfig::load(directory.path()).expect("configuration should load");
+
+        assert_eq!(
+            config.ignore(),
+            vec![
+                IgnorePattern::new("examples/"),
+                IgnorePattern::new("a/b.rs")
+            ]
+        );
+    }
+
+    #[test]
+    fn load_with_invalid_manifest_returns_error() {
+        let directory = workspace("[workspace\nthis is not toml\n");
+
+        let error = WhiskerConfig::load(directory.path()).expect_err("configuration should fail");
+
+        assert!(
+            format!("{error:#}").contains("failed to read the Cargo workspace containing"),
+            "error should report that Cargo could not read the manifest: {error:#}"
+        );
+    }
+
+    #[test]
+    fn load_with_malformed_ignore_value_returns_error() {
+        let directory = workspace(&format!(
+            "{EMPTY_WORKSPACE}\n[workspace.metadata.whisker]\nignore = \"examples/\"\n"
+        ));
+
+        let error = WhiskerConfig::load(directory.path()).expect_err("configuration should fail");
+
+        assert!(
+            format!("{error:#}").contains("[workspace.metadata.whisker]"),
+            "error should name the offending table: {error:#}"
+        );
+        assert!(
+            format!("{error:#}").contains("invalid type"),
+            "error should describe the type mismatch: {error:#}"
+        );
+    }
+
+    #[test]
+    fn load_with_no_manifest_returns_an_empty_configuration() {
+        let directory = tempfile::tempdir().expect("temporary directory should be created");
+
+        let config = WhiskerConfig::load(directory.path()).expect("configuration should load");
+
+        assert_eq!(config.root(), resolved(&directory));
+        assert!(config.ignore().is_empty());
+    }
+
+    #[test]
+    fn load_with_no_metadata_table_returns_an_empty_configuration() {
+        let directory = workspace(EMPTY_WORKSPACE);
+
+        let config = WhiskerConfig::load(directory.path()).expect("configuration should load");
+
+        assert_eq!(config.root(), resolved(&directory));
+        assert!(config.ignore().is_empty());
+    }
+
+    #[test]
+    fn load_with_no_whisker_table_returns_an_empty_configuration() {
+        let directory = workspace(&format!(
+            "{EMPTY_WORKSPACE}\n[workspace.metadata.other-tool]\nsetting = true\n"
+        ));
+
+        let config = WhiskerConfig::load(directory.path()).expect("configuration should load");
+
+        assert!(config.ignore().is_empty());
+    }
+
+    #[test]
+    fn load_with_nonexistent_path_returns_error() {
+        let directory = tempfile::tempdir().expect("temporary directory should be created");
+
+        let error = WhiskerConfig::load(&directory.path().join("missing"))
+            .expect_err("configuration should fail");
+
+        assert!(
+            format!("{error:#}").contains("failed to resolve"),
+            "error should report the unresolvable path: {error:#}"
+        );
+    }
+
+    #[test]
+    fn load_with_unknown_key_returns_error() {
+        let directory = workspace(&format!(
+            "{EMPTY_WORKSPACE}\n[workspace.metadata.whisker]\nignoer = [\"examples/\"]\n"
+        ));
+
+        let error = WhiskerConfig::load(directory.path()).expect_err("configuration should fail");
+
+        assert!(
+            format!("{error:#}").contains("unknown field `ignoer`"),
+            "error should name the unrecognized key: {error:#}"
+        );
+    }
+
+    #[test]
+    fn new_returns_the_given_root_and_patterns() {
+        let root = PathBuf::from("/src/project");
+        let patterns = vec![IgnorePattern::new("examples/")];
+
+        let config = WhiskerConfig::new(root.clone(), patterns.clone());
+
+        assert_eq!(config.root(), root);
+        assert_eq!(config.ignore(), patterns);
+    }
+
+    #[test]
+    fn trait_send() {
+        fn assert_send<T: Send>() {}
+        assert_send::<WhiskerConfig>();
+    }
+
+    #[test]
+    fn trait_sync() {
+        fn assert_sync<T: Sync>() {}
+        assert_sync::<WhiskerConfig>();
+    }
+
+    #[test]
+    fn trait_unpin() {
+        fn assert_unpin<T: Unpin>() {}
+        assert_unpin::<WhiskerConfig>();
+    }
+}

--- a/crates/whisker/src/config/ignore_pattern.rs
+++ b/crates/whisker/src/config/ignore_pattern.rs
@@ -1,0 +1,92 @@
+/// A gitignore-syntax pattern that excludes files from a `whisker check` run
+///
+/// The syntax is gitignore's, so projects do not need a second pattern
+/// language. A trailing slash restricts a pattern to directories, `**`
+/// crosses directory boundaries, and a leading `!` re-includes an earlier
+/// exclusion. As in gitignore, `!` cannot re-include a file whose parent
+/// directory is excluded, because the walk never enters that directory.
+///
+/// Patterns match against the Cargo workspace root, not against the run's
+/// starting directory. A bare `examples/` matches at any depth beneath the
+/// root, and `/examples/` matches only at the root.
+///
+/// # Examples
+///
+/// ```ignore
+/// let pattern = IgnorePattern::new("examples/");
+///
+/// assert_eq!(pattern.as_str(), "examples/");
+/// ```
+#[derive(Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug)]
+pub struct IgnorePattern(String);
+
+impl IgnorePattern {
+    /// Creates a pattern from its gitignore-syntax source
+    ///
+    /// The constructor does not validate the source. Discovery compiles the
+    /// patterns later and rejects invalid syntax with an error that names
+    /// the pattern.
+    ///
+    /// # Examples
+    ///
+    /// ```ignore
+    /// let pattern = IgnorePattern::new("target/");
+    /// ```
+    pub fn new(pattern: impl Into<String>) -> Self {
+        Self(pattern.into())
+    }
+
+    /// Returns the gitignore-syntax source of this pattern
+    ///
+    /// # Examples
+    ///
+    /// ```ignore
+    /// assert_eq!(IgnorePattern::new("target/").as_str(), "target/");
+    /// ```
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+}
+
+impl std::fmt::Display for IgnorePattern {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(&self.0)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn as_str_returns_source() {
+        let pattern = IgnorePattern::new("examples/");
+
+        assert_eq!(pattern.as_str(), "examples/");
+    }
+
+    #[test]
+    fn display_matches_source() {
+        let pattern = IgnorePattern::new("crates/*/tests/fixtures/");
+
+        assert_eq!(pattern.to_string(), "crates/*/tests/fixtures/");
+    }
+
+    #[test]
+    fn trait_send() {
+        fn assert_send<T: Send>() {}
+        assert_send::<IgnorePattern>();
+    }
+
+    #[test]
+    fn trait_sync() {
+        fn assert_sync<T: Sync>() {}
+        assert_sync::<IgnorePattern>();
+    }
+
+    #[test]
+    fn trait_unpin() {
+        fn assert_unpin<T: Unpin>() {}
+        assert_unpin::<IgnorePattern>();
+    }
+}

--- a/crates/whisker/src/discovery.rs
+++ b/crates/whisker/src/discovery.rs
@@ -1,8 +1,11 @@
 use std::path::{Path, PathBuf};
 
 use anyhow::Context as _;
-use ignore::{DirEntry, WalkBuilder};
+use ignore::gitignore::{Gitignore, GitignoreBuilder};
+use ignore::{DirEntry, Match, WalkBuilder};
 use whisker_types::Language;
+
+use crate::config::WhiskerConfig;
 
 mod walk_error_policy;
 mod walk_failure;
@@ -10,13 +13,24 @@ mod walk_failure;
 pub use walk_error_policy::WalkErrorPolicy;
 use walk_failure::WalkFailure;
 
-/// The source files a `whisker check` run inspects
+/// The source files a `whisker check` run will inspect
 ///
-/// The walk skips hidden files and directories, and it honors `.gitignore`,
-/// `.ignore`, `.git/info/exclude`, and the user's global gitignore. Unlike
-/// `ripgrep`, it applies these rules even without a repository. An ignore
-/// file in a tarball or a vendored tree still describes which files that
-/// tree generates.
+/// The walk honors the exclusions the project's own tooling honors:
+/// `.gitignore`, `.ignore`, `.git/info/exclude`, the user's global gitignore,
+/// and hidden files. Whisker's own [`IgnorePattern`]s apply on top, so
+/// generated output stays out of a run.
+///
+/// The walk honors these files even without a repository around them, which
+/// is where whisker departs from `ripgrep`'s default. A `.gitignore` in a
+/// tarball or a vendored checkout still describes which files the project
+/// generates.
+///
+/// Discovery keeps failures alongside the files so the caller can act on
+/// them. An unreadable directory or an unparsable ignore file would
+/// otherwise shrink the scan. A shrunken scan lets a run report success over
+/// source it never opened.
+///
+/// [`IgnorePattern`]: crate::config::IgnorePattern
 #[derive(Debug)]
 pub struct Discovery {
     files: Vec<PathBuf>,
@@ -26,32 +40,47 @@ pub struct Discovery {
 impl Discovery {
     /// Discovers the files to lint beneath `path`
     ///
-    /// A `path` that names one file comes back as-is. Ignore rules do not
-    /// apply to it, because the user already chose the file. The grammar
-    /// comes from the extension of `path`, not from the name a symlink
-    /// resolves to. Whisker reports the path the user named.
+    /// When `path` names a single file, the run returns it as-is, and no
+    /// ignore pattern excludes it. A user who types a file's name already
+    /// made the decision the ignore rules automate. The grammar check
+    /// still applies. Otherwise whisker reports an unsupported file as
+    /// clean. The grammar comes from the extension of `path`, not from the
+    /// name a symlink resolves to, and whisker reports the path the user
+    /// named.
+    ///
+    /// The walk enters a directory named on the command line even when a
+    /// pattern excludes it. That pattern does not apply again to the files
+    /// inside, but patterns that match deeper entries still prune them.
     ///
     /// # Errors
     ///
-    /// Returns an error if `path` cannot be resolved, if `path` names a file
-    /// with no extension, if `path` names a file written in a language
-    /// whisker has no grammar for, if a configured
-    /// ignore pattern is not valid gitignore syntax, or - under
-    /// [`WalkErrorPolicy::Fail`] - if a directory entry or an ignore file
-    /// cannot be read.
+    /// Returns an error if `path` cannot be resolved, or if `path` names a
+    /// file whisker has no grammar for. A file with no extension names no
+    /// language, so it is an error too.
+    ///
+    /// Returns an error if a configured ignore pattern is not valid
+    /// gitignore syntax. Under [`WalkErrorPolicy::Fail`], an unreadable
+    /// directory entry or ignore file is also an error.
     ///
     /// # Examples
     ///
     /// ```ignore
-    /// let discovery = Discovery::run(Path::new("."), WalkErrorPolicy::Fail)?;
+    /// let config = WhiskerConfig::load(Path::new("."))?;
+    /// let discovery = Discovery::run(Path::new("."), &config, WalkErrorPolicy::Fail)?;
     ///
     /// for file in discovery.files() {
     ///     println!("{}", file.display());
     /// }
     /// ```
-    pub fn run(path: &Path, on_error: WalkErrorPolicy) -> anyhow::Result<Self> {
+    pub fn run(
+        path: &Path,
+        config: &WhiskerConfig,
+        on_error: WalkErrorPolicy,
+    ) -> anyhow::Result<Self> {
         let root = std::fs::canonicalize(path)
             .with_context(|| format!("failed to resolve {}", path.display()))?;
+
+        let excludes = build_excludes(config)?;
 
         if root.is_file() {
             let Some(extension) = path.extension() else {
@@ -77,7 +106,20 @@ impl Discovery {
             });
         }
 
-        let walk = WalkBuilder::new(&root).require_git(false).build();
+        let walk = WalkBuilder::new(&root)
+            .require_git(false)
+            .filter_entry(move |entry| {
+                let is_dir = entry
+                    .file_type()
+                    .is_some_and(|file_type| file_type.is_dir());
+
+                match excludes.matched(entry.path(), is_dir) {
+                    Match::None => true,
+                    Match::Ignore(_) => false,
+                    Match::Whitelist(_) => true,
+                }
+            })
+            .build();
 
         let mut files = Vec::new();
         let mut errors = Vec::new();
@@ -169,6 +211,31 @@ fn attached_error(entry: &DirEntry) -> Option<anyhow::Error> {
     Some(anyhow::Error::msg(error.to_string()).context("failed to read an ignore file"))
 }
 
+/// Compiles the configured ignore patterns into a matcher
+///
+/// The matcher anchors patterns at the configured root, not at the walk
+/// root, so a pattern means the same thing from any starting directory.
+/// Within that root the patterns behave as they would in a `.gitignore`
+/// written there.
+///
+/// # Errors
+///
+/// Returns an error that names the offending pattern when it is not valid
+/// gitignore syntax.
+fn build_excludes(config: &WhiskerConfig) -> anyhow::Result<Gitignore> {
+    let mut builder = GitignoreBuilder::new(config.root());
+
+    for pattern in config.ignore() {
+        builder
+            .add_line(None, pattern.as_str())
+            .with_context(|| format!("failed to read the ignore pattern `{pattern}`"))?;
+    }
+
+    builder
+        .build()
+        .context("failed to compile the configured ignore patterns")
+}
+
 /// Rebases `entry` from the resolved `root` onto the `original` argument
 ///
 /// The walk resolves its root, but diagnostics must show the path the user
@@ -185,6 +252,13 @@ mod tests {
     use tempfile::TempDir;
 
     use super::*;
+    use crate::config::IgnorePattern;
+
+    /// A virtual workspace manifest with no members
+    ///
+    /// The tests that use a manifest read only its metadata table, so
+    /// members are unnecessary.
+    const EMPTY_WORKSPACE: &str = "[workspace]\nresolver = \"3\"\nmembers = []\n";
 
     /// A directory whose permissions are restored when this value is dropped
     ///
@@ -233,6 +307,17 @@ mod tests {
              sorting anything; give the test more files or different names",
             directory.display()
         );
+    }
+
+    /// Builds a configuration anchored at `root` with the given patterns
+    fn config(root: &Path, patterns: &[&str]) -> WhiskerConfig {
+        let root = std::fs::canonicalize(root).expect("root should resolve");
+        let patterns = patterns
+            .iter()
+            .map(|pattern| IgnorePattern::new(*pattern))
+            .collect();
+
+        WhiskerConfig::new(root, patterns)
     }
 
     /// Returns the discovered files as slash-separated paths relative to `root`
@@ -299,6 +384,19 @@ mod tests {
     }
 
     #[test]
+    fn build_excludes_with_invalid_pattern_returns_error() {
+        let directory = tree(&[]);
+        let config = config(directory.path(), &["{a,b"]);
+
+        let error = build_excludes(&config).expect_err("pattern should be rejected");
+
+        assert!(
+            format!("{error:#}").contains("failed to read the ignore pattern `{a,b`"),
+            "error should name the offending pattern: {error:#}"
+        );
+    }
+
+    #[test]
     fn rebase_with_entry_outside_root_returns_the_entry() {
         let entry = Path::new("/elsewhere/main.rs");
 
@@ -314,6 +412,37 @@ mod tests {
         let path = rebase(Path::new("."), Path::new("/project"), entry);
 
         assert_eq!(path, Path::new("./src/main.rs"));
+    }
+
+    /// Pins the exclusions whisker's own manifest declares
+    ///
+    /// The fixture projects exist to violate lint rules, so a pattern that
+    /// stops matching would fill an otherwise clean run with their
+    /// diagnostics.
+    #[test]
+    fn run_over_whiskers_own_workspace_excludes_its_fixture_projects() {
+        let root = Path::new(env!("CARGO_MANIFEST_DIR")).join("..").join("..");
+        let config = WhiskerConfig::load(&root).expect("whisker's own configuration should load");
+
+        let discovery = Discovery::run(&root, &config, WalkErrorPolicy::Fail)
+            .expect("discovery should succeed");
+
+        let files = discovered(&discovery, &root);
+        assert!(
+            files.contains(&"crates/whisker/src/discovery.rs".to_owned()),
+            "discovery should have found whisker's own source: {files:?}"
+        );
+        let fixtures: Vec<&String> = files
+            .iter()
+            .filter(|file| {
+                file.starts_with("examples/")
+                    || file.starts_with("crates/whisker-rust/tests/fixtures/")
+            })
+            .collect();
+        assert!(
+            fixtures.is_empty(),
+            "the configured patterns should have excluded every fixture project: {fixtures:?}"
+        );
     }
 
     /// The sort makes diagnostics reproducible across machines. This test
@@ -332,8 +461,9 @@ mod tests {
             "snake.rs",
         ]);
         assert_stored_out_of_order(directory.path());
+        let config = config(directory.path(), &[]);
 
-        let discovery = Discovery::run(directory.path(), WalkErrorPolicy::Fail)
+        let discovery = Discovery::run(directory.path(), &config, WalkErrorPolicy::Fail)
             .expect("discovery should succeed");
 
         assert_eq!(
@@ -352,29 +482,73 @@ mod tests {
     }
 
     #[test]
-    fn run_with_dot_ignore_file_excludes_it() {
-        let directory = tree(&["src/main.rs", "generated/schema.rs"]);
-        std::fs::write(directory.path().join(".ignore"), "generated/\n")
-            .expect("ignore file should be written");
+    fn run_with_anchored_pattern_prunes_only_at_the_workspace_root() {
+        let directory = tree(&[
+            "examples/demo.rs",
+            "crates/app/examples/demo.rs",
+            "src/main.rs",
+        ]);
+        let config = config(directory.path(), &["/examples/"]);
 
-        let discovery = Discovery::run(directory.path(), WalkErrorPolicy::Fail)
+        let discovery = Discovery::run(directory.path(), &config, WalkErrorPolicy::Fail)
+            .expect("discovery should succeed");
+
+        assert_eq!(
+            discovered(&discovery, directory.path()),
+            ["crates/app/examples/demo.rs", "src/main.rs"]
+        );
+    }
+
+    #[test]
+    fn run_with_directory_pattern_prunes_the_directory() {
+        let directory = tree(&["src/main.rs", "examples/demo/src/main.rs"]);
+        let config = config(directory.path(), &["examples/"]);
+
+        let discovery = Discovery::run(directory.path(), &config, WalkErrorPolicy::Fail)
             .expect("discovery should succeed");
 
         assert_eq!(discovered(&discovery, directory.path()), ["src/main.rs"]);
     }
 
-    /// An ignore rule that matches a named directory does not prune it. The
-    /// walker reads the ignore files above its root, but it never applies
-    /// them to the root.
+    #[test]
+    fn run_with_dot_ignore_file_excludes_it() {
+        let directory = tree(&["src/main.rs", "generated/schema.rs"]);
+        std::fs::write(directory.path().join(".ignore"), "generated/\n")
+            .expect("ignore file should be written");
+        let config = config(directory.path(), &[]);
+
+        let discovery = Discovery::run(directory.path(), &config, WalkErrorPolicy::Fail)
+            .expect("discovery should succeed");
+
+        assert_eq!(discovered(&discovery, directory.path()), ["src/main.rs"]);
+    }
+
+    #[test]
+    fn run_with_excluded_directory_does_not_reinclude_a_file_inside_it() {
+        let directory = tree(&["examples/demo.rs", "examples/keep.rs", "src/main.rs"]);
+        let config = config(directory.path(), &["examples/", "!examples/keep.rs"]);
+
+        let discovery = Discovery::run(directory.path(), &config, WalkErrorPolicy::Fail)
+            .expect("discovery should succeed");
+
+        assert_eq!(discovered(&discovery, directory.path()), ["src/main.rs"]);
+    }
+
+    /// An ignore rule that matches a named directory does not prune it
+    ///
+    /// The walker reads the ignore files above its root, but it never
+    /// applies them to the root. A configured pattern behaves the same way,
+    /// so this test states both rules and expects neither to bite.
     #[test]
     fn run_with_explicit_directory_target_is_not_pruned() {
         let directory = tree(&["examples/demo.rs"]);
         std::fs::write(directory.path().join(".gitignore"), "examples/\n")
             .expect("gitignore should be written");
+        let config = config(directory.path(), &["examples/"]);
         let target = directory.path().join("examples");
 
-        let discovery =
-            Discovery::run(&target, WalkErrorPolicy::Fail).expect("discovery should succeed");
+        let discovery = Discovery::run(&target, &config, WalkErrorPolicy::Fail)
+            .expect("discovery should succeed");
 
         assert_eq!(discovered(&discovery, &target), ["demo.rs"]);
     }
@@ -382,10 +556,11 @@ mod tests {
     #[test]
     fn run_with_explicit_extensionless_file_target_returns_error() {
         let directory = tree(&["LICENSE"]);
+        let config = config(directory.path(), &[]);
         let target = directory.path().join("LICENSE");
 
-        let error =
-            Discovery::run(&target, WalkErrorPolicy::Fail).expect_err("discovery should fail");
+        let error = Discovery::run(&target, &config, WalkErrorPolicy::Fail)
+            .expect_err("discovery should fail");
 
         assert!(
             format!("{error:#}").contains("no file extension"),
@@ -402,12 +577,13 @@ mod tests {
     #[test]
     fn run_with_explicit_extensionless_symlink_to_a_rust_file_returns_error() {
         let directory = tree(&["src/main.rs"]);
+        let config = config(directory.path(), &[]);
         let link = directory.path().join("LICENSE");
         std::os::unix::fs::symlink(directory.path().join("src").join("main.rs"), &link)
             .expect("symlink should be created");
 
-        let error =
-            Discovery::run(&link, WalkErrorPolicy::Fail).expect_err("discovery should fail");
+        let error = Discovery::run(&link, &config, WalkErrorPolicy::Fail)
+            .expect_err("discovery should fail");
 
         assert!(
             format!("{error:#}").contains("no file extension"),
@@ -415,16 +591,52 @@ mod tests {
         );
     }
 
-    /// A file the user names skips the walk, so no ignore rule reaches it
+    /// Pins that an invalid pattern is an error for a file target too
+    ///
+    /// Patterns do not select an explicit file, so the file branch has no
+    /// other reason to compile them. The error then reaches the user only
+    /// on some invocations.
+    #[test]
+    fn run_with_explicit_file_target_and_invalid_pattern_returns_error() {
+        let directory = tree(&["src/main.rs"]);
+        let config = config(directory.path(), &["{a,b"]);
+        let target = directory.path().join("src").join("main.rs");
+
+        let error = Discovery::run(&target, &config, WalkErrorPolicy::Fail)
+            .expect_err("discovery should fail");
+        let over_directory = Discovery::run(directory.path(), &config, WalkErrorPolicy::Fail)
+            .expect_err("discovery should fail");
+
+        assert!(
+            format!("{error:#}").contains("failed to read the ignore pattern `{a,b`"),
+            "error should name the offending pattern: {error:#}"
+        );
+        assert_eq!(format!("{error:#}"), format!("{over_directory:#}"));
+    }
+
+    #[test]
+    fn run_with_explicit_file_target_ignores_patterns() {
+        let directory = tree(&["examples/demo.rs"]);
+        let config = config(directory.path(), &["examples/", "*.rs"]);
+        let target = directory.path().join("examples").join("demo.rs");
+
+        let discovery = Discovery::run(&target, &config, WalkErrorPolicy::Fail)
+            .expect("discovery should succeed");
+
+        assert_eq!(discovery.files(), vec![target]);
+    }
+
+    /// A file the user names skips the walk, so no ignore file reaches it
     #[test]
     fn run_with_explicit_file_target_is_not_ignored() {
         let directory = tree(&["generated/schema.rs"]);
+        let config = config(directory.path(), &[]);
         std::fs::write(directory.path().join(".gitignore"), "generated/\n")
             .expect("gitignore should be written");
         let target = directory.path().join("generated").join("schema.rs");
 
-        let discovery =
-            Discovery::run(&target, WalkErrorPolicy::Fail).expect("discovery should succeed");
+        let discovery = Discovery::run(&target, &config, WalkErrorPolicy::Fail)
+            .expect("discovery should succeed");
 
         assert_eq!(
             discovered(&discovery, directory.path()),
@@ -435,10 +647,11 @@ mod tests {
     #[test]
     fn run_with_explicit_non_rust_file_target_returns_error() {
         let directory = tree(&["Cargo.toml"]);
+        let config = config(directory.path(), &[]);
         let target = directory.path().join("Cargo.toml");
 
-        let error =
-            Discovery::run(&target, WalkErrorPolicy::Fail).expect_err("discovery should fail");
+        let error = Discovery::run(&target, &config, WalkErrorPolicy::Fail)
+            .expect_err("discovery should fail");
 
         assert!(
             format!("{error:#}").contains("no grammar for `.toml` files"),
@@ -454,12 +667,13 @@ mod tests {
     #[test]
     fn run_with_explicit_rust_symlink_to_an_extensionless_file_returns_the_link() {
         let directory = tree(&["data"]);
+        let config = config(directory.path(), &[]);
         let link = directory.path().join("link.rs");
         std::os::unix::fs::symlink(directory.path().join("data"), &link)
             .expect("symlink should be created");
 
-        let discovery =
-            Discovery::run(&link, WalkErrorPolicy::Fail).expect("discovery should succeed");
+        let discovery = Discovery::run(&link, &config, WalkErrorPolicy::Fail)
+            .expect("discovery should succeed");
 
         assert_eq!(discovery.files(), vec![link]);
     }
@@ -476,8 +690,9 @@ mod tests {
             "generated/\n",
         )
         .expect("exclude file should be written");
+        let config = config(directory.path(), &[]);
 
-        let discovery = Discovery::run(directory.path(), WalkErrorPolicy::Fail)
+        let discovery = Discovery::run(directory.path(), &config, WalkErrorPolicy::Fail)
             .expect("discovery should succeed");
 
         assert_eq!(discovered(&discovery, directory.path()), ["src/main.rs"]);
@@ -488,8 +703,9 @@ mod tests {
         let directory = tree(&["src/main.rs", "generated/schema.rs"]);
         std::fs::write(directory.path().join(".gitignore"), "generated/\n")
             .expect("gitignore should be written");
+        let config = config(directory.path(), &[]);
 
-        let discovery = Discovery::run(directory.path(), WalkErrorPolicy::Fail)
+        let discovery = Discovery::run(directory.path(), &config, WalkErrorPolicy::Fail)
             .expect("discovery should succeed");
 
         assert_eq!(discovered(&discovery, directory.path()), ["src/main.rs"]);
@@ -498,18 +714,34 @@ mod tests {
     #[test]
     fn run_with_hidden_directory_excludes_it() {
         let directory = tree(&["src/main.rs", ".cache/build.rs"]);
+        let config = config(directory.path(), &[]);
 
-        let discovery = Discovery::run(directory.path(), WalkErrorPolicy::Fail)
+        let discovery = Discovery::run(directory.path(), &config, WalkErrorPolicy::Fail)
             .expect("discovery should succeed");
 
         assert_eq!(discovered(&discovery, directory.path()), ["src/main.rs"]);
     }
 
     #[test]
+    fn run_with_negated_pattern_reincludes_the_file() {
+        let directory = tree(&["examples/demo.rs", "examples/keep.rs", "src/main.rs"]);
+        let config = config(directory.path(), &["examples/*.rs", "!examples/keep.rs"]);
+
+        let discovery = Discovery::run(directory.path(), &config, WalkErrorPolicy::Fail)
+            .expect("discovery should succeed");
+
+        assert_eq!(
+            discovered(&discovery, directory.path()),
+            ["examples/keep.rs", "src/main.rs"]
+        );
+    }
+
+    #[test]
     fn run_with_non_rust_files_excludes_them() {
         let directory = tree(&["src/main.rs", "README.md", "Cargo.toml", "LICENSE"]);
+        let config = config(directory.path(), &[]);
 
-        let discovery = Discovery::run(directory.path(), WalkErrorPolicy::Fail)
+        let discovery = Discovery::run(directory.path(), &config, WalkErrorPolicy::Fail)
             .expect("discovery should succeed");
 
         assert_eq!(discovered(&discovery, directory.path()), ["src/main.rs"]);
@@ -518,9 +750,14 @@ mod tests {
     #[test]
     fn run_with_nonexistent_path_returns_error() {
         let directory = tempfile::tempdir().expect("temporary directory should be created");
+        let config = config(directory.path(), &[]);
 
-        let error = Discovery::run(&directory.path().join("missing"), WalkErrorPolicy::Fail)
-            .expect_err("discovery should fail");
+        let error = Discovery::run(
+            &directory.path().join("missing"),
+            &config,
+            WalkErrorPolicy::Fail,
+        )
+        .expect_err("discovery should fail");
 
         assert!(
             format!("{error:#}").contains("failed to resolve"),
@@ -528,18 +765,61 @@ mod tests {
         );
     }
 
+    #[test]
+    fn run_with_pattern_matching_nothing_keeps_every_file() {
+        let directory = tree(&["src/main.rs", "src/lib.rs"]);
+        let config = config(directory.path(), &["vendor/", "*.py"]);
+
+        let discovery = Discovery::run(directory.path(), &config, WalkErrorPolicy::Fail)
+            .expect("discovery should succeed");
+
+        assert_eq!(
+            discovered(&discovery, directory.path()),
+            ["src/lib.rs", "src/main.rs"]
+        );
+        assert!(discovery.errors().is_empty());
+    }
+
+    #[test]
+    fn run_with_pattern_outside_the_walk_root_still_anchors_at_the_workspace() {
+        let directory = tree(&["crates/app/src/main.rs", "crates/app/src/generated.rs"]);
+        let config = config(directory.path(), &["crates/app/src/generated.rs"]);
+        let target = directory.path().join("crates").join("app");
+
+        let discovery = Discovery::run(&target, &config, WalkErrorPolicy::Fail)
+            .expect("discovery should succeed");
+
+        assert_eq!(discovered(&discovery, &target), ["src/main.rs"]);
+    }
+
     #[cfg(unix)]
     #[test]
     fn run_with_target_reached_through_a_symlink_returns_the_given_prefix() {
         let directory = tree(&["src/main.rs"]);
+        let config = config(directory.path(), &[]);
         let link = directory.path().join("link");
         std::os::unix::fs::symlink(directory.path().join("src"), &link)
             .expect("symlink should be created");
 
-        let discovery =
-            Discovery::run(&link, WalkErrorPolicy::Fail).expect("discovery should succeed");
+        let discovery = Discovery::run(&link, &config, WalkErrorPolicy::Fail)
+            .expect("discovery should succeed");
 
         assert_eq!(discovery.files(), vec![link.join("main.rs")]);
+    }
+
+    #[test]
+    fn run_with_unanchored_pattern_prunes_at_every_depth() {
+        let directory = tree(&[
+            "examples/demo.rs",
+            "crates/app/examples/demo.rs",
+            "src/main.rs",
+        ]);
+        let config = config(directory.path(), &["examples/"]);
+
+        let discovery = Discovery::run(directory.path(), &config, WalkErrorPolicy::Fail)
+            .expect("discovery should succeed");
+
+        assert_eq!(discovered(&discovery, directory.path()), ["src/main.rs"]);
     }
 
     /// Pins that an ignore file is named as one wherever the walker found it
@@ -552,10 +832,11 @@ mod tests {
         let directory = tree(&["proj/src/main.rs"]);
         std::fs::write(directory.path().join(".gitignore"), "{a,b\n")
             .expect("gitignore should be written");
+        let config = config(directory.path(), &[]);
         let target = directory.path().join("proj");
 
-        let error =
-            Discovery::run(&target, WalkErrorPolicy::Fail).expect_err("discovery should fail");
+        let error = Discovery::run(&target, &config, WalkErrorPolicy::Fail)
+            .expect_err("discovery should fail");
 
         let error = format!("{error:#}");
         assert!(
@@ -576,8 +857,9 @@ mod tests {
             "{a,b\n",
         )
         .expect("gitignore should be written");
+        let config = config(directory.path(), &[]);
 
-        let error = Discovery::run(directory.path(), WalkErrorPolicy::Fail)
+        let error = Discovery::run(directory.path(), &config, WalkErrorPolicy::Fail)
             .expect_err("discovery should fail");
 
         let error = format!("{error:#}");
@@ -603,9 +885,14 @@ mod tests {
             "{a,b\n",
         )
         .expect("gitignore should be written");
+        let config = config(directory.path(), &[]);
 
-        let discovery = Discovery::run(directory.path(), WalkErrorPolicy::ReportAndContinue)
-            .expect("discovery should succeed");
+        let discovery = Discovery::run(
+            directory.path(),
+            &config,
+            WalkErrorPolicy::ReportAndContinue,
+        )
+        .expect("discovery should succeed");
 
         assert_eq!(
             discovered(&discovery, directory.path()),
@@ -619,8 +906,9 @@ mod tests {
         let directory = tree(&["src/main.rs"]);
         std::fs::write(directory.path().join(".gitignore"), "{a,b\n")
             .expect("gitignore should be written");
+        let config = config(directory.path(), &[]);
 
-        let error = Discovery::run(directory.path(), WalkErrorPolicy::Fail)
+        let error = Discovery::run(directory.path(), &config, WalkErrorPolicy::Fail)
             .expect_err("discovery should fail");
 
         assert!(
@@ -633,10 +921,11 @@ mod tests {
     #[test]
     fn run_with_unreadable_directory_and_fail_policy_returns_error() {
         let directory = tree(&["src/main.rs", "locked/inner.rs"]);
+        let config = config(directory.path(), &[]);
         let locked = directory.path().join("locked");
         let _unreadable = make_unreadable(&locked);
 
-        let error = Discovery::run(directory.path(), WalkErrorPolicy::Fail)
+        let error = Discovery::run(directory.path(), &config, WalkErrorPolicy::Fail)
             .expect_err("discovery should fail");
 
         let error = format!("{error:#}");
@@ -658,14 +947,35 @@ mod tests {
     #[test]
     fn run_with_unreadable_directory_and_keep_going_records_the_error() {
         let directory = tree(&["src/main.rs", "locked/inner.rs"]);
+        let config = config(directory.path(), &[]);
         let locked = directory.path().join("locked");
         let _unreadable = make_unreadable(&locked);
 
-        let discovery = Discovery::run(directory.path(), WalkErrorPolicy::ReportAndContinue)
-            .expect("discovery should succeed");
+        let discovery = Discovery::run(
+            directory.path(),
+            &config,
+            WalkErrorPolicy::ReportAndContinue,
+        )
+        .expect("discovery should succeed");
 
         assert_eq!(discovered(&discovery, directory.path()), ["src/main.rs"]);
         assert_eq!(discovery.errors().len(), 1);
+    }
+
+    #[test]
+    fn run_with_workspace_configuration_excludes_the_configured_pattern() {
+        let directory = tree(&["src/main.rs", "generated/schema.rs"]);
+        std::fs::write(
+            directory.path().join("Cargo.toml"),
+            format!("{EMPTY_WORKSPACE}\n[workspace.metadata.whisker]\nignore = [\"generated/\"]\n"),
+        )
+        .expect("manifest should be written");
+        let config = WhiskerConfig::load(directory.path()).expect("configuration should load");
+
+        let discovery = Discovery::run(directory.path(), &config, WalkErrorPolicy::Fail)
+            .expect("discovery should succeed");
+
+        assert_eq!(discovered(&discovery, directory.path()), ["src/main.rs"]);
     }
 
     #[test]

--- a/crates/whisker/src/main.rs
+++ b/crates/whisker/src/main.rs
@@ -1,4 +1,5 @@
 mod commands;
+mod config;
 mod discovery;
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {

--- a/crates/whisker/tests/check.rs
+++ b/crates/whisker/tests/check.rs
@@ -127,6 +127,23 @@ fn check_package_whose_sources_a_gitignore_excludes_fails() {
         .stderr(predicate::str::contains("analyzed no files"));
 }
 
+#[test]
+fn check_package_whose_sources_the_configuration_excludes_fails() {
+    let package = package(CLEAN_SOURCE);
+    std::fs::write(
+        package.path().join("Cargo.toml"),
+        format!("{MANIFEST}\n[workspace]\n\n[workspace.metadata.whisker]\nignore = [\"src/\"]\n"),
+    )
+    .expect("manifest should be written");
+
+    whisker()
+        .arg("check")
+        .arg(package.path())
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains("analyzed no files"));
+}
+
 /// Pins the exclusion source that lives entirely outside the project
 ///
 /// The test points `GIT_CONFIG_GLOBAL` at a temporary config, so it neither


### PR DESCRIPTION
Gitignore rules cover build output and anything a checkout already hides, but
they cannot express "this is deliberately violation-laden fixture material for
the lint suite". This repository has two such directories, and git has every
reason to track them.

Projects can now declare a `[workspace.metadata.whisker]` table in the
workspace manifest holding gitignore-syntax patterns, layered on top of the
ignore files. Patterns anchor at the workspace root, so a pattern means the
same thing whether the run starts there or inside a member crate three levels
down.

The table is small on purpose, and a malformed one is a hard error. A typo'd
key that silently ignores nothing is the same class of bug as a linter that
reports a file clean because it could not read it, which is the failure this
whole area keeps producing.

Whisker's own manifest uses the table to exclude the two fixture workspaces.
That exclusion is load-bearing: both sit outside the root workspace, so
rust-analyzer has no data for them, and a later change in this stack turns "no
data" into a hard error. A test loads this repository's own configuration and
asserts no discovered file falls under them, and that whisker's own source
still does, so it cannot pass vacuously.
