### PR TITLE
Tell the user what to do about a file whisker skipped

### DIFF
--- a/crates/whisker/src/commands/check.rs
+++ b/crates/whisker/src/commands/check.rs
@@ -10,10 +10,10 @@ use anyhow::Context as _;
 use clawless::prelude::*;
 use whisker_core::Pipeline;
 use whisker_rust::{RustDecorationProvider, RustLintPassAdapter};
-use whisker_types::{DecorationProvider, Diagnostic, LintPass};
+use whisker_types::{DecorationProvider, Diagnostic, LintPass, UncoveredFile};
 
 use self::check_outcome::CheckOutcome;
-use self::error_recovery::ErrorRecovery;
+use self::error_recovery::{ErrorRecovery, Walk};
 use self::failure_threshold::FailureThreshold;
 use crate::config::WhiskerConfig;
 use crate::discovery::{Discovery, WalkErrorPolicy};
@@ -55,6 +55,45 @@ fn create_lint_passes() -> Vec<Box<dyn LintPass>> {
             wildcard_match_arm::WildcardMatchArm,
         )),
     ]
+}
+
+/// The distinct remedies for the files this run could not analyze
+///
+/// The run collects remedies during the walk and prints each one once.
+/// Per-file printing would repeat the same sentence for every skipped file
+/// and hide the diagnostics. Each remedy comes from a [`CoverageGap`], so a
+/// run that trips two kinds of gap prints both fixes.
+///
+/// [`CoverageGap`]: whisker_types::CoverageGap
+#[derive(Clone, Eq, PartialEq, Debug, Default)]
+struct CoverageRemedies {
+    remedies: Vec<&'static str>,
+}
+
+impl CoverageRemedies {
+    /// Records the remedy for every gap reported against one file
+    ///
+    /// The method drops duplicate remedies, so the run prints at most one
+    /// line per [`CoverageGap`] variant.
+    ///
+    /// [`CoverageGap`]: whisker_types::CoverageGap
+    fn record(&mut self, uncovered: &UncoveredFile) {
+        for (_provider, gap) in uncovered.gaps() {
+            let remedy = gap.help();
+            if !self.remedies.contains(&remedy) {
+                self.remedies.push(remedy);
+            }
+        }
+    }
+
+    /// Prints each remedy once, after the per-file errors
+    ///
+    /// The per-file error names the file and the reason; this names the fix.
+    fn print(&self) {
+        for remedy in &self.remedies {
+            eprintln!("help: {remedy}");
+        }
+    }
 }
 
 #[command]
@@ -114,14 +153,15 @@ pub async fn check(args: CheckArgs, _context: Context) -> CommandResult {
 
     let mut all_diagnostics = Vec::new();
     let mut sources: HashMap<Arc<Path>, String> = HashMap::new();
+    let mut remedies = CoverageRemedies::default();
 
     for file in files {
         let source = match std::fs::read_to_string(file) {
             Ok(source) => source,
-            Err(e) => {
-                recovery.record(&mut outcome, file, anyhow::Error::new(e))?;
-                continue;
-            }
+            Err(e) => match recovery.record(&mut outcome, file, anyhow::Error::new(e)) {
+                Walk::Continue => continue,
+                Walk::Stop => break,
+            },
         };
 
         let mut passes = create_lint_passes();
@@ -134,9 +174,20 @@ pub async fn check(args: CheckArgs, _context: Context) -> CommandResult {
                     all_diagnostics.extend(diagnostics);
                 }
             }
-            Err(e) => recovery.record(&mut outcome, file, e)?,
+            Err(e) => {
+                if let Some(uncovered) = e.downcast_ref::<UncoveredFile>() {
+                    remedies.record(uncovered);
+                }
+
+                match recovery.record(&mut outcome, file, e) {
+                    Walk::Continue => {}
+                    Walk::Stop => break,
+                }
+            }
         }
     }
+
+    remedies.print();
 
     let all_diagnostics: Vec<Diagnostic> = all_diagnostics
         .into_iter()
@@ -153,5 +204,84 @@ pub async fn check(args: CheckArgs, _context: Context) -> CommandResult {
     match outcome {
         CheckOutcome::Failure => std::process::exit(1),
         CheckOutcome::Success => Ok(()),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use whisker_types::{CoverageGap, ProviderName};
+
+    use super::*;
+
+    fn root() -> Arc<Path> {
+        Arc::from(PathBuf::from("/ws"))
+    }
+
+    #[test]
+    fn record_with_no_gaps_collects_no_remedy() {
+        let uncovered = UncoveredFile::new(PathBuf::from("stray.rs"), Vec::new());
+        let mut remedies = CoverageRemedies::default();
+
+        remedies.record(&uncovered);
+
+        assert!(remedies.remedies.is_empty());
+    }
+
+    #[test]
+    fn record_with_repeated_gap_keeps_one_remedy() {
+        let gap = CoverageGap::Unreachable { root: root() };
+        let first = UncoveredFile::new(
+            PathBuf::from("one.rs"),
+            vec![(ProviderName("rust"), gap.clone())],
+        );
+        let second = UncoveredFile::new(PathBuf::from("two.rs"), vec![(ProviderName("rust"), gap)]);
+        let mut remedies = CoverageRemedies::default();
+
+        remedies.record(&first);
+        remedies.record(&second);
+
+        assert_eq!(remedies.remedies.len(), 1);
+        assert_eq!(
+            remedies.remedies[0],
+            CoverageGap::Unreachable { root: root() }.help()
+        );
+    }
+
+    #[test]
+    fn record_with_two_kinds_of_gap_keeps_both_remedies() {
+        let uncovered = UncoveredFile::new(
+            PathBuf::from("stray.rs"),
+            vec![
+                (
+                    ProviderName("rust"),
+                    CoverageGap::Unreachable { root: root() },
+                ),
+                (ProviderName("other"), CoverageGap::StaleSource),
+            ],
+        );
+        let mut remedies = CoverageRemedies::default();
+
+        remedies.record(&uncovered);
+
+        assert_eq!(remedies.remedies.len(), 2);
+        assert_eq!(remedies.remedies[1], CoverageGap::StaleSource.help());
+    }
+
+    #[test]
+    fn trait_send() {
+        fn assert_send<T: Send>() {}
+        assert_send::<CoverageRemedies>();
+    }
+
+    #[test]
+    fn trait_sync() {
+        fn assert_sync<T: Sync>() {}
+        assert_sync::<CoverageRemedies>();
+    }
+
+    #[test]
+    fn trait_unpin() {
+        fn assert_unpin<T: Unpin>() {}
+        assert_unpin::<CoverageRemedies>();
     }
 }

--- a/crates/whisker/src/commands/check/error_recovery.rs
+++ b/crates/whisker/src/commands/check/error_recovery.rs
@@ -2,43 +2,57 @@ use std::path::Path;
 
 use super::check_outcome::CheckOutcome;
 
+/// Whether the walk continues after a file fails
+///
+/// A per-file failure never propagates out of the walk. The run keeps the
+/// diagnostics it already collected and only decides whether to visit the
+/// remaining files.
+#[derive(Copy, Clone, Eq, PartialEq, Hash, Debug)]
+pub(crate) enum Walk {
+    /// The walk moves on to the next file
+    Continue,
+    /// The walk stops, and the run reports what it already collected
+    Stop,
+}
+
 /// What `whisker check` does with a file it cannot read or analyze
 ///
-/// Read failures and analysis failures both go through
-/// [`ErrorRecovery::record`], so one place decides whether a per-file
-/// failure ends the run. The `--keep-going` flag selects
-/// [`ErrorRecovery::Continue`].
+/// A file can fail in two ways: the bytes are not valid UTF-8, or the
+/// pipeline rejects the source. Both paths route through this type, so one
+/// place decides how a per-file failure affects the run.
+///
+/// Both modes report the failure and set the outcome to
+/// [`CheckOutcome::Failure`]. A file that fails produces no diagnostics, so
+/// nothing else would keep the exit code non-zero. The modes differ only in
+/// whether the walk visits the remaining files.
 #[derive(Copy, Clone, Eq, PartialEq, Hash, Debug)]
 pub(crate) enum ErrorRecovery {
-    /// The first failing file ends the run with its error
+    /// The first failing file ends the walk
     Abort,
-    /// Whisker reports each failing file, continues, and still fails the run
+    /// The run reports the failing file and the walk continues
     Continue,
 }
 
 impl ErrorRecovery {
-    /// Records a failure for one file
+    /// Reports a failure encountered while processing a single file
     ///
-    /// Under [`ErrorRecovery::Continue`], the error goes to stderr and
-    /// `outcome` becomes [`CheckOutcome::Failure`].
+    /// The method writes the error to stderr and sets `outcome` to
+    /// [`CheckOutcome::Failure`], which the command turns into a non-zero
+    /// exit code after the walk.
     ///
-    /// # Errors
-    ///
-    /// Under [`ErrorRecovery::Abort`], returns `error` with the file name
-    /// added, so the caller can end the run with it.
+    /// Returns whether the caller should keep walking.
     pub(crate) fn record(
         self,
         outcome: &mut CheckOutcome,
         file: &Path,
         error: anyhow::Error,
-    ) -> anyhow::Result<()> {
+    ) -> Walk {
+        eprintln!("error: {}: {error:#}", file.display());
+        *outcome = CheckOutcome::Failure;
+
         match self {
-            Self::Abort => Err(error.context(format!("check {}", file.display()))),
-            Self::Continue => {
-                eprintln!("error: {}: {error:#}", file.display());
-                *outcome = CheckOutcome::Failure;
-                Ok(())
-            }
+            Self::Abort => Walk::Stop,
+            Self::Continue => Walk::Continue,
         }
     }
 }
@@ -52,64 +66,68 @@ mod tests {
     }
 
     #[test]
-    fn trait_send() {
-        fn assert_send<T: Send>() {}
-        assert_send::<ErrorRecovery>();
-    }
-
-    #[test]
-    fn trait_sync() {
-        fn assert_sync<T: Sync>() {}
-        assert_sync::<ErrorRecovery>();
-    }
-
-    #[test]
-    fn trait_unpin() {
-        fn assert_unpin<T: Unpin>() {}
-        assert_unpin::<ErrorRecovery>();
-    }
-
-    #[test]
-    fn record_with_abort_leaves_the_outcome_untouched() {
+    fn record_with_abort_fails_the_outcome() {
         let mut outcome = CheckOutcome::Success;
 
-        let _error = ErrorRecovery::Abort
-            .record(&mut outcome, Path::new("bad.rs"), test_error())
-            .expect_err("abort should fail the run");
+        ErrorRecovery::Abort.record(&mut outcome, Path::new("bad.rs"), test_error());
 
-        assert_eq!(outcome, CheckOutcome::Success);
+        assert_eq!(outcome, CheckOutcome::Failure);
     }
 
     #[test]
-    fn record_with_abort_names_the_failing_file() {
+    fn record_with_abort_stops_the_walk() {
         let mut outcome = CheckOutcome::Success;
 
-        let error = ErrorRecovery::Abort
-            .record(&mut outcome, Path::new("bad.rs"), test_error())
-            .expect_err("abort should fail the run");
+        let walk = ErrorRecovery::Abort.record(&mut outcome, Path::new("bad.rs"), test_error());
 
-        assert_eq!(format!("{error:#}"), "check bad.rs: something broke");
+        assert_eq!(walk, Walk::Stop);
+    }
+
+    #[test]
+    fn record_with_continue_fails_the_outcome() {
+        let mut outcome = CheckOutcome::Success;
+
+        ErrorRecovery::Continue.record(&mut outcome, Path::new("bad.rs"), test_error());
+
+        assert_eq!(outcome, CheckOutcome::Failure);
     }
 
     #[test]
     fn record_with_continue_keeps_an_earlier_failure() {
         let mut outcome = CheckOutcome::Failure;
 
-        ErrorRecovery::Continue
-            .record(&mut outcome, Path::new("bad.rs"), test_error())
-            .expect("continue should not fail the run");
+        ErrorRecovery::Continue.record(&mut outcome, Path::new("bad.rs"), test_error());
 
         assert_eq!(outcome, CheckOutcome::Failure);
     }
 
     #[test]
-    fn record_with_continue_marks_the_outcome_failed() {
+    fn record_with_continue_keeps_walking() {
         let mut outcome = CheckOutcome::Success;
 
-        ErrorRecovery::Continue
-            .record(&mut outcome, Path::new("bad.rs"), test_error())
-            .expect("continue should not fail the run");
+        let walk = ErrorRecovery::Continue.record(&mut outcome, Path::new("bad.rs"), test_error());
 
-        assert_eq!(outcome, CheckOutcome::Failure);
+        assert_eq!(walk, Walk::Continue);
+    }
+
+    #[test]
+    fn trait_send() {
+        fn assert_send<T: Send>() {}
+        assert_send::<ErrorRecovery>();
+        assert_send::<Walk>();
+    }
+
+    #[test]
+    fn trait_sync() {
+        fn assert_sync<T: Sync>() {}
+        assert_sync::<ErrorRecovery>();
+        assert_sync::<Walk>();
+    }
+
+    #[test]
+    fn trait_unpin() {
+        fn assert_unpin<T: Unpin>() {}
+        assert_unpin::<ErrorRecovery>();
+        assert_unpin::<Walk>();
     }
 }

--- a/crates/whisker/tests/check.rs
+++ b/crates/whisker/tests/check.rs
@@ -1,3 +1,4 @@
+use std::path::{Path, PathBuf};
 use std::process::Command;
 
 use assert_cmd::prelude::*;
@@ -49,15 +50,42 @@ fn package(source: &str) -> TempDir {
     directory
 }
 
-/// Creates a package that holds one readable source and one non-UTF-8 file
+/// Creates a package whose `src` holds Rust files no module declares
 ///
-/// The non-UTF-8 file is a sibling, not the crate root, so the package
-/// still loads and the read failure is the one under test.
-fn package_with_unreadable_source() -> TempDir {
+/// An orphan is a file the walk finds but no crate reaches, which is the
+/// shape the coverage errors describe. The orphans live in a temporary
+/// package because a checked-in orphan would make `whisker check .` fail
+/// for everyone.
+fn package_with_orphans(names: &[&str]) -> TempDir {
     let directory = package(CLEAN_SOURCE);
 
-    std::fs::write(directory.path().join("src").join("broken.rs"), NOT_UTF8)
+    for name in names {
+        std::fs::write(
+            directory.path().join("src").join(format!("{name}.rs")),
+            CLEAN_SOURCE,
+        )
+        .expect("orphan source should be written");
+    }
+
+    directory
+}
+
+/// Creates a package whose `src` holds two sources that are not UTF-8
+///
+/// The crate root beside them is valid UTF-8 and trips no lints, so only
+/// the two siblings fail. Two failing files let the error count separate
+/// the two `--keep-going` modes. Discovery sorts, so a stopped run always
+/// names `broken_first.rs`.
+fn package_with_unreadable_sources() -> TempDir {
+    let directory = package(CLEAN_SOURCE);
+
+    for name in ["broken_first", "broken_second"] {
+        std::fs::write(
+            directory.path().join("src").join(format!("{name}.rs")),
+            NOT_UTF8,
+        )
         .expect("unreadable source should be written");
+    }
 
     directory
 }
@@ -66,6 +94,68 @@ fn whisker() -> Command {
     Command::cargo_bin("whisker").expect("whisker binary should exist")
 }
 
+/// Returns the fixture workspace that whisker-rust's own tests analyze
+///
+/// The fixture is a real Cargo package with a real crate graph, so whisker
+/// can decorate the files under its `src` directory.
+fn sample_project() -> PathBuf {
+    Path::new(env!("CARGO_MANIFEST_DIR")).join("../whisker-rust/tests/fixtures/sample_project")
+}
+
+/// Writes a Cargo project holding one analyzable file and one unreadable one
+///
+/// The fixture carries its own manifest because whisker loads the workspace
+/// around the path it is given. `CARGO_TARGET_TMPDIR` is a scratch
+/// directory, and nothing guarantees that a Cargo project sits above it.
+///
+/// `src/lib.rs` trips `lint.wildcard-match-arm` and produces a diagnostic.
+/// Whisker cannot read `src/not_utf8.rs`. Discovery sorts, so `src/lib.rs`
+/// comes first, and a run without `--keep-going` collects the diagnostic
+/// before `src/not_utf8.rs` stops the walk.
+///
+/// Each caller passes its own `name`, so two tests that run at once never
+/// write the same directory.
+fn mixed_project(name: &str) -> PathBuf {
+    let root = Path::new(env!("CARGO_TARGET_TMPDIR")).join(name);
+    std::fs::create_dir_all(root.join("src")).expect("should create the fixture directories");
+    std::fs::write(
+        root.join("Cargo.toml"),
+        "[workspace]\n\n[package]\nname = \"mixed_project\"\nversion = \"0.1.0\"\nedition = \"2024\"\n",
+    )
+    .expect("should write the fixture manifest");
+    std::fs::write(
+        root.join("src/lib.rs"),
+        "pub enum Color {\n    Red,\n    Green,\n}\n\npub fn match_on_enum(color: Color) {\n    match color {\n        Color::Red => {}\n        _ => {}\n    }\n}\n",
+    )
+    .expect("should write the fixture crate root");
+    std::fs::write(root.join("src/not_utf8.rs"), [0xff, 0xfe, 0x00])
+        .expect("should write the fixture file that is not UTF-8");
+
+    root
+}
+
+/// Counts the failing files whisker reported on stderr
+///
+/// The count separates the two `--keep-going` modes: an aborted run reports
+/// one failing file, a run that continues reports every one.
+fn error_count(stderr: &str) -> usize {
+    stderr.matches("error: ").count()
+}
+
+/// Counts how many times whisker printed the remedy for an unreachable file
+///
+/// Whisker prints the remedy once per run, not once per file; the count
+/// pins that limit.
+fn unreachable_help_count(stderr: &str) -> usize {
+    stderr
+        .matches("help: reference the file from a source the toolchain already loads")
+        .count()
+}
+
+/// Pins that `whisker check` succeeds on this crate's own source
+///
+/// The test fails if anyone reintroduces source the decoration provider
+/// cannot reach.
 #[test]
 fn check_current_directory_succeeds() {
     whisker().arg("check").assert().success();
@@ -99,6 +189,47 @@ fn check_nonexistent_path_fails() {
         .assert()
         .failure()
         .stderr(predicate::str::contains("does not exist"));
+}
+
+/// Pins that without `--keep-going` an uncoverable file ends the run, and
+/// that the remedy still prints
+///
+/// The run collects the remedy during the walk; only the code after the
+/// walk prints it.
+#[test]
+fn check_orphan_directory_reports_no_coverage() {
+    let package = package_with_orphans(&["stray"]);
+
+    whisker()
+        .arg("check")
+        .arg(package.path())
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains(
+            "no decoration provider covers this file",
+        ))
+        .stderr(predicate::str::contains("stray.rs"))
+        .stderr(predicate::function(|stderr: &str| error_count(stderr) == 1))
+        .stderr(predicate::function(|stderr: &str| {
+            unreachable_help_count(stderr) == 1
+        }));
+}
+
+#[test]
+fn check_orphan_file_reports_no_coverage() {
+    let package = package_with_orphans(&["stray"]);
+
+    whisker()
+        .args(["check", "src/stray.rs"])
+        .current_dir(package.path())
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains(
+            "no decoration provider covers this file",
+        ))
+        .stderr(predicate::str::contains(
+            "nothing the toolchain loaded reaches it",
+        ));
 }
 
 #[test]
@@ -256,6 +387,22 @@ fn check_package_with_an_unreadable_directory_fails() {
         .stderr(predicate::str::contains("failed to read a directory entry"));
 }
 
+/// Pins that a package the provider can fully reach produces lint output,
+/// not coverage errors
+///
+/// Without this the coverage tests could all pass against a provider that
+/// covered nothing at all, since every assertion they make is about failure.
+#[test]
+fn check_real_crate_produces_diagnostics_not_coverage_errors() {
+    whisker()
+        .current_dir(sample_project())
+        .args(["check", "src"])
+        .assert()
+        .success()
+        .stderr(predicate::str::contains("no decoration provider covers this file").not())
+        .stderr(predicate::str::contains("warning[lint.wildcard-match-arm]"));
+}
+
 #[test]
 fn check_single_file_succeeds() {
     let package = package(CLEAN_SOURCE);
@@ -280,12 +427,15 @@ fn check_with_deny_warnings_fails_on_warnings() {
         .stderr(predicate::str::contains("error[lint.bool-param]"));
 }
 
-/// The non-UTF-8 source produces a read failure and no diagnostic, so only
-/// that failure can make the exit code non-zero. The recovery path alone
-/// prints the lowercase `error:` line the assertions accept.
+/// Pins the exit code to the failure recorded while walking the files, not
+/// just to the diagnostics that came out of the walk
+///
+/// The crate root is clean, so only the recorded failures can make the exit
+/// code non-zero. An error count of two shows the walk reported both
+/// unreadable files.
 #[test]
 fn check_with_keep_going_and_unreadable_file_fails() {
-    let package = package_with_unreadable_source();
+    let package = package_with_unreadable_sources();
 
     whisker()
         .args(["check", "--keep-going"])
@@ -295,8 +445,30 @@ fn check_with_keep_going_and_unreadable_file_fails() {
         .stderr(predicate::str::contains(
             "stream did not contain valid UTF-8",
         ))
-        .stderr(predicate::str::contains("error: "))
-        .stderr(predicate::str::contains("Error:").not());
+        .stderr(predicate::str::contains("broken_first.rs"))
+        .stderr(predicate::str::contains("broken_second.rs"))
+        .stderr(predicate::function(|stderr: &str| error_count(stderr) == 2));
+}
+
+/// Pins that `--keep-going` reports every uncoverable file, not just the first
+///
+/// Two errors mean the walk continued past the first orphan. The run still
+/// prints the remedy once.
+#[test]
+fn check_with_keep_going_reports_every_orphan_file() {
+    let package = package_with_orphans(&["first_stray", "second_stray"]);
+
+    whisker()
+        .args(["check", "--keep-going"])
+        .arg(package.path())
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains("first_stray.rs"))
+        .stderr(predicate::str::contains("second_stray.rs"))
+        .stderr(predicate::function(|stderr: &str| error_count(stderr) == 2))
+        .stderr(predicate::function(|stderr: &str| {
+            unreachable_help_count(stderr) == 1
+        }));
 }
 
 #[test]
@@ -311,22 +483,25 @@ fn check_with_keep_going_succeeds() {
         .stderr(predicate::str::is_empty());
 }
 
-/// Without `--keep-going`, the same package ends the run. The error names
-/// the failing file; anyhow renders the cause as a separate line.
+/// Pins that without `--keep-going` the walk stops at the first unreadable
+/// file
+///
+/// The run reports only one of the two unreadable siblings, and the error
+/// names the file so the failure stays attributable.
 #[test]
 fn check_with_unreadable_file_and_no_keep_going_fails() {
-    let package = package_with_unreadable_source();
+    let package = package_with_unreadable_sources();
 
     whisker()
         .arg("check")
         .arg(package.path())
         .assert()
         .code(1)
-        .stderr(predicate::str::contains("Error:"))
-        .stderr(predicate::str::contains("broken.rs"))
+        .stderr(predicate::str::contains("broken_first.rs"))
         .stderr(predicate::str::contains(
             "stream did not contain valid UTF-8",
-        ));
+        ))
+        .stderr(predicate::function(|stderr: &str| error_count(stderr) == 1));
 }
 
 #[test]
@@ -339,4 +514,21 @@ fn check_without_deny_warnings_reports_warnings_and_succeeds() {
         .assert()
         .success()
         .stderr(predicate::str::contains("warning[lint.bool-param]"));
+}
+
+/// Pins that a stopped run keeps the diagnostics from earlier files
+///
+/// A run without `--keep-going` stops at the first unreadable file. The
+/// diagnostics collected before that point still reach the user.
+#[test]
+fn check_without_keep_going_keeps_diagnostics_from_earlier_files() {
+    let root = mixed_project("check_without_keep_going");
+
+    whisker()
+        .current_dir(&root)
+        .args(["check", "src"])
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains("error: src/not_utf8.rs"))
+        .stderr(predicate::str::contains("warning[lint.wildcard-match-arm]"));
 }


### PR DESCRIPTION
A declined file reached the user as a bare per-file failure: the reason was
there, but not the fix. Being told your file cannot be analyzed, without being
told what would make it analyzable, leaves you nowhere to go. And a directory
of orphaned files repeated the same sentence on every line, burying the
diagnostics under it.

Each gap now carries the remedy it implies, and a run collects the distinct
remedies and prints each once, after the per-file errors that earned it. The
per-file line names the file and the reason; the remedy names the fix.

Stopping at a file that cannot be analyzed also no longer throws away the
diagnostics collected from the files before it. `ErrorRecovery` used to model
aborting as returning the error, which unwound past everything the run had
found so far. That work was done and those findings were true; losing them
made one bad file cost the user twice. Recovery now answers whether to keep
walking, not whether to fail. Both modes report the failure and drive the run
to a non-zero exit, and what separates them is how many files get reported.
