### PR TITLE
Resolve types by span rather than by start offset

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2882,6 +2882,7 @@ name = "whisker-rust"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "anyhow_missing_context",
  "proptest",
  "ra_ap_hir",
  "ra_ap_ide_db",
@@ -2894,6 +2895,7 @@ dependencies = [
  "whisker-codegen",
  "whisker-core",
  "whisker-types",
+ "wildcard_match_arm",
 ]
 
 [[package]]

--- a/crates/whisker-rust/Cargo.toml
+++ b/crates/whisker-rust/Cargo.toml
@@ -18,8 +18,14 @@ tree-sitter-rust.workspace = true
 whisker-types.workspace = true
 
 [dev-dependencies]
+# The lint crates depend on this one, so the two lint entries below close a
+# cycle. Cargo permits that for dev-dependencies. The cycle lets the
+# integration tests assert on diagnostics that real lints draw from real
+# decorations, not on the decorations alone.
+anyhow_missing_context = { path = "../../lints/anyhow_missing_context" }
 proptest.workspace = true
 whisker-core.workspace = true
+wildcard_match_arm = { path = "../../lints/wildcard_match_arm" }
 
 [build-dependencies]
 whisker-codegen.workspace = true

--- a/crates/whisker-rust/src/provider.rs
+++ b/crates/whisker-rust/src/provider.rs
@@ -7,8 +7,7 @@ use ra_ap_ide_db::base_db::SourceDatabase as _;
 use ra_ap_ide_db::{ChangeWithProcMacros, RootDatabase};
 use ra_ap_load_cargo::{LoadCargoConfig, ProcMacroServerChoice};
 use ra_ap_project_model::{CargoConfig, ProjectManifest, ProjectWorkspace};
-use ra_ap_syntax::AstNode;
-use ra_ap_syntax::ast;
+use ra_ap_syntax::{AstNode, NodeOrToken, SyntaxNode, TextRange, TextSize, ast};
 use ra_ap_vfs::{AbsPathBuf, FileExcluded, FileId, Vfs, VfsPath};
 use whisker_types::{
     Coverage, CoverageGap, DecoratedNode, DecoratedTree, DecorationMap, DecorationProvider,
@@ -207,11 +206,25 @@ impl DecorationProvider for RustDecorationProvider {
 
     /// Attaches type decorations to the tree's nodes, or declines the file
     ///
-    /// The provider covers a file only when four conditions hold. The VFS
-    /// must know the file. The toolchain must not exclude it. A crate
-    /// module must reach it. The tree's source must equal the text the
-    /// database holds. Each failed condition maps to a [`CoverageGap`]
-    /// variant.
+    /// Four conditions must hold before a single decoration is produced,
+    /// and their order matters. The file must be interned by the VFS, or
+    /// rust-analyzer has never heard of it. It must not be excluded, or
+    /// every question the database can be asked about it panics: the VFS
+    /// keeps an excluded file's identity and neither its contents nor a
+    /// source root, so the check has to come before the database is touched
+    /// at all, not merely before its text is read. It must belong to a
+    /// module, because `parse_guess_edition` papers over a missing module by
+    /// guessing the current edition and then resolves nothing. And the text
+    /// the pipeline parsed must equal the text the database holds, because
+    /// the byte ranges carried by every target index into rust-analyzer's
+    /// parse of that text.
+    ///
+    /// Only the first two conditions are guards. The module check protects
+    /// nothing, because establishing the module reads whatever sibling
+    /// modules the crate declares; a file whose text the load dropped would
+    /// already have brought the process down by then, which is why
+    /// [`give_text_to_files_that_have_none`] repairs the database at load
+    /// time, so the read here needs no careful ordering.
     ///
     /// # Errors
     ///
@@ -287,19 +300,16 @@ fn resolve_targets(
     let mut decorations = DecorationMap::new();
     for target in targets {
         match target {
-            Target::Function {
-                node_id,
-                start_byte,
-            } => {
-                if let Some(sig) = resolve_function(&ctx, *start_byte) {
+            Target::Function { node_id, range } => {
+                if let Some(sig) = resolve_function(&ctx, *range) {
                     decorations.insert(*node_id, sig);
                 }
             }
             Target::MatchScrutinee {
-                scrutinee_start_byte,
+                scrutinee_range,
                 scrutinee_node_id,
             } => {
-                if let Some((ty, flags)) = resolve_match_scrutinee(&ctx, *scrutinee_start_byte) {
+                if let Some((ty, flags)) = resolve_match_scrutinee(&ctx, *scrutinee_range) {
                     decorations.insert(*scrutinee_node_id, ty);
                     if let Some(flags) = flags {
                         decorations.insert(*scrutinee_node_id, flags);
@@ -307,18 +317,18 @@ fn resolve_targets(
                 }
             }
             Target::IfElse {
-                else_start_byte,
+                branch_range,
                 else_node_id,
             } => {
-                if let Some(ty) = resolve_expr_type(&ctx, *else_start_byte) {
+                if let Some(ty) = resolve_expr_type(&ctx, *branch_range) {
                     decorations.insert(*else_node_id, ty);
                 }
             }
             Target::TryExpr {
-                operand_start_byte,
+                operand_range,
                 operand_node_id,
             } => {
-                if let Some(ty) = resolve_expr_type(&ctx, *operand_start_byte) {
+                if let Some(ty) = resolve_expr_type(&ctx, *operand_range) {
                     decorations.insert(*operand_node_id, ty);
                 }
             }
@@ -327,37 +337,65 @@ fn resolve_targets(
     decorations
 }
 
+/// A node the provider asks rust-analyzer to resolve
+///
+/// Each variant pairs the byte range rust-analyzer inspects with the
+/// tree-sitter node ID that receives the decoration. These can differ: the
+/// provider types an `else` branch from its block but decorates the
+/// enclosing `else_clause`.
+///
+/// A full range, not a start offset, selects the node in rust-analyzer's
+/// tree. A start offset lands on one token, and the smallest expression
+/// around that token is often wrong. In `foo().bar()`, the start offset
+/// names the path `foo`, not the call.
 enum Target {
     Function {
         node_id: usize,
-        start_byte: usize,
+        range: TextRange,
     },
     MatchScrutinee {
-        scrutinee_start_byte: usize,
+        scrutinee_range: TextRange,
         scrutinee_node_id: usize,
     },
     IfElse {
-        else_start_byte: usize,
+        branch_range: TextRange,
         else_node_id: usize,
     },
     TryExpr {
-        operand_start_byte: usize,
+        operand_range: TextRange,
         operand_node_id: usize,
     },
+}
+
+/// Converts a tree-sitter byte range into a rust-analyzer [`TextRange`]
+///
+/// Rust-analyzer stores text offsets as 32 bits. When an offset does not
+/// fit, the function returns [`None`]. The caller then skips the target,
+/// because a truncated offset would name some other expression.
+fn text_range_of(node: &DecoratedNode<'_>) -> Option<TextRange> {
+    let range = node.raw().byte_range();
+    let start = u32::try_from(range.start).ok()?;
+    let end = u32::try_from(range.end).ok()?;
+
+    Some(TextRange::new(TextSize::from(start), TextSize::from(end)))
 }
 
 fn collect_targets(node: &DecoratedNode<'_>, targets: &mut Vec<Target>) {
     match node.kind() {
         "function_item" => {
-            targets.push(Target::Function {
-                node_id: node.id(),
-                start_byte: node.raw().start_byte(),
-            });
+            if let Some(range) = text_range_of(node) {
+                targets.push(Target::Function {
+                    node_id: node.id(),
+                    range,
+                });
+            }
         }
         "match_expression" => {
-            if let Some(scrutinee) = node.child_by_field_name("value") {
+            if let Some(scrutinee) = node.child_by_field_name("value")
+                && let Some(scrutinee_range) = text_range_of(&scrutinee)
+            {
                 targets.push(Target::MatchScrutinee {
-                    scrutinee_start_byte: scrutinee.raw().start_byte(),
+                    scrutinee_range,
                     scrutinee_node_id: scrutinee.id(),
                 });
             }
@@ -365,16 +403,20 @@ fn collect_targets(node: &DecoratedNode<'_>, targets: &mut Vec<Target>) {
         "if_expression" => {
             if let Some(alt) = node.child_by_field_name("alternative") {
                 let block = alt.named_child(0).unwrap_or(alt.clone());
-                targets.push(Target::IfElse {
-                    else_start_byte: block.raw().start_byte(),
-                    else_node_id: alt.id(),
-                });
+                if let Some(branch_range) = text_range_of(&block) {
+                    targets.push(Target::IfElse {
+                        branch_range,
+                        else_node_id: alt.id(),
+                    });
+                }
             }
         }
         "try_expression" => {
-            if let Some(operand) = node.named_child(0) {
+            if let Some(operand) = node.named_child(0)
+                && let Some(operand_range) = text_range_of(&operand)
+            {
                 targets.push(Target::TryExpr {
-                    operand_start_byte: operand.raw().start_byte(),
+                    operand_range,
                     operand_node_id: operand.id(),
                 });
             }
@@ -400,29 +442,42 @@ impl DecorateCtx<'_, '_> {
     }
 }
 
-fn find_enclosing_fn(
-    ctx: &DecorateCtx<'_, '_>,
-    offset: ra_ap_syntax::TextSize,
-) -> Option<ra_ap_hir::Function> {
-    let fn_node = ctx
-        .syntax
-        .token_at_offset(offset)
-        .right_biased()?
-        .parent_ancestors()
+/// Returns the smallest node in rust-analyzer's tree that covers `range`
+///
+/// Tree-sitter's parse and rust-analyzer's parse agree on byte offsets but
+/// not on tree shape, so the function locates a node by its span. Callers
+/// climb from the covering node to the smallest [`ast::Expr`] or
+/// [`ast::Fn`] that encloses the whole span.
+///
+/// The function returns [`None`] for an empty range or a range outside the
+/// tree. Tree-sitter synthesizes zero-width nodes during error recovery,
+/// and a zero-width span "covers" some unrelated neighbor.
+fn covering_node(ctx: &DecorateCtx<'_, '_>, range: TextRange) -> Option<SyntaxNode> {
+    if range.is_empty() || !ctx.syntax.text_range().contains_range(range) {
+        return None;
+    }
+
+    match ctx.syntax.covering_element(range) {
+        NodeOrToken::Node(node) => Some(node),
+        NodeOrToken::Token(token) => token.parent(),
+    }
+}
+
+fn find_enclosing_fn(ctx: &DecorateCtx<'_, '_>, range: TextRange) -> Option<ra_ap_hir::Function> {
+    let fn_node = covering_node(ctx, range)?
+        .ancestors()
         .find_map(ast::Fn::cast)?;
     ctx.sema.to_def(&fn_node)
 }
 
-fn find_expr_at(ctx: &DecorateCtx<'_, '_>, offset: ra_ap_syntax::TextSize) -> Option<ast::Expr> {
-    ctx.syntax
-        .token_at_offset(offset)
-        .right_biased()
-        .and_then(|t| t.parent_ancestors().find_map(ast::Expr::cast))
+fn find_expr_covering(ctx: &DecorateCtx<'_, '_>, range: TextRange) -> Option<ast::Expr> {
+    covering_node(ctx, range)?
+        .ancestors()
+        .find_map(ast::Expr::cast)
 }
 
-fn resolve_function(ctx: &DecorateCtx<'_, '_>, start_byte: usize) -> Option<FnSignature> {
-    let offset = ra_ap_syntax::TextSize::from(start_byte as u32);
-    let func = find_enclosing_fn(ctx, offset)?;
+fn resolve_function(ctx: &DecorateCtx<'_, '_>, range: TextRange) -> Option<FnSignature> {
+    let func = find_enclosing_fn(ctx, range)?;
 
     let ret_type = func.ret_type(ctx.sema.db);
     let display = ctx.display_type(&ret_type, &func);
@@ -444,16 +499,15 @@ fn resolve_function(ctx: &DecorateCtx<'_, '_>, start_byte: usize) -> Option<FnSi
 
 fn resolve_match_scrutinee(
     ctx: &DecorateCtx<'_, '_>,
-    scrutinee_start_byte: usize,
+    scrutinee_range: TextRange,
 ) -> Option<(ResolvedType, Option<AdtFlags>)> {
-    let offset = ra_ap_syntax::TextSize::from(scrutinee_start_byte as u32);
-    let expr_node = find_expr_at(ctx, offset)?;
+    let expr_node = find_expr_covering(ctx, scrutinee_range)?;
     let ty_info = ctx.sema.type_of_expr(&expr_node)?;
 
     let ty = ty_info.original;
     let is_enum = ty.as_adt().is_some_and(|adt| matches!(adt, Adt::Enum(_)));
 
-    let func = find_enclosing_fn(ctx, offset);
+    let func = find_enclosing_fn(ctx, scrutinee_range);
     let display = match &func {
         Some(f) => ctx.display_type(&ty, f),
         None => format!("{ty:?}"),
@@ -474,13 +528,12 @@ fn resolve_match_scrutinee(
     Some((resolved, flags))
 }
 
-fn resolve_expr_type(ctx: &DecorateCtx<'_, '_>, start_byte: usize) -> Option<ResolvedType> {
-    let offset = ra_ap_syntax::TextSize::from(start_byte as u32);
-    let expr = find_expr_at(ctx, offset)?;
+fn resolve_expr_type(ctx: &DecorateCtx<'_, '_>, range: TextRange) -> Option<ResolvedType> {
+    let expr = find_expr_covering(ctx, range)?;
     let ty_info = ctx.sema.type_of_expr(&expr)?;
 
     let ty = ty_info.original;
-    let func = find_enclosing_fn(ctx, offset);
+    let func = find_enclosing_fn(ctx, range);
     let display = match &func {
         Some(f) => ctx.display_type(&ty, f),
         None => format!("{ty:?}"),

--- a/crates/whisker-rust/tests/fixtures/sample_project/src/lib.rs
+++ b/crates/whisker-rust/tests/fixtures/sample_project/src/lib.rs
@@ -6,6 +6,24 @@ pub enum Color {
     Blue,
 }
 
+pub struct Palette {
+    pub primary: Color,
+}
+
+pub struct Loader {
+    pub path: String,
+}
+
+impl Loader {
+    pub fn load(&self) -> anyhow::Result<String> {
+        std::fs::read_to_string(&self.path).context("reading the configured path")
+    }
+}
+
+pub fn pick_color() -> Color {
+    Color::Blue
+}
+
 pub fn match_on_enum(color: Color) {
     match color {
         Color::Red => {}
@@ -20,15 +38,35 @@ pub fn match_on_integer(x: i32) {
     }
 }
 
+pub fn match_on_field_expression(palette: Palette) {
+    match palette.primary {
+        Color::Red => {}
+        _ => {}
+    }
+}
+
+pub fn match_on_call_expression() {
+    match pick_color() {
+        Color::Red => {}
+        _ => {}
+    }
+}
+
 pub fn returns_anyhow_result() -> anyhow::Result<()> {
-    let _file = std::fs::read_to_string("test.txt")?;
-    let _with_context = std::fs::read_to_string("other.txt").context("reading other")?;
+    let _file = std::fs::read_to_string("anyhow_bare.txt")?;
+    let _with_context =
+        std::fs::read_to_string("anyhow_with_context.txt").context("reading other")?;
     Ok(())
 }
 
 pub fn returns_io_result() -> std::io::Result<()> {
-    let _file = std::fs::read_to_string("test.txt")?;
+    let _file = std::fs::read_to_string("io_bare.txt")?;
     Ok(())
+}
+
+pub fn try_on_method_call(loader: &Loader) -> anyhow::Result<usize> {
+    let contents = loader.load()?;
+    Ok(contents.len())
 }
 
 pub fn if_let_with_diverging_else(x: Option<i32>) -> i32 {

--- a/crates/whisker-rust/tests/provider_integration.rs
+++ b/crates/whisker-rust/tests/provider_integration.rs
@@ -1,9 +1,15 @@
+use std::ops::Range;
 use std::path::{Path, PathBuf};
 use std::sync::OnceLock;
 
-use whisker_rust::RustDecorationProvider;
+use anyhow_missing_context::AnyhowMissingContext;
 use whisker_rust::decorations::{AdtFlags, FnSignature, ResolvedType};
-use whisker_types::{Coverage, CoverageGap, DecoratedNode, DecoratedTree, DecorationProvider};
+use whisker_rust::{RustDecorationProvider, RustLintPassAdapter};
+use whisker_types::{
+    Coverage, CoverageGap, DecoratedNode, DecoratedTree, DecorationProvider, Diagnostic, LintPass,
+    RuleId, Severity, Span,
+};
+use wildcard_match_arm::WildcardMatchArm;
 
 static PROVIDER: OnceLock<RustDecorationProvider> = OnceLock::new();
 
@@ -113,6 +119,32 @@ fn find_first_node_of_kind<'a>(node: &DecoratedNode<'a>, kind: &str) -> Option<D
         }
     }
     None
+}
+
+/// Returns the operand of the first `?` expression inside `node`
+fn find_first_try_operand<'a>(node: &DecoratedNode<'a>) -> Option<DecoratedNode<'a>> {
+    find_first_node_of_kind(node, "try_expression")?.named_child(0)
+}
+
+/// Returns the source text covered by each diagnostic raised inside `func`
+///
+/// A diagnostic belongs to `func` when `func` contains the whole diagnostic
+/// span. An expectation therefore does not depend on positions in the
+/// diagnostics list. The helper returns source text, not offsets, so the
+/// fixture can grow without renumbering every expectation.
+fn flagged_within<'a>(
+    tree: &'a DecoratedTree,
+    diagnostics: &[Diagnostic],
+    func: &DecoratedNode<'_>,
+) -> Vec<&'a str> {
+    let Range { start, end } = func.raw().byte_range();
+
+    diagnostics
+        .iter()
+        .map(Diagnostic::span)
+        .filter(|span| start <= span.start() && span.end() <= end)
+        .map(|span| &tree.source()[span.start()..span.end()])
+        .collect()
 }
 
 /// Checks that a module that is not UTF-8 leaves its siblings covered
@@ -362,6 +394,70 @@ fn match_scrutinee_on_integer_has_is_enum_false() {
     assert!(!ty.is_enum(), "i32 should not be an enum");
 }
 
+/// A scrutinee reached through a field must be typed as the field
+///
+/// A lookup at the start offset of `palette.primary` finds the path
+/// `palette` and reports the struct, not the enum.
+#[test]
+fn match_scrutinee_on_field_expression_has_is_enum_true() {
+    let provider = load_provider();
+    let tree = parse_and_decorate_fixture(provider);
+    let root = tree.root_node();
+
+    let func = find_function_by_name(&root, "match_on_field_expression")
+        .expect("should find match_on_field_expression");
+
+    let match_expr =
+        find_first_node_of_kind(&func, "match_expression").expect("should find match_expression");
+
+    let scrutinee = match_expr
+        .child_by_field_name("value")
+        .expect("match should have value field");
+
+    let ty = scrutinee
+        .decoration::<ResolvedType>()
+        .expect("scrutinee should have ResolvedType");
+
+    assert_eq!(scrutinee.text(), "palette.primary");
+    assert!(
+        ty.is_enum(),
+        "the field's Color type should be an enum, got: {}",
+        ty.display()
+    );
+}
+
+/// A scrutinee returned by a call must be typed as the call's result
+///
+/// A lookup at the start offset of `pick_color()` finds the callee path,
+/// whose type is the function itself, not the `Color` it returns.
+#[test]
+fn match_scrutinee_on_call_expression_has_is_enum_true() {
+    let provider = load_provider();
+    let tree = parse_and_decorate_fixture(provider);
+    let root = tree.root_node();
+
+    let func = find_function_by_name(&root, "match_on_call_expression")
+        .expect("should find match_on_call_expression");
+
+    let match_expr =
+        find_first_node_of_kind(&func, "match_expression").expect("should find match_expression");
+
+    let scrutinee = match_expr
+        .child_by_field_name("value")
+        .expect("match should have value field");
+
+    let ty = scrutinee
+        .decoration::<ResolvedType>()
+        .expect("scrutinee should have ResolvedType");
+
+    assert_eq!(scrutinee.text(), "pick_color()");
+    assert!(
+        ty.is_enum(),
+        "the returned Color type should be an enum, got: {}",
+        ty.display()
+    );
+}
+
 #[test]
 fn local_enum_has_non_exhaustive_external_false() {
     let provider = load_provider();
@@ -435,6 +531,180 @@ fn if_let_with_non_diverging_else_is_not_never() {
             "non-diverging else should not have never type"
         );
     }
+}
+
+/// The operand of `?` must be typed as the call, not as the callee
+///
+/// A lookup at the start offset of the operand finds the callee path,
+/// whose type is a function, not a `Result`. Lints that require a `Result`
+/// operand then never fire.
+#[test]
+fn try_operand_on_call_expression_is_typed_as_the_call_result() {
+    let provider = load_provider();
+    let tree = parse_and_decorate_fixture(provider);
+    let root = tree.root_node();
+
+    let func = find_function_by_name(&root, "returns_anyhow_result")
+        .expect("should find returns_anyhow_result");
+
+    let operand = find_first_try_operand(&func).expect("should find a `?` operand");
+
+    let ty = operand
+        .decoration::<ResolvedType>()
+        .expect("`?` operand should have ResolvedType");
+
+    assert_eq!(
+        operand.text(),
+        "std::fs::read_to_string(\"anyhow_bare.txt\")"
+    );
+    assert!(
+        ty.is_result(),
+        "read_to_string returns a Result, got: {}",
+        ty.display()
+    );
+}
+
+/// The operand of `?` must be typed as the method call, not as the receiver
+///
+/// A lookup at the start offset of `loader.load()?` finds the token
+/// `loader`, whose type is a reference to the struct. This test pins the
+/// method-call shape of the same fault.
+#[test]
+fn try_operand_on_method_call_is_typed_as_the_call_result() {
+    let provider = load_provider();
+    let tree = parse_and_decorate_fixture(provider);
+    let root = tree.root_node();
+
+    let func =
+        find_function_by_name(&root, "try_on_method_call").expect("should find try_on_method_call");
+
+    let operand = find_first_try_operand(&func).expect("should find a `?` operand");
+
+    let ty = operand
+        .decoration::<ResolvedType>()
+        .expect("`?` operand should have ResolvedType");
+
+    assert_eq!(operand.text(), "loader.load()");
+    assert!(
+        ty.is_result(),
+        "Loader::load returns a Result, got: {}",
+        ty.display()
+    );
+}
+
+/// A diagnostic that starts inside `func` but ends past it does not count
+///
+/// A lint reports one node, and nodes nest, so no fixture produces this
+/// shape. The test builds the span by hand.
+#[test]
+fn flagged_within_with_a_span_past_the_function_end_returns_nothing() {
+    let tree = parse_fixture_file("src/lib.rs");
+    let root = tree.root_node();
+    let func = find_function_by_name(&root, "match_on_enum").expect("should find match_on_enum");
+    let Range { start, end } = func.raw().byte_range();
+    let diagnostics = vec![Diagnostic::new(
+        RuleId("lint.test"),
+        Severity::Warn,
+        "a span that leaves the function".to_string(),
+        Span::new(tree.file().to_path_buf(), start, end + 1),
+    )];
+
+    let flagged = flagged_within(&tree, &diagnostics, &func);
+
+    assert!(flagged.is_empty(), "unexpected matches: {flagged:?}");
+}
+
+/// The `anyhow_missing_context` rule fires on decorations the provider made
+///
+/// The rule's unit tests attach decorations by hand, so only an end-to-end
+/// run shows that real decorations satisfy the rule. The expectation lists
+/// everything the rule flags in the function, so the `.context(..)` call
+/// next to the bare `?` must stay unflagged.
+#[test]
+fn anyhow_missing_context_flags_a_bare_try_in_an_anyhow_function() {
+    let provider = load_provider();
+    let tree = parse_and_decorate_fixture(provider);
+    let root = tree.root_node();
+    let func = find_function_by_name(&root, "returns_anyhow_result")
+        .expect("should find returns_anyhow_result");
+    let mut passes: Vec<Box<dyn LintPass>> = vec![AnyhowMissingContext::into_lint_pass()];
+
+    let diagnostics = whisker_core::walk(&tree, &mut passes);
+
+    assert_eq!(
+        flagged_within(&tree, &diagnostics, &func),
+        vec!["std::fs::read_to_string(\"anyhow_bare.txt\")?"]
+    );
+}
+
+#[test]
+fn anyhow_missing_context_flags_a_bare_try_on_a_method_call() {
+    let provider = load_provider();
+    let tree = parse_and_decorate_fixture(provider);
+    let root = tree.root_node();
+    let func =
+        find_function_by_name(&root, "try_on_method_call").expect("should find try_on_method_call");
+    let mut passes: Vec<Box<dyn LintPass>> = vec![AnyhowMissingContext::into_lint_pass()];
+
+    let diagnostics = whisker_core::walk(&tree, &mut passes);
+
+    assert_eq!(
+        flagged_within(&tree, &diagnostics, &func),
+        vec!["loader.load()?"]
+    );
+}
+
+/// The `wildcard_match_arm` rule fires on a scrutinee reached through a field
+///
+/// The old start-offset lookup only resolved scrutinees that are a bare
+/// name. This test pins a shape that lookup used to miss.
+#[test]
+fn wildcard_match_arm_flags_a_scrutinee_reached_through_a_field() {
+    let provider = load_provider();
+    let tree = parse_and_decorate_fixture(provider);
+    let root = tree.root_node();
+    let func = find_function_by_name(&root, "match_on_field_expression")
+        .expect("should find match_on_field_expression");
+    let mut passes: Vec<Box<dyn LintPass>> =
+        vec![Box::new(RustLintPassAdapter::new(WildcardMatchArm))];
+
+    let diagnostics = whisker_core::walk(&tree, &mut passes);
+
+    assert_eq!(flagged_within(&tree, &diagnostics, &func), vec!["_"]);
+}
+
+#[test]
+fn wildcard_match_arm_flags_a_scrutinee_returned_by_a_call() {
+    let provider = load_provider();
+    let tree = parse_and_decorate_fixture(provider);
+    let root = tree.root_node();
+    let func = find_function_by_name(&root, "match_on_call_expression")
+        .expect("should find match_on_call_expression");
+    let mut passes: Vec<Box<dyn LintPass>> =
+        vec![Box::new(RustLintPassAdapter::new(WildcardMatchArm))];
+
+    let diagnostics = whisker_core::walk(&tree, &mut passes);
+
+    assert_eq!(flagged_within(&tree, &diagnostics, &func), vec!["_"]);
+}
+
+/// The `wildcard_match_arm` rule still ignores a non-enum scrutinee
+///
+/// A lookup that resolves too broadly would make `is_enum` true for
+/// scrutinees that are not enums, and this test would catch that.
+#[test]
+fn wildcard_match_arm_ignores_a_scrutinee_that_is_not_an_enum() {
+    let provider = load_provider();
+    let tree = parse_and_decorate_fixture(provider);
+    let root = tree.root_node();
+    let func =
+        find_function_by_name(&root, "match_on_integer").expect("should find match_on_integer");
+    let mut passes: Vec<Box<dyn LintPass>> =
+        vec![Box::new(RustLintPassAdapter::new(WildcardMatchArm))];
+
+    let diagnostics = whisker_core::walk(&tree, &mut passes);
+
+    assert!(flagged_within(&tree, &diagnostics, &func).is_empty());
 }
 
 #[test]


### PR DESCRIPTION
The Rust provider asked rust-analyzer about a tree-sitter node by handing it
the node's first byte and taking the innermost expression around the token
found there. That answers a different question than the one being asked. The
first byte of `std::fs::read_to_string("x")` belongs to the token `std`, whose
innermost enclosing expression is the callee path, so the operand of `?` was
decorated with a function type, not with the `Result` the call produces. The
`anyhow_missing_context` rule bails on any operand that is not a `Result`,
which is why it had never once fired on the form it exists to catch.

The same fault reached match scrutinees, where `match palette.primary` was
typed as `palette` and `match pick_color()` as `pick_color`, so
`wildcard_match_arm` saw a struct and a function where an enum was sitting.
Every shape whose first token starts a smaller expression was affected: calls,
method calls, field access, indexing, and parentheses.

Each target now carries the full byte range of the syntax it is about, and the
lookup descends rust-analyzer's tree to the smallest node covering that range
before climbing to the enclosing expression. That reaches the expression the
range names whatever shape either parser gave it, without depending on the two
trees agreeing about what sits at one offset. Ranges that rust-analyzer's
32-bit offsets cannot express, and the zero-width nodes tree-sitter
synthesizes during error recovery, are dropped instead of resolved, because
both would name some unrelated expression.

The rules' own unit tests hand-build their decorations, so they went on
passing throughout. The provider's integration tests now run the real rules
over the real decorations the real provider makes, which is the only
arrangement that can tell a working rule from one whose input never arrives.
Those tests reach the rule crates through dev-dependencies that point back at
this crate; Cargo permits the cycle, and it costs nothing next to loading a
second workspace.
