### PR TITLE
Make a decoration provider state its coverage

### DIFF
--- a/crates/whisker-core/src/pipeline.rs
+++ b/crates/whisker-core/src/pipeline.rs
@@ -1,7 +1,9 @@
 use std::path::Path;
 
 use anyhow::Context as _;
-use whisker_types::{DecoratedTree, DecorationProvider, Diagnostic, Language, LintPass};
+use whisker_types::{
+    Coverage, DecoratedTree, DecorationProvider, Diagnostic, Language, LintPass, UncoveredFile,
+};
 
 use crate::tree_walker;
 
@@ -32,7 +34,8 @@ impl Pipeline {
     ///
     /// # Errors
     ///
-    /// Returns an error if the file cannot be read, parsed, or decorated.
+    /// Returns an error if the file cannot be read. Any other error comes
+    /// from [`Pipeline::run_on_source`].
     pub fn run(
         &mut self,
         path: &Path,
@@ -47,9 +50,18 @@ impl Pipeline {
 
     /// Runs the pipeline on source text directly
     ///
+    /// The pipeline offers the file to every provider, and one claim is
+    /// enough. If no provider claims the file, the pipeline returns an
+    /// [`UncoveredFile`] error instead of a false clean result.
+    ///
+    /// Decorations merge in provider order. The first decoration of a
+    /// type on a node is the one lint rules see.
+    ///
     /// # Errors
     ///
-    /// Returns an error if parsing or decoration fails.
+    /// Returns an error if parsing fails, if a provider's toolchain
+    /// malfunctions, or if no provider claims the file. An empty provider
+    /// list counts as no claims.
     pub fn run_on_source(
         &mut self,
         source: &str,
@@ -64,10 +76,26 @@ impl Pipeline {
 
         let mut decorated = DecoratedTree::new(tree, source.to_string(), path.to_path_buf());
 
+        let mut covered = Vec::new();
+        let mut gaps = Vec::new();
+
         for provider in providers {
-            provider
-                .decorate(&mut decorated)
-                .context("decoration provider failed")?;
+            let coverage = provider
+                .decorate(&decorated)
+                .with_context(|| format!("run the `{}` decoration provider", provider.name()))?;
+
+            match coverage {
+                Coverage::Covered(decorations) => covered.push(decorations),
+                Coverage::NotCovered(gap) => gaps.push((provider.name(), gap)),
+            }
+        }
+
+        if covered.is_empty() {
+            return Err(UncoveredFile::new(path.to_path_buf(), gaps).into());
+        }
+
+        for decorations in covered {
+            decorated.merge_decorations(decorations);
         }
 
         Ok(tree_walker::walk(&decorated, passes))
@@ -93,9 +121,79 @@ pub fn detect_language(path: &Path) -> anyhow::Result<Language> {
 mod tests {
     use std::path::PathBuf;
 
-    use whisker_types::{DecoratedNode, Diagnostic, Language, RuleId, Severity};
+    use whisker_types::{
+        CoverageGap, DecoratedNode, DecorationMap, Diagnostic, Language, ProviderName, RuleId,
+        Severity,
+    };
 
     use super::*;
+
+    /// Claims every file and decorates nothing
+    struct Covering;
+
+    impl DecorationProvider for Covering {
+        fn name(&self) -> ProviderName {
+            ProviderName("covering")
+        }
+
+        fn decorate(&self, _tree: &DecoratedTree) -> anyhow::Result<Coverage> {
+            Ok(Coverage::Covered(DecorationMap::new()))
+        }
+    }
+
+    /// Claims nothing, so the pipeline must treat the file as unanalyzable
+    struct Declining;
+
+    impl DecorationProvider for Declining {
+        fn name(&self) -> ProviderName {
+            ProviderName("declining")
+        }
+
+        fn decorate(&self, _tree: &DecoratedTree) -> anyhow::Result<Coverage> {
+            Ok(Coverage::NotCovered(CoverageGap::StaleSource))
+        }
+    }
+
+    /// Claims every file and puts a known marker on the root node
+    struct Decorating(&'static str);
+
+    impl DecorationProvider for Decorating {
+        fn name(&self) -> ProviderName {
+            ProviderName("decorating")
+        }
+
+        fn decorate(&self, tree: &DecoratedTree) -> anyhow::Result<Coverage> {
+            let mut decorations = DecorationMap::new();
+            decorations.insert(tree.root_node().id(), Marker(self.0));
+            Ok(Coverage::Covered(decorations))
+        }
+    }
+
+    #[derive(Debug)]
+    struct Marker(&'static str);
+
+    /// Reports whichever [`Marker`] a provider left on the root node
+    ///
+    /// The assertion runs through a lint pass, so the test observes what
+    /// a real rule would see, not what the pipeline happened to store.
+    struct ReportMarker;
+
+    impl LintPass for ReportMarker {
+        fn check_node(&mut self, node: &DecoratedNode<'_>) -> Vec<Diagnostic> {
+            if node.kind() != "source_file" {
+                return Vec::new();
+            }
+            let Some(marker) = node.decoration::<Marker>() else {
+                return Vec::new();
+            };
+            vec![Diagnostic::new(
+                RuleId("test.marker"),
+                Severity::Warn,
+                marker.0.into(),
+                node.span(),
+            )]
+        }
+    }
 
     #[test]
     fn trait_send() {
@@ -134,12 +232,62 @@ mod tests {
     }
 
     #[test]
+    fn run_on_source_with_covering_and_declining_providers_returns_diagnostics() {
+        let ts_lang: tree_sitter::Language = tree_sitter_rust::LANGUAGE.into();
+        let mut pipeline = Pipeline::new(&ts_lang).unwrap();
+        let mut passes: Vec<Box<dyn LintPass>> = vec![Box::new(ReportMarker)];
+
+        let diagnostics = pipeline
+            .run_on_source(
+                "fn main() {}",
+                Path::new("test.rs"),
+                &[
+                    &Declining as &dyn DecorationProvider,
+                    &Decorating("covered"),
+                ],
+                &mut passes,
+            )
+            .expect("one covering provider should be enough");
+
+        assert_eq!(diagnostics.len(), 1);
+        assert_eq!(diagnostics[0].message(), "covered");
+    }
+
+    #[test]
+    fn run_on_source_with_declining_provider_returns_uncovered_file() {
+        let ts_lang: tree_sitter::Language = tree_sitter_rust::LANGUAGE.into();
+        let mut pipeline = Pipeline::new(&ts_lang).unwrap();
+
+        let error = pipeline
+            .run_on_source(
+                "fn main() {}",
+                Path::new("test.rs"),
+                &[&Declining as &dyn DecorationProvider],
+                &mut Vec::new(),
+            )
+            .expect_err("a declining provider should not cover the file");
+
+        let uncovered = error
+            .downcast_ref::<UncoveredFile>()
+            .expect("should be an UncoveredFile");
+        assert_eq!(uncovered.file(), Path::new("test.rs"));
+        assert_eq!(uncovered.gaps().len(), 1);
+        assert_eq!(uncovered.gaps()[0].0, ProviderName("declining"));
+        assert_eq!(uncovered.gaps()[0].1, CoverageGap::StaleSource);
+    }
+
+    #[test]
     fn run_on_source_with_empty_passes_produces_no_diagnostics() {
         let ts_lang: tree_sitter::Language = tree_sitter_rust::LANGUAGE.into();
         let mut pipeline = Pipeline::new(&ts_lang).unwrap();
 
         let diagnostics = pipeline
-            .run_on_source("fn main() {}", Path::new("test.rs"), &[], &mut Vec::new())
+            .run_on_source(
+                "fn main() {}",
+                Path::new("test.rs"),
+                &[&Covering as &dyn DecorationProvider],
+                &mut Vec::new(),
+            )
             .unwrap();
 
         assert!(diagnostics.is_empty());
@@ -168,11 +316,84 @@ mod tests {
         let mut passes: Vec<Box<dyn whisker_types::LintPass>> = vec![Box::new(AlwaysWarn)];
 
         let diagnostics = pipeline
-            .run_on_source("fn main() {}", Path::new("test.rs"), &[], &mut passes)
+            .run_on_source(
+                "fn main() {}",
+                Path::new("test.rs"),
+                &[&Covering as &dyn DecorationProvider],
+                &mut passes,
+            )
             .unwrap();
 
         assert_eq!(diagnostics.len(), 1);
         assert_eq!(diagnostics[0].message(), "found function");
+    }
+
+    #[test]
+    fn run_on_source_with_no_providers_returns_uncovered_file() {
+        let ts_lang: tree_sitter::Language = tree_sitter_rust::LANGUAGE.into();
+        let mut pipeline = Pipeline::new(&ts_lang).unwrap();
+
+        let error = pipeline
+            .run_on_source("fn main() {}", Path::new("test.rs"), &[], &mut Vec::new())
+            .expect_err("no providers means nothing can be analyzed");
+
+        let uncovered = error
+            .downcast_ref::<UncoveredFile>()
+            .expect("should be an UncoveredFile");
+        assert!(uncovered.gaps().is_empty());
+        assert!(
+            uncovered
+                .to_string()
+                .contains("no decoration providers were configured"),
+            "unexpected message: {uncovered}"
+        );
+    }
+
+    #[test]
+    fn run_on_source_with_two_decorating_providers_keeps_first_decoration() {
+        let ts_lang: tree_sitter::Language = tree_sitter_rust::LANGUAGE.into();
+        let mut pipeline = Pipeline::new(&ts_lang).unwrap();
+        let mut passes: Vec<Box<dyn LintPass>> = vec![Box::new(ReportMarker)];
+
+        let diagnostics = pipeline
+            .run_on_source(
+                "fn main() {}",
+                Path::new("test.rs"),
+                &[
+                    &Decorating("first") as &dyn DecorationProvider,
+                    &Decorating("second"),
+                ],
+                &mut passes,
+            )
+            .expect("both providers cover the file");
+
+        assert_eq!(diagnostics.len(), 1);
+        assert_eq!(diagnostics[0].message(), "first");
+    }
+
+    #[test]
+    fn run_on_source_with_uncovered_file_does_not_run_passes() {
+        struct Exploding;
+        impl whisker_types::LintPass for Exploding {
+            fn check_node(&mut self, _node: &DecoratedNode<'_>) -> Vec<Diagnostic> {
+                panic!("lint passes must not run on an uncovered file");
+            }
+        }
+
+        let ts_lang: tree_sitter::Language = tree_sitter_rust::LANGUAGE.into();
+        let mut pipeline = Pipeline::new(&ts_lang).unwrap();
+        let mut passes: Vec<Box<dyn whisker_types::LintPass>> = vec![Box::new(Exploding)];
+
+        let error = pipeline
+            .run_on_source(
+                "fn main() {}",
+                Path::new("test.rs"),
+                &[&Declining as &dyn DecorationProvider],
+                &mut passes,
+            )
+            .expect_err("a declining provider should not cover the file");
+
+        assert!(error.downcast_ref::<UncoveredFile>().is_some());
     }
 
     mod prop {
@@ -206,7 +427,7 @@ mod tests {
                 let result = pipeline.run_on_source(
                     &source,
                     Path::new("test.rs"),
-                    &[],
+                    &[&Covering as &dyn DecorationProvider],
                     &mut Vec::new(),
                 );
 
@@ -224,11 +445,29 @@ mod tests {
                 let result = pipeline.run_on_source(
                     &source,
                     Path::new("test.rs"),
-                    &[],
+                    &[&Covering as &dyn DecorationProvider],
                     &mut Vec::new(),
                 );
 
                 prop_assert!(result.is_ok());
+            }
+
+            #[test]
+            fn run_on_source_without_providers_always_reports_uncovered(
+                source in "(fn [a-z]+\\(\\) \\{\\}\n){0,5}",
+            ) {
+                let ts_lang: tree_sitter::Language = tree_sitter_rust::LANGUAGE.into();
+                let mut pipeline = Pipeline::new(&ts_lang).unwrap();
+
+                let result = pipeline.run_on_source(
+                    &source,
+                    Path::new("test.rs"),
+                    &[],
+                    &mut Vec::new(),
+                );
+
+                let error = result.expect_err("no providers can never cover a file");
+                prop_assert!(error.downcast_ref::<UncoveredFile>().is_some());
             }
         }
     }

--- a/crates/whisker-rust/src/lib.rs
+++ b/crates/whisker-rust/src/lib.rs
@@ -17,7 +17,8 @@ mod tests {
     use std::path::PathBuf;
 
     use whisker_types::{
-        DecoratedNode, DecoratedTree, DecorationProvider, Diagnostic, RuleId, Severity,
+        Coverage, CoverageGap, DecoratedNode, DecoratedTree, DecorationMap, DecorationProvider,
+        Diagnostic, RuleId, Severity,
     };
 
     use super::*;
@@ -64,20 +65,45 @@ mod tests {
     }
 
     #[test]
-    fn provider_decorate_succeeds_on_empty_tree() {
+    fn decorate_with_empty_provider_leaves_existing_decorations_intact() {
         let provider = RustDecorationProvider::empty();
-        let mut tree = parse_rust("");
-        provider.decorate(&mut tree).expect("should succeed");
+        let mut tree = parse_rust("fn main() {}");
+        let root_id = tree.root_node().id();
+        let mut staged = DecorationMap::new();
+        staged.insert(root_id, 7u32);
+        tree.merge_decorations(staged);
+
+        let coverage = provider.decorate(&tree).expect("should succeed");
+
+        match coverage {
+            Coverage::Covered(_) => panic!("an empty VFS cannot cover any file"),
+            Coverage::NotCovered(CoverageGap::OutsideRoot { .. }) => {}
+            Coverage::NotCovered(gap) => panic!("unexpected gap: {gap}"),
+        }
+        assert_eq!(tree.root_node().decoration::<u32>(), Some(&7));
     }
 
     #[test]
-    fn provider_decorate_does_not_add_decorations() {
+    fn decorate_with_empty_provider_reports_outside_workspace() {
         let provider = RustDecorationProvider::empty();
-        let mut tree = parse_rust("fn main() {}");
-        provider.decorate(&mut tree).expect("should succeed");
+        let tree = parse_rust("");
 
-        let root = tree.root_node();
-        assert!(root.decoration::<u32>().is_none());
+        let coverage = provider.decorate(&tree).expect("should succeed");
+
+        match coverage {
+            Coverage::Covered(_) => panic!("an empty VFS cannot cover any file"),
+            Coverage::NotCovered(CoverageGap::OutsideRoot { .. }) => {}
+            Coverage::NotCovered(gap) => panic!("unexpected gap: {gap}"),
+        }
+    }
+
+    #[test]
+    fn name_returns_rust() {
+        let provider = RustDecorationProvider::empty();
+
+        let name = provider.name();
+
+        assert_eq!(name.as_str(), "rust");
     }
 
     #[test]

--- a/crates/whisker-rust/src/provider.rs
+++ b/crates/whisker-rust/src/provider.rs
@@ -1,15 +1,19 @@
 use std::path::Path;
-use std::sync::Mutex;
+use std::sync::{Arc, Mutex};
 
 use anyhow::Context as _;
 use ra_ap_hir::{Adt, HasAttrs, HirDisplay, Semantics, attach_db};
-use ra_ap_ide_db::RootDatabase;
+use ra_ap_ide_db::base_db::SourceDatabase as _;
+use ra_ap_ide_db::{ChangeWithProcMacros, RootDatabase};
 use ra_ap_load_cargo::{LoadCargoConfig, ProcMacroServerChoice};
-use ra_ap_project_model::CargoConfig;
+use ra_ap_project_model::{CargoConfig, ProjectManifest, ProjectWorkspace};
 use ra_ap_syntax::AstNode;
 use ra_ap_syntax::ast;
-use ra_ap_vfs::Vfs;
-use whisker_types::{DecoratedNode, DecoratedTree, DecorationProvider};
+use ra_ap_vfs::{AbsPathBuf, FileExcluded, FileId, Vfs, VfsPath};
+use whisker_types::{
+    Coverage, CoverageGap, DecoratedNode, DecoratedTree, DecorationMap, DecorationProvider,
+    ProviderName,
+};
 
 use crate::decorations::{AdtFlags, FnSignature, ResolvedType};
 
@@ -20,30 +24,46 @@ use crate::decorations::{AdtFlags, FnSignature, ResolvedType};
 /// decorate phase. The workspace load is expensive and happens once; the
 /// per-file decoration pass is relatively cheap.
 ///
+/// The provider stores the workspace root. Every gap except
+/// [`CoverageGap::StaleSource`] names this root.
+///
 /// # Examples
 ///
 /// ```ignore
 /// let provider = RustDecorationProvider::load(Path::new("."))?;
-/// provider.decorate(&mut tree)?;
+/// let coverage = provider.decorate(&tree)?;
 /// ```
 pub struct RustDecorationProvider {
     db: Mutex<RootDatabase>,
     vfs: Vfs,
+    root: Arc<Path>,
 }
 
 impl RustDecorationProvider {
+    /// Identifies this provider in diagnostics
+    const NAME: ProviderName = ProviderName("rust");
+
     /// Loads a Cargo workspace for semantic analysis
+    ///
+    /// rust-analyzer discovers the nearest manifest above
+    /// `workspace_root`, and Cargo expands that manifest to its whole
+    /// workspace. A gap that names a workspace names the discovered
+    /// root, not `workspace_root`. Analysis enables the `test` cfg, so
+    /// code under `#[cfg(test)]` resolves like any other code.
     ///
     /// This is an expensive operation that builds rust-analyzer's internal
     /// database from the project's Cargo.toml. Call this once at startup.
     ///
     /// # Errors
     ///
-    /// Returns an error if the workspace cannot be loaded (missing
-    /// Cargo.toml, dependency resolution failure, etc.).
+    /// Returns an error if the current directory cannot be read, if
+    /// `workspace_root` is not valid UTF-8, or if discovery finds no
+    /// Cargo project. The load also fails when workspace resolution, the
+    /// build scripts, or the analysis database build fails.
     pub fn load(workspace_root: &Path) -> anyhow::Result<Self> {
         let cargo_config = CargoConfig {
             sysroot: Some(ra_ap_project_model::RustLibSource::Discover),
+            set_test: true,
             ..CargoConfig::default()
         };
         let load_config = LoadCargoConfig {
@@ -54,49 +74,169 @@ impl RustDecorationProvider {
             proc_macro_processes: 0,
         };
 
-        let manifest = workspace_root.join("Cargo.toml");
-        let manifest = if manifest.exists() {
-            manifest
-        } else {
-            workspace_root.to_path_buf()
-        };
+        let cwd = std::env::current_dir().context("read the current directory")?;
+        let discover_from = cwd.join(workspace_root);
+        anyhow::ensure!(
+            discover_from.to_str().is_some(),
+            "{} is not valid UTF-8, and rust-analyzer only addresses UTF-8 paths",
+            discover_from.display()
+        );
+        let discover_from = AbsPathBuf::assert_utf8(discover_from);
+        let manifest = ProjectManifest::discover_single(&discover_from)
+            .with_context(|| format!("discover a Cargo project at {}", workspace_root.display()))?;
 
-        let (db, vfs, _proc_macro_client) =
-            ra_ap_load_cargo::load_workspace_at(&manifest, &cargo_config, &load_config, &|_msg| {})
-                .context("failed to load Cargo workspace for analysis")?;
+        let mut workspace = ProjectWorkspace::load(manifest, &cargo_config, &|_msg| {})
+            .with_context(|| {
+                format!(
+                    "resolve the Cargo workspace discovered from {}",
+                    workspace_root.display()
+                )
+            })?;
+
+        if load_config.load_out_dirs_from_check {
+            let build_scripts = workspace
+                .run_build_scripts(&cargo_config, &|_msg| {})
+                .context("run build scripts for the workspace")?;
+            workspace.set_build_scripts(build_scripts);
+        }
+
+        let root: Arc<Path> = Arc::from(workspace.workspace_root().as_ref() as &Path);
+
+        let (mut db, vfs, _proc_macro_client) =
+            ra_ap_load_cargo::load_workspace(workspace, &cargo_config.extra_env, &load_config)
+                .context("build the analysis database for the workspace")?;
+
+        give_text_to_files_that_have_none(&mut db, &vfs, &root);
 
         Ok(Self {
             db: Mutex::new(db),
             vfs,
+            root,
         })
     }
 
-    /// Creates a no-op provider that attaches no decorations
+    /// Creates a provider that holds an empty workspace
     ///
-    /// Useful for testing syntax-only lints or when semantic analysis is
-    /// not needed.
+    /// The provider declines every file with
+    /// [`CoverageGap::OutsideRoot`]. Do not use it as a fallback when
+    /// [`RustDecorationProvider::load`] fails: the pipeline would then
+    /// refuse every file.
+    ///
+    /// # Examples
+    ///
+    /// ```ignore
+    /// let provider = RustDecorationProvider::empty();
+    /// let coverage = provider.decorate(&tree)?;
+    /// ```
     pub fn empty() -> Self {
         Self {
             db: Mutex::new(RootDatabase::default()),
             vfs: Vfs::default(),
+            root: Arc::from(Path::new(".")),
+        }
+    }
+
+    /// Classifies a file rust-analyzer never interned
+    ///
+    /// A path under the loaded root reports [`CoverageGap::Unreachable`],
+    /// because the toolchain could have known the file and did not. Any
+    /// other path reports [`CoverageGap::OutsideRoot`].
+    fn gap_for_unknown_file(&self, file_path: &Path) -> CoverageGap {
+        if file_path.starts_with(&*self.root) {
+            CoverageGap::Unreachable {
+                root: Arc::clone(&self.root),
+            }
+        } else {
+            CoverageGap::OutsideRoot {
+                root: Arc::clone(&self.root),
+            }
         }
     }
 }
 
+/// Records lossy UTF-8 text for interned files under `root` that have none
+///
+/// The load interns a file whose bytes are not UTF-8, but records no
+/// text for it. rust-analyzer panics when it later reads a file that has
+/// no recorded text. The read can happen while rust-analyzer analyzes a
+/// sibling file, so the guard in `decorate` cannot prevent the panic.
+/// This function stores the bytes as lossy UTF-8 text, so the database
+/// always has text to read. The source-match guard in `decorate` still
+/// declines the repaired file, because its lossy text differs from the
+/// text whisker parsed.
+///
+/// The check covers only files under `root`, so it does not read the
+/// sysroot or the dependencies on every run. It covers every extension,
+/// because `include_str!` makes rust-analyzer read non-Rust files as
+/// well.
+fn give_text_to_files_that_have_none(db: &mut RootDatabase, vfs: &Vfs, root: &Path) {
+    let mut lossy = Vec::new();
+
+    for (file_id, vfs_path) in vfs.iter() {
+        let Some(path) = vfs_path.as_path() else {
+            continue;
+        };
+        let path: &Path = path.as_ref();
+        if !path.starts_with(root) {
+            continue;
+        }
+        let Ok(bytes) = std::fs::read(path) else {
+            continue;
+        };
+        if std::str::from_utf8(&bytes).is_ok() {
+            continue;
+        }
+        lossy.push((file_id, String::from_utf8_lossy(&bytes).into_owned()));
+    }
+
+    if lossy.is_empty() {
+        return;
+    }
+
+    let mut change = ChangeWithProcMacros::default();
+    for (file_id, text) in lossy {
+        change.change_file(file_id, Some(text));
+    }
+    db.apply_change(change);
+}
+
 impl DecorationProvider for RustDecorationProvider {
-    /// Attaches type decorations to the tree's nodes
+    fn name(&self) -> ProviderName {
+        Self::NAME
+    }
+
+    /// Attaches type decorations to the tree's nodes, or declines the file
+    ///
+    /// The provider covers a file only when four conditions hold. The VFS
+    /// must know the file. The toolchain must not exclude it. A crate
+    /// module must reach it. The tree's source must equal the text the
+    /// database holds. Each failed condition maps to a [`CoverageGap`]
+    /// variant.
     ///
     /// # Errors
     ///
-    /// Returns an error if semantic analysis fails.
-    fn decorate(&self, tree: &mut DecoratedTree) -> anyhow::Result<()> {
+    /// Returns an error if the file path cannot be made absolute or the
+    /// database lock is poisoned. A file this provider knows nothing about
+    /// is a [`Coverage::NotCovered`] verdict, not an error.
+    fn decorate(&self, tree: &DecoratedTree) -> anyhow::Result<Coverage> {
         let file_path = tree.file();
-        let file_path = std::path::absolute(file_path).unwrap_or_else(|_| file_path.to_path_buf());
+        let file_path = std::path::absolute(file_path)
+            .with_context(|| format!("resolve {} to an absolute path", file_path.display()))?;
 
-        let vfs_path = ra_ap_vfs::VfsPath::new_real_path(file_path.to_string_lossy().to_string());
-        let Some((file_id, _excluded)) = self.vfs.file_id(&vfs_path) else {
-            return Ok(());
+        let vfs_path = VfsPath::new_real_path(file_path.to_string_lossy().to_string());
+
+        let Some((file_id, excluded)) = self.vfs.file_id(&vfs_path) else {
+            return Ok(Coverage::NotCovered(self.gap_for_unknown_file(&file_path)));
         };
+
+        match excluded {
+            FileExcluded::Yes => {
+                return Ok(Coverage::NotCovered(CoverageGap::ExcludedByToolchain {
+                    root: Arc::clone(&self.root),
+                }));
+            }
+            FileExcluded::No => {}
+        }
 
         let db = self
             .db
@@ -106,77 +246,85 @@ impl DecorationProvider for RustDecorationProvider {
         let mut targets = Vec::new();
         collect_targets(&tree.root_node(), &mut targets);
 
-        let results: Vec<Decoration> = attach_db(&*db, || {
+        let coverage = attach_db(&*db, || {
             let sema = Semantics::new(&*db);
-            let source_file = sema.parse_guess_edition(file_id);
-            let syntax = source_file.syntax().clone();
 
-            let ctx = DecorateCtx {
-                sema: &sema,
-                syntax: &syntax,
-            };
-
-            let mut decorations = Vec::new();
-            for target in &targets {
-                match target {
-                    Target::Function {
-                        node_id,
-                        start_byte,
-                    } => {
-                        if let Some(sig) = resolve_function(&ctx, *start_byte) {
-                            decorations.push(Decoration::FnSig(*node_id, sig));
-                        }
-                    }
-                    Target::MatchScrutinee {
-                        scrutinee_start_byte,
-                        scrutinee_node_id,
-                    } => {
-                        if let Some((ty, flags)) =
-                            resolve_match_scrutinee(&ctx, *scrutinee_start_byte)
-                        {
-                            decorations.push(Decoration::Type(*scrutinee_node_id, ty));
-                            if let Some(f) = flags {
-                                decorations.push(Decoration::Adt(*scrutinee_node_id, f));
-                            }
-                        }
-                    }
-                    Target::IfElse {
-                        else_start_byte,
-                        else_node_id,
-                    } => {
-                        if let Some(ty) = resolve_expr_type(&ctx, *else_start_byte) {
-                            decorations.push(Decoration::Type(*else_node_id, ty));
-                        }
-                    }
-                    Target::TryExpr {
-                        operand_start_byte,
-                        operand_node_id,
-                    } => {
-                        if let Some(ty) = resolve_expr_type(&ctx, *operand_start_byte) {
-                            decorations.push(Decoration::Type(*operand_node_id, ty));
-                        }
-                    }
-                }
+            if sema.file_to_module_def(file_id).is_none() {
+                return Coverage::NotCovered(CoverageGap::Unreachable {
+                    root: Arc::clone(&self.root),
+                });
             }
-            decorations
+
+            let db_text: &str = db.file_text(file_id).text(&*db);
+            if db_text != tree.source() {
+                return Coverage::NotCovered(CoverageGap::StaleSource);
+            }
+
+            Coverage::Covered(resolve_targets(&sema, file_id, &targets))
         });
 
-        for decoration in results {
-            match decoration {
-                Decoration::Type(id, ty) => tree.decorations_mut().insert(id, ty),
-                Decoration::Adt(id, flags) => tree.decorations_mut().insert(id, flags),
-                Decoration::FnSig(id, sig) => tree.decorations_mut().insert(id, sig),
-            }
-        }
-
-        Ok(())
+        Ok(coverage)
     }
 }
 
-enum Decoration {
-    Type(usize, ResolvedType),
-    Adt(usize, AdtFlags),
-    FnSig(usize, FnSignature),
+/// Resolves every collected target against rust-analyzer's parse
+///
+/// The caller has already checked that `file_id` belongs to a module and
+/// that its recorded text matches the source the targets index into.
+fn resolve_targets(
+    sema: &Semantics<'_, RootDatabase>,
+    file_id: FileId,
+    targets: &[Target],
+) -> DecorationMap {
+    let source_file = sema.parse_guess_edition(file_id);
+    let syntax = source_file.syntax().clone();
+
+    let ctx = DecorateCtx {
+        sema,
+        syntax: &syntax,
+    };
+
+    let mut decorations = DecorationMap::new();
+    for target in targets {
+        match target {
+            Target::Function {
+                node_id,
+                start_byte,
+            } => {
+                if let Some(sig) = resolve_function(&ctx, *start_byte) {
+                    decorations.insert(*node_id, sig);
+                }
+            }
+            Target::MatchScrutinee {
+                scrutinee_start_byte,
+                scrutinee_node_id,
+            } => {
+                if let Some((ty, flags)) = resolve_match_scrutinee(&ctx, *scrutinee_start_byte) {
+                    decorations.insert(*scrutinee_node_id, ty);
+                    if let Some(flags) = flags {
+                        decorations.insert(*scrutinee_node_id, flags);
+                    }
+                }
+            }
+            Target::IfElse {
+                else_start_byte,
+                else_node_id,
+            } => {
+                if let Some(ty) = resolve_expr_type(&ctx, *else_start_byte) {
+                    decorations.insert(*else_node_id, ty);
+                }
+            }
+            Target::TryExpr {
+                operand_start_byte,
+                operand_node_id,
+            } => {
+                if let Some(ty) = resolve_expr_type(&ctx, *operand_start_byte) {
+                    decorations.insert(*operand_node_id, ty);
+                }
+            }
+        }
+    }
+    decorations
 }
 
 enum Target {
@@ -239,12 +387,12 @@ fn collect_targets(node: &DecoratedNode<'_>, targets: &mut Vec<Target>) {
     }
 }
 
-struct DecorateCtx<'a> {
-    sema: &'a Semantics<'a, RootDatabase>,
+struct DecorateCtx<'a, 'db> {
+    sema: &'a Semantics<'db, RootDatabase>,
     syntax: &'a ra_ap_syntax::SyntaxNode,
 }
 
-impl DecorateCtx<'_> {
+impl DecorateCtx<'_, '_> {
     fn display_type(&self, ty: &ra_ap_hir::Type<'_>, func: &ra_ap_hir::Function) -> String {
         let krate = func.module(self.sema.db).krate(self.sema.db);
         let target = krate.to_display_target(self.sema.db);
@@ -253,7 +401,7 @@ impl DecorateCtx<'_> {
 }
 
 fn find_enclosing_fn(
-    ctx: &DecorateCtx<'_>,
+    ctx: &DecorateCtx<'_, '_>,
     offset: ra_ap_syntax::TextSize,
 ) -> Option<ra_ap_hir::Function> {
     let fn_node = ctx
@@ -265,14 +413,14 @@ fn find_enclosing_fn(
     ctx.sema.to_def(&fn_node)
 }
 
-fn find_expr_at(ctx: &DecorateCtx<'_>, offset: ra_ap_syntax::TextSize) -> Option<ast::Expr> {
+fn find_expr_at(ctx: &DecorateCtx<'_, '_>, offset: ra_ap_syntax::TextSize) -> Option<ast::Expr> {
     ctx.syntax
         .token_at_offset(offset)
         .right_biased()
         .and_then(|t| t.parent_ancestors().find_map(ast::Expr::cast))
 }
 
-fn resolve_function(ctx: &DecorateCtx<'_>, start_byte: usize) -> Option<FnSignature> {
+fn resolve_function(ctx: &DecorateCtx<'_, '_>, start_byte: usize) -> Option<FnSignature> {
     let offset = ra_ap_syntax::TextSize::from(start_byte as u32);
     let func = find_enclosing_fn(ctx, offset)?;
 
@@ -295,7 +443,7 @@ fn resolve_function(ctx: &DecorateCtx<'_>, start_byte: usize) -> Option<FnSignat
 }
 
 fn resolve_match_scrutinee(
-    ctx: &DecorateCtx<'_>,
+    ctx: &DecorateCtx<'_, '_>,
     scrutinee_start_byte: usize,
 ) -> Option<(ResolvedType, Option<AdtFlags>)> {
     let offset = ra_ap_syntax::TextSize::from(scrutinee_start_byte as u32);
@@ -326,7 +474,7 @@ fn resolve_match_scrutinee(
     Some((resolved, flags))
 }
 
-fn resolve_expr_type(ctx: &DecorateCtx<'_>, start_byte: usize) -> Option<ResolvedType> {
+fn resolve_expr_type(ctx: &DecorateCtx<'_, '_>, start_byte: usize) -> Option<ResolvedType> {
     let offset = ra_ap_syntax::TextSize::from(start_byte as u32);
     let expr = find_expr_at(ctx, offset)?;
     let ty_info = ctx.sema.type_of_expr(&expr)?;
@@ -371,7 +519,49 @@ fn extract_result_error_type(display: &str) -> Option<String> {
 
 #[cfg(test)]
 mod tests {
+    use std::path::PathBuf;
+
     use super::*;
+
+    /// Parses `source` as the contents of `file_path`, without decorating it
+    fn parse_rust(source: &str, file_path: PathBuf) -> DecoratedTree {
+        let mut parser = tree_sitter::Parser::new();
+        parser
+            .set_language(&crate::language())
+            .expect("the Rust grammar should load");
+        let tree = parser.parse(source, None).expect("should parse");
+
+        DecoratedTree::new(tree, source.to_string(), file_path)
+    }
+
+    /// Exercises the exclusion guard, which no fixture workspace can reach
+    ///
+    /// The VFS keeps an excluded file's identity but no contents, so any
+    /// database query about it panics. The test seeds the state directly,
+    /// because the load whisker performs never marks a file excluded.
+    #[test]
+    fn decorate_with_excluded_file_reports_excluded_by_toolchain() {
+        let file_path =
+            std::path::absolute("excluded_by_toolchain.rs").expect("should be made absolute");
+        let mut vfs = Vfs::default();
+        vfs.insert_excluded_file(VfsPath::new_real_path(
+            file_path.to_string_lossy().to_string(),
+        ));
+        let provider = RustDecorationProvider {
+            db: Mutex::new(RootDatabase::default()),
+            vfs,
+            root: Arc::from(Path::new("/")),
+        };
+        let tree = parse_rust("fn main() {}\n", file_path);
+
+        let coverage = provider.decorate(&tree).expect("decorate should succeed");
+
+        match coverage {
+            Coverage::Covered(_) => panic!("an excluded file must not be covered"),
+            Coverage::NotCovered(CoverageGap::ExcludedByToolchain { .. }) => {}
+            Coverage::NotCovered(gap) => panic!("unexpected gap: {gap}"),
+        }
+    }
 
     #[test]
     fn extract_result_error_type_simple() {
@@ -399,6 +589,25 @@ mod tests {
         assert_eq!(
             extract_result_error_type("Result<(), Box<dyn Error>>"),
             Some("Box<dyn Error>".into())
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn load_with_non_utf8_path_returns_error() {
+        use std::ffi::OsStr;
+        use std::os::unix::ffi::OsStrExt as _;
+        use std::path::PathBuf;
+
+        let path = PathBuf::from(OsStr::from_bytes(b"whisker-\xff-not-utf8"));
+
+        let Err(error) = RustDecorationProvider::load(&path) else {
+            panic!("a path that is not UTF-8 should be rejected");
+        };
+
+        assert!(
+            error.to_string().contains("not valid UTF-8"),
+            "unexpected error: {error:#}"
         );
     }
 }

--- a/crates/whisker-rust/tests/fixtures/sample_project/orphan.rs
+++ b/crates/whisker-rust/tests/fixtures/sample_project/orphan.rs
@@ -1,0 +1,10 @@
+//! Holds code that no crate's module tree reaches
+//!
+//! Cargo never compiles this file, because it sits beside `Cargo.toml` and
+//! outside the crate's `src` directory. rust-analyzer's VFS still interns
+//! it, because the package directory is a source root. Whisker once
+//! reported such a file clean, although no lint rule resolved anything.
+
+pub fn orphan() -> i32 {
+    42
+}

--- a/crates/whisker-rust/tests/fixtures/sample_project/src/lib.rs
+++ b/crates/whisker-rust/tests/fixtures/sample_project/src/lib.rs
@@ -58,3 +58,15 @@ pub fn bool_param(verbose: bool) -> &'static str {
 pub struct Config {
     pub debug: bool,
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    pub fn match_on_enum_under_cfg_test(color: Color) {
+        match color {
+            Color::Red => {}
+            _ => {}
+        }
+    }
+}

--- a/crates/whisker-rust/tests/provider_integration.rs
+++ b/crates/whisker-rust/tests/provider_integration.rs
@@ -3,12 +3,47 @@ use std::sync::OnceLock;
 
 use whisker_rust::RustDecorationProvider;
 use whisker_rust::decorations::{AdtFlags, FnSignature, ResolvedType};
-use whisker_types::{DecoratedNode, DecoratedTree, DecorationProvider};
+use whisker_types::{Coverage, CoverageGap, DecoratedNode, DecoratedTree, DecorationProvider};
 
 static PROVIDER: OnceLock<RustDecorationProvider> = OnceLock::new();
 
 fn fixture_path() -> PathBuf {
     Path::new(env!("CARGO_MANIFEST_DIR")).join("tests/fixtures/sample_project")
+}
+
+/// Writes a Cargo project whose crate reaches two files that are not UTF-8
+///
+/// This function generates the project at run time, because a committed
+/// file that is not valid UTF-8 rarely survives review or an editor
+/// intact. The project is a separate package, so the bad module cannot
+/// break analysis of any other crate.
+///
+/// The two files cover both routes on which rust-analyzer reads text.
+/// It reads the module `src/bad.rs` when it builds the definition map.
+/// It reads the [`include_str!`] target `src/notes.md` when it infers
+/// the body that includes it.
+fn not_utf8_project() -> PathBuf {
+    let root = Path::new(env!("CARGO_TARGET_TMPDIR")).join("not_utf8_project");
+    std::fs::create_dir_all(root.join("src")).expect("should create the fixture directories");
+    std::fs::write(
+        root.join("Cargo.toml"),
+        "[workspace]\n\n[package]\nname = \"not_utf8_project\"\nversion = \"0.1.0\"\nedition = \"2024\"\n",
+    )
+    .expect("should write the fixture manifest");
+    std::fs::write(
+        root.join("src/lib.rs"),
+        "pub mod bad;\n\npub enum Color {\n    Red,\n    Green,\n}\n\npub fn match_on_enum(color: Color) {\n    let _notes = include_str!(\"notes.md\");\n    match color {\n        Color::Red => {}\n        _ => {}\n    }\n}\n",
+    )
+    .expect("should write the fixture crate root");
+    std::fs::write(
+        root.join("src/bad.rs"),
+        b"pub fn f() -> u8 { b\"\xff\xfe\"[0] }\n",
+    )
+    .expect("should write the fixture module that is not UTF-8");
+    std::fs::write(root.join("src/notes.md"), b"notes \xff\xfe\n")
+        .expect("should write the fixture include_str target that is not UTF-8");
+
+    root
 }
 
 /// Loads the fixture workspace once and lends it to every test
@@ -24,18 +59,32 @@ fn load_provider() -> &'static RustDecorationProvider {
         .get_or_init(|| RustDecorationProvider::load(&fixture_path()).expect("should load fixture"))
 }
 
-fn parse_and_decorate_fixture(provider: &RustDecorationProvider) -> DecoratedTree {
-    let file_path = fixture_path().join("src/lib.rs");
-    let source = std::fs::read_to_string(&file_path).expect("should read fixture source");
-
+fn parse_source(source: String, file_path: PathBuf) -> DecoratedTree {
     let mut parser = tree_sitter::Parser::new();
     parser.set_language(&whisker_rust::language()).unwrap();
     let tree = parser.parse(&source, None).unwrap();
 
-    let mut decorated = DecoratedTree::new(tree, source, file_path);
-    provider
-        .decorate(&mut decorated)
+    DecoratedTree::new(tree, source, file_path)
+}
+
+fn parse_fixture_file(relative: &str) -> DecoratedTree {
+    let file_path = fixture_path().join(relative);
+    let source = std::fs::read_to_string(&file_path).expect("should read fixture source");
+
+    parse_source(source, file_path)
+}
+
+fn parse_and_decorate_fixture(provider: &RustDecorationProvider) -> DecoratedTree {
+    let mut decorated = parse_fixture_file("src/lib.rs");
+
+    let coverage = provider
+        .decorate(&decorated)
         .expect("decorate should succeed");
+
+    match coverage {
+        Coverage::Covered(decorations) => decorated.merge_decorations(decorations),
+        Coverage::NotCovered(gap) => panic!("fixture should be covered, got: {gap}"),
+    }
     decorated
 }
 
@@ -64,6 +113,138 @@ fn find_first_node_of_kind<'a>(node: &DecoratedNode<'a>, kind: &str) -> Option<D
         }
     }
     None
+}
+
+/// Checks that a module that is not UTF-8 leaves its siblings covered
+///
+/// Before the load repaired such files, rust-analyzer panicked over the
+/// missing file text and aborted the whole test binary. The fixture
+/// holds a bad module and a bad [`include_str!`] target, so a repair
+/// narrowed to Rust source also fails this test.
+#[test]
+fn decorate_with_a_module_that_is_not_utf8_covers_its_siblings() {
+    let root = not_utf8_project();
+    let provider = RustDecorationProvider::load(&root).expect("should load the fixture");
+    let file_path = root.join("src/lib.rs");
+    let source = std::fs::read_to_string(&file_path).expect("should read the fixture crate root");
+    let mut tree = parse_source(source, file_path);
+
+    let coverage = provider.decorate(&tree).expect("decorate should succeed");
+
+    match coverage {
+        Coverage::Covered(decorations) => tree.merge_decorations(decorations),
+        Coverage::NotCovered(gap) => panic!("the crate root should be covered, got: {gap}"),
+    }
+    let root_node = tree.root_node();
+    let func =
+        find_function_by_name(&root_node, "match_on_enum").expect("should find the function");
+    let match_expr =
+        find_first_node_of_kind(&func, "match_expression").expect("should find match_expression");
+    let scrutinee = match_expr
+        .child_by_field_name("value")
+        .expect("match should have value field");
+    let ty = scrutinee
+        .decoration::<ResolvedType>()
+        .expect("scrutinee should have ResolvedType");
+    assert!(ty.is_enum(), "Color should be an enum");
+}
+
+/// Checks that code under `#[cfg(test)]` resolves like any other code
+///
+/// Cargo leaves `test` out of the cfg options by default. Without it,
+/// every test block resolves to nothing and whisker reports the file
+/// clean.
+#[test]
+fn decorate_with_code_under_cfg_test_resolves_types() {
+    let provider = load_provider();
+    let tree = parse_and_decorate_fixture(provider);
+    let root = tree.root_node();
+
+    let func = find_function_by_name(&root, "match_on_enum_under_cfg_test")
+        .expect("should find match_on_enum_under_cfg_test");
+
+    let match_expr =
+        find_first_node_of_kind(&func, "match_expression").expect("should find match_expression");
+    let scrutinee = match_expr
+        .child_by_field_name("value")
+        .expect("match should have value field");
+    let ty = scrutinee
+        .decoration::<ResolvedType>()
+        .expect("a scrutinee under cfg(test) should have ResolvedType");
+    assert!(ty.is_enum(), "Color should be an enum");
+}
+
+#[test]
+fn decorate_with_file_outside_workspace_reports_outside_workspace() {
+    let provider = load_provider();
+    let tree = parse_source(
+        "fn main() {}\n".to_string(),
+        PathBuf::from("/tmp/not_a_real_file.rs"),
+    );
+
+    let coverage = provider.decorate(&tree).expect("decorate should succeed");
+
+    match coverage {
+        Coverage::Covered(_) => panic!("a file outside the loaded root must not be covered"),
+        Coverage::NotCovered(CoverageGap::OutsideRoot { .. }) => {}
+        Coverage::NotCovered(gap) => panic!("unexpected gap: {gap}"),
+    }
+}
+
+/// Checks that a generated file under the root reports
+/// [`CoverageGap::Unreachable`]
+///
+/// Build scripts create files under `target` that rust-analyzer never
+/// interned. The [`CoverageGap::OutsideRoot`] verdict would print a
+/// path inside the root next to a message that claims it is outside.
+#[test]
+fn decorate_with_generated_file_under_root_reports_unreachable() {
+    let provider = load_provider();
+    let tree = parse_source(
+        "fn main() {}\n".to_string(),
+        fixture_path().join("target/debug/build/generated_out/out/generated.rs"),
+    );
+
+    let coverage = provider.decorate(&tree).expect("decorate should succeed");
+
+    match coverage {
+        Coverage::Covered(_) => panic!("a file no crate reaches must not be covered"),
+        Coverage::NotCovered(CoverageGap::Unreachable { .. }) => {}
+        Coverage::NotCovered(gap) => panic!("unexpected gap: {gap}"),
+    }
+}
+
+#[test]
+fn decorate_with_modified_source_reports_stale_source() {
+    let provider = load_provider();
+    let file_path = fixture_path().join("src/lib.rs");
+    let source = std::fs::read_to_string(&file_path).expect("should read fixture source");
+    let tree = parse_source(
+        format!("{source}\npub fn added_after_load() {{}}\n"),
+        file_path,
+    );
+
+    let coverage = provider.decorate(&tree).expect("decorate should succeed");
+
+    match coverage {
+        Coverage::Covered(_) => panic!("text the toolchain never saw must not be covered"),
+        Coverage::NotCovered(CoverageGap::StaleSource) => {}
+        Coverage::NotCovered(gap) => panic!("unexpected gap: {gap}"),
+    }
+}
+
+#[test]
+fn decorate_with_orphan_file_reports_unreachable() {
+    let provider = load_provider();
+    let tree = parse_fixture_file("orphan.rs");
+
+    let coverage = provider.decorate(&tree).expect("decorate should succeed");
+
+    match coverage {
+        Coverage::Covered(_) => panic!("a file no crate reaches must not be covered"),
+        Coverage::NotCovered(CoverageGap::Unreachable { .. }) => {}
+        Coverage::NotCovered(gap) => panic!("unexpected gap: {gap}"),
+    }
 }
 
 #[test]

--- a/crates/whisker-types/src/decoration_provider.rs
+++ b/crates/whisker-types/src/decoration_provider.rs
@@ -1,32 +1,46 @@
-use crate::DecoratedTree;
+use crate::{Coverage, DecoratedTree, ProviderName};
 
 /// Attaches semantic decorations to a parsed syntax tree
 ///
 /// Decoration providers bridge between a language toolchain (e.g.
 /// rust-analyzer) and the platform's decoration system. A provider reads
-/// the syntax tree, queries the toolchain for semantic information, and
-/// inserts decorations into the tree's [`DecorationMap`].
+/// the syntax tree, queries the toolchain, and returns decorations
+/// together with a [`Coverage`] verdict.
 ///
-/// [`DecorationMap`]: crate::DecorationMap
+/// The verdict tells the caller whether the provider could analyze the
+/// file. An empty decoration set is ambiguous: a file with nothing to
+/// decorate and an unknown file produce the same output.
 pub trait DecorationProvider: Send + Sync {
-    /// Populates decorations on the given tree
+    /// Returns the name that identifies this provider in diagnostics
+    fn name(&self) -> ProviderName;
+
+    /// Decorates the file, or explains why the provider declines it
+    ///
+    /// The provider cannot mutate the tree, so a declined file carries no
+    /// partial state.
     ///
     /// # Errors
     ///
-    /// Returns an error if the toolchain connection fails or produces
-    /// invalid results.
-    fn decorate(&self, tree: &mut DecoratedTree) -> anyhow::Result<()>;
+    /// Returns an error only when the toolchain itself malfunctions, for
+    /// example a poisoned lock. Lack of information about a file is not
+    /// an error; the provider reports [`Coverage::NotCovered`] instead.
+    fn decorate(&self, tree: &DecoratedTree) -> anyhow::Result<Coverage>;
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::DecorationMap;
 
     struct Stub;
 
     impl DecorationProvider for Stub {
-        fn decorate(&self, _tree: &mut DecoratedTree) -> anyhow::Result<()> {
-            Ok(())
+        fn name(&self) -> ProviderName {
+            ProviderName("stub")
+        }
+
+        fn decorate(&self, _tree: &DecoratedTree) -> anyhow::Result<Coverage> {
+            Ok(Coverage::Covered(DecorationMap::new()))
         }
     }
 


### PR DESCRIPTION
`DecorationProvider::decorate` returned `anyhow::Result<()>`, so `Ok(())` meant
both "I decorated this file" and "I have nothing for this file". The pipeline
read the first meaning, walked a completely undecorated tree, and the three
rules that depend on semantic decorations found nothing. Whisker reported the
file clean because it had been unable to analyze it, which the user cannot
tell apart from a clean bill of health.

Providers now return `Coverage`, and one that declines hands back the gap
explaining why. `Pipeline::run_on_source` refuses to walk a tree no provider
claimed. Decorations come back by value instead of being written through a
mutable handle, which makes "declined after writing half its decorations"
unrepresentable.

Answering honestly turned out to need three fixes to what the provider knows.
VFS membership was the wrong predicate: `parse_guess_edition` papers over a
missing module by guessing the current edition and resolving nothing, so a
file the toolchain interned but no crate reaches passed the guard and produced
nothing. Cargo leaves `test` out of a crate's cfg options, so every
`#[cfg(test)] mod tests` block resolved to nothing while whisker walked it and
reported it clean; those blocks hold roughly half the lines of this codebase.
And a file whose bytes are not UTF-8 is interned without its text, so
rust-analyzer panicked when something later read it, from inside the crate
around it, never the file whisker was asked about.

The CLI still reports a declined file as an ordinary per-file failure. What it
should say about one, and what happens to the diagnostics already collected,
comes next in the stack.
