### PR TITLE
Add types that name a Rust item rather than render it

### DIFF
--- a/crates/whisker-rust/src/decorations.rs
+++ b/crates/whisker-rust/src/decorations.rs
@@ -5,9 +5,17 @@
 //! module can express.
 
 mod adt_flags;
+mod error_type;
 mod fn_signature;
 mod resolved_type;
+mod return_mode;
+mod type_path;
+mod type_path_ref;
 
 pub use adt_flags::AdtFlags;
+pub use error_type::ErrorType;
 pub use fn_signature::FnSignature;
 pub use resolved_type::ResolvedType;
+pub use return_mode::ReturnMode;
+pub use type_path::TypePath;
+pub use type_path_ref::TypePathRef;

--- a/crates/whisker-rust/src/decorations/error_type.rs
+++ b/crates/whisker-rust/src/decorations/error_type.rs
@@ -1,0 +1,111 @@
+use crate::decorations::{TypePath, TypePathRef};
+
+/// The `E` of the [`Result<T, E>`] a function returns
+///
+/// Not every `E` has a defining item. A type parameter, a reference, or a
+/// tuple has none, so no [`TypePath`] exists for it.
+///
+/// `Box<dyn Error>` is [`ErrorType::Named`] with the path
+/// `alloc::boxed::Box`, because `Box` is the ADT in the `E` slot.
+///
+/// [`Result<T, E>`]: std::result::Result
+/// [`TypePath`]: crate::decorations::TypePath
+#[derive(Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug)]
+pub enum ErrorType {
+    /// The error is an ADT, identified by where it is defined
+    Named(TypePath),
+    /// The error is a type parameter, not a concrete type
+    Generic,
+    /// The error is a type with no defining item
+    Unnamed,
+}
+
+impl ErrorType {
+    /// Returns whether the error type is the one `path` names
+    ///
+    /// The comparison uses definition paths, not rendered names, so
+    /// `syn::Error` does not match `anyhow::Error`.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use whisker_rust::decorations::{ErrorType, TypePath, TypePathRef};
+    ///
+    /// const ANYHOW_ERROR: TypePathRef<'static> = TypePathRef::new("anyhow", &[], "Error");
+    ///
+    /// let error = ErrorType::Named(TypePath::new("syn", ["error"], "Error"));
+    ///
+    /// assert!(!error.is(ANYHOW_ERROR));
+    /// ```
+    pub fn is(&self, path: TypePathRef<'_>) -> bool {
+        match self {
+            ErrorType::Named(actual) => *actual == path,
+            ErrorType::Generic => false,
+            ErrorType::Unnamed => false,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const ANYHOW_ERROR: TypePathRef<'static> = TypePathRef::new("anyhow", &[], "Error");
+
+    #[test]
+    fn is_with_generic_returns_false() {
+        let error = ErrorType::Generic;
+
+        let matches = error.is(ANYHOW_ERROR);
+
+        assert!(!matches);
+    }
+
+    #[test]
+    fn is_with_matching_path_returns_true() {
+        let error = ErrorType::Named(TypePath::new("anyhow", [] as [&str; 0], "Error"));
+
+        let matches = error.is(ANYHOW_ERROR);
+
+        assert!(matches);
+    }
+
+    /// Pins that `syn::Error` does not match a path that names `anyhow::Error`
+    ///
+    /// Both render as `Error`, so only the definition path distinguishes them.
+    #[test]
+    fn is_with_same_name_in_another_crate_returns_false() {
+        let error = ErrorType::Named(TypePath::new("syn", ["error"], "Error"));
+
+        let matches = error.is(ANYHOW_ERROR);
+
+        assert!(!matches);
+    }
+
+    #[test]
+    fn is_with_unnamed_returns_false() {
+        let error = ErrorType::Unnamed;
+
+        let matches = error.is(ANYHOW_ERROR);
+
+        assert!(!matches);
+    }
+
+    #[test]
+    fn trait_send_error_type() {
+        fn assert_send<T: Send>() {}
+        assert_send::<ErrorType>();
+    }
+
+    #[test]
+    fn trait_sync_error_type() {
+        fn assert_sync<T: Sync>() {}
+        assert_sync::<ErrorType>();
+    }
+
+    #[test]
+    fn trait_unpin_error_type() {
+        fn assert_unpin<T: Unpin>() {}
+        assert_unpin::<ErrorType>();
+    }
+}

--- a/crates/whisker-rust/src/decorations/return_mode.rs
+++ b/crates/whisker-rust/src/decorations/return_mode.rs
@@ -1,0 +1,37 @@
+/// Where a function's error type comes from
+///
+/// For a plain function, the declared return type holds the error type. For
+/// an `async fn`, the declared type is an opaque future, and the error type
+/// is in the future's output.
+#[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug)]
+pub enum ReturnMode {
+    /// The error type is in the declared return type
+    Direct,
+    /// The function is `async`; the error type is in the future's output
+    Awaited,
+    /// The function is `async`, but the future's output is unknown
+    Opaque,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn trait_send_return_mode() {
+        fn assert_send<T: Send>() {}
+        assert_send::<ReturnMode>();
+    }
+
+    #[test]
+    fn trait_sync_return_mode() {
+        fn assert_sync<T: Sync>() {}
+        assert_sync::<ReturnMode>();
+    }
+
+    #[test]
+    fn trait_unpin_return_mode() {
+        fn assert_unpin<T: Unpin>() {}
+        assert_unpin::<ReturnMode>();
+    }
+}

--- a/crates/whisker-rust/src/decorations/type_path.rs
+++ b/crates/whisker-rust/src/decorations/type_path.rs
@@ -1,0 +1,210 @@
+use std::fmt;
+
+use crate::decorations::TypePathRef;
+
+/// Where a type is defined, as a path from its crate root
+///
+/// Rust-analyzer can render `syn::Error`, `std::io::Error`, and
+/// `anyhow::Error` all as `Error`. A rule that must distinguish them needs
+/// the definition, not the rendered name.
+///
+/// The path names the item's definition, not a re-export, so `syn::Error`
+/// appears here as `syn::error::Error`.
+///
+/// # Examples
+///
+/// ```
+/// use whisker_rust::decorations::TypePath;
+///
+/// let path = TypePath::new("syn", ["error"], "Error");
+///
+/// assert_eq!(path.to_string(), "syn::error::Error");
+/// ```
+#[derive(Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug)]
+pub struct TypePath {
+    krate: Box<str>,
+    modules: Box<[Box<str>]>,
+    name: Box<str>,
+}
+
+impl TypePath {
+    /// Creates a path from a crate name, its module segments, and an item name
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use whisker_rust::decorations::TypePath;
+    ///
+    /// let path = TypePath::new("anyhow", [] as [&str; 0], "Error");
+    ///
+    /// assert_eq!(path.to_string(), "anyhow::Error");
+    /// ```
+    pub fn new<M>(krate: &str, modules: M, name: &str) -> Self
+    where
+        M: IntoIterator,
+        M::Item: AsRef<str>,
+    {
+        Self {
+            krate: Box::from(krate),
+            modules: modules
+                .into_iter()
+                .map(|segment| Box::from(segment.as_ref()))
+                .collect(),
+            name: Box::from(name),
+        }
+    }
+
+    /// Returns the name of the crate that defines the type
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use whisker_rust::decorations::TypePath;
+    ///
+    /// let path = TypePath::new("syn", ["error"], "Error");
+    ///
+    /// assert_eq!(path.krate(), "syn");
+    /// ```
+    pub fn krate(&self) -> &str {
+        &self.krate
+    }
+
+    /// Returns the module segments between the crate root and the definition
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use whisker_rust::decorations::TypePath;
+    ///
+    /// let path = TypePath::new("syn", ["error"], "Error");
+    ///
+    /// assert_eq!(path.modules().collect::<Vec<_>>(), vec!["error"]);
+    /// ```
+    pub fn modules(&self) -> impl Iterator<Item = &str> {
+        self.modules.iter().map(AsRef::as_ref)
+    }
+
+    /// Returns the item's own name
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use whisker_rust::decorations::TypePath;
+    ///
+    /// let path = TypePath::new("syn", ["error"], "Error");
+    ///
+    /// assert_eq!(path.name(), "Error");
+    /// ```
+    pub fn name(&self) -> &str {
+        &self.name
+    }
+}
+
+/// Renders the crate, the module segments, and the name, joined by `::`
+///
+/// To test identity, compare the path against a [`TypePathRef`].
+///
+/// [`TypePathRef`]: crate::decorations::TypePathRef
+impl fmt::Display for TypePath {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}", self.krate)?;
+        for segment in &self.modules {
+            write!(f, "::{segment}")?;
+        }
+        write!(f, "::{}", self.name)
+    }
+}
+
+impl PartialEq<TypePathRef<'_>> for TypePath {
+    fn eq(&self, other: &TypePathRef<'_>) -> bool {
+        &*self.krate == other.krate()
+            && &*self.name == other.name()
+            && self.modules.len() == other.modules().len()
+            && self
+                .modules
+                .iter()
+                .zip(other.modules())
+                .all(|(lhs, rhs)| &**lhs == *rhs)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn display_renders_crate_modules_and_name() {
+        let path = TypePath::new("syn", ["error"], "Error");
+
+        let rendered = path.to_string();
+
+        assert_eq!(rendered, "syn::error::Error");
+    }
+
+    #[test]
+    fn display_with_no_modules_renders_crate_and_name() {
+        let path = TypePath::new("anyhow", [] as [&str; 0], "Error");
+
+        let rendered = path.to_string();
+
+        assert_eq!(rendered, "anyhow::Error");
+    }
+
+    #[test]
+    fn eq_with_different_crate_is_false() {
+        let path = TypePath::new("thiserror", [] as [&str; 0], "Error");
+
+        let matches = path == TypePathRef::new("anyhow", &[], "Error");
+
+        assert!(!matches);
+    }
+
+    /// Pins the explicit length check in the module comparison
+    ///
+    /// `zip` stops at the shorter list, so without the check a path whose
+    /// modules are a prefix of another's compares equal.
+    #[test]
+    fn eq_with_different_module_depth_is_false() {
+        let path = TypePath::new("core", ["io", "error"], "Error");
+
+        let matches = path == TypePathRef::new("core", &["io"], "Error");
+
+        assert!(!matches);
+    }
+
+    #[test]
+    fn eq_with_different_name_is_false() {
+        let path = TypePath::new("anyhow", [] as [&str; 0], "Chain");
+
+        let matches = path == TypePathRef::new("anyhow", &[], "Error");
+
+        assert!(!matches);
+    }
+
+    #[test]
+    fn eq_with_matching_type_path_ref_is_true() {
+        let path = TypePath::new("syn", ["error"], "Error");
+
+        let matches = path == TypePathRef::new("syn", &["error"], "Error");
+
+        assert!(matches);
+    }
+
+    #[test]
+    fn trait_send_type_path() {
+        fn assert_send<T: Send>() {}
+        assert_send::<TypePath>();
+    }
+
+    #[test]
+    fn trait_sync_type_path() {
+        fn assert_sync<T: Sync>() {}
+        assert_sync::<TypePath>();
+    }
+
+    #[test]
+    fn trait_unpin_type_path() {
+        fn assert_unpin<T: Unpin>() {}
+        assert_unpin::<TypePath>();
+    }
+}

--- a/crates/whisker-rust/src/decorations/type_path_ref.rs
+++ b/crates/whisker-rust/src/decorations/type_path_ref.rs
@@ -1,0 +1,124 @@
+/// A borrowed [`TypePath`] a rule can declare as a `const`
+///
+/// [`TypePath`] owns its segments and cannot be a `const`. This type
+/// borrows instead, so a rule declares the type it checks for at module
+/// scope.
+///
+/// # Examples
+///
+/// ```
+/// use whisker_rust::decorations::{TypePath, TypePathRef};
+///
+/// const ANYHOW_ERROR: TypePathRef<'static> = TypePathRef::new("anyhow", &[], "Error");
+///
+/// assert!(TypePath::new("anyhow", [] as [&str; 0], "Error") == ANYHOW_ERROR);
+/// assert!(TypePath::new("syn", ["error"], "Error") != ANYHOW_ERROR);
+/// ```
+///
+/// [`TypePath`]: crate::decorations::TypePath
+#[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug)]
+pub struct TypePathRef<'a> {
+    krate: &'a str,
+    modules: &'a [&'a str],
+    name: &'a str,
+}
+
+impl<'a> TypePathRef<'a> {
+    /// Creates a borrowed path usable in a `const`
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use whisker_rust::decorations::TypePathRef;
+    ///
+    /// const ANYHOW_ERROR: TypePathRef<'static> = TypePathRef::new("anyhow", &[], "Error");
+    ///
+    /// assert_eq!(ANYHOW_ERROR.krate(), "anyhow");
+    /// ```
+    pub const fn new(krate: &'a str, modules: &'a [&'a str], name: &'a str) -> Self {
+        Self {
+            krate,
+            modules,
+            name,
+        }
+    }
+
+    /// Returns the name of the crate that defines the type
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use whisker_rust::decorations::TypePathRef;
+    ///
+    /// let path = TypePathRef::new("syn", &["error"], "Error");
+    ///
+    /// assert_eq!(path.krate(), "syn");
+    /// ```
+    pub const fn krate(&self) -> &'a str {
+        self.krate
+    }
+
+    /// Returns the module segments between the crate root and the definition
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use whisker_rust::decorations::TypePathRef;
+    ///
+    /// let path = TypePathRef::new("syn", &["error"], "Error");
+    ///
+    /// assert_eq!(path.modules(), &["error"]);
+    /// ```
+    pub const fn modules(&self) -> &'a [&'a str] {
+        self.modules
+    }
+
+    /// Returns the item's own name
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use whisker_rust::decorations::TypePathRef;
+    ///
+    /// let path = TypePathRef::new("syn", &["error"], "Error");
+    ///
+    /// assert_eq!(path.name(), "Error");
+    /// ```
+    pub const fn name(&self) -> &'a str {
+        self.name
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn accessors_return_the_constructed_parts() {
+        let path = TypePathRef::new("core", &["io", "error"], "Error");
+
+        let (krate, modules, name) = (path.krate(), path.modules(), path.name());
+
+        assert_eq!(krate, "core");
+        assert_eq!(modules, &["io", "error"]);
+        assert_eq!(name, "Error");
+    }
+
+    #[test]
+    fn trait_send_type_path_ref() {
+        fn assert_send<T: Send>() {}
+        assert_send::<TypePathRef<'static>>();
+    }
+
+    #[test]
+    fn trait_sync_type_path_ref() {
+        fn assert_sync<T: Sync>() {}
+        assert_sync::<TypePathRef<'static>>();
+    }
+
+    #[test]
+    fn trait_unpin_type_path_ref() {
+        fn assert_unpin<T: Unpin>() {}
+        assert_unpin::<TypePathRef<'static>>();
+    }
+}


### PR DESCRIPTION
`anyhow_missing_context` decides whether a function returns an anyhow error by
comparing the rendered type name against `"anyhow::Error"` or `"Error"`.
rust-analyzer renders `syn::Error`, `serde_json::Error`, `std::io::Error`, and
`std::fmt::Error` all as `Error`, so the comparison cannot tell them apart. A
display string does not carry type identity, and no amount of string
comparison recovers it.

This adds the types that carry it instead. `TypePath` names the item that
defines a type (crate, module path, item), and `TypePathRef` is its borrowed
form, so a lint can hold a path as a constant and compare against it without
allocating. `ErrorType` pairs a function's error type with that path.
`ReturnMode` records whether a signature was read directly, awaited through an
`async fn`, or left opaque, which keeps "async and unprojectable"
distinguishable from "async and not a `Result`".

None of it is wired up here. The change that teaches the provider to resolve
identities and the rule to compare them comes right after.
