### PR TITLE
Resolve error types by identity, not by rendering

### DIFF
--- a/crates/whisker-rust/src/decorations/fn_signature.rs
+++ b/crates/whisker-rust/src/decorations/fn_signature.rs
@@ -1,57 +1,80 @@
-use crate::decorations::ResolvedType;
+use crate::decorations::{ErrorType, ResolvedType, ReturnMode};
 
 /// Function signature information
 ///
-/// Attached to function item nodes so lints can inspect the return type
-/// without re-querying the semantic model.
+/// Attached to `function_item` nodes so lints can inspect the return type
+/// without re-querying the semantic model. Every resolved function gets a
+/// signature, even an empty one. An absent decoration would look like a
+/// function the provider never reached, and those are different facts.
 #[derive(Clone, Eq, PartialEq, Hash, Debug)]
 pub struct FnSignature {
     return_type: Option<ResolvedType>,
-    error_type_name: Option<String>,
+    error_type: Option<ErrorType>,
+    return_mode: ReturnMode,
 }
 
 impl FnSignature {
     /// Creates a function signature
-    pub fn new(return_type: Option<ResolvedType>, error_type_name: Option<String>) -> Self {
+    pub fn new(
+        return_type: Option<ResolvedType>,
+        error_type: Option<ErrorType>,
+        return_mode: ReturnMode,
+    ) -> Self {
         Self {
             return_type,
-            error_type_name,
+            error_type,
+            return_mode,
         }
     }
 
-    /// Returns the resolved return type, if available
+    /// Returns the resolved return type, awaited for an `async fn`
     pub fn return_type(&self) -> Option<&ResolvedType> {
         self.return_type.as_ref()
     }
 
-    /// Returns the error type name for `Result`-returning functions
+    /// Returns the `E` of the `Result<T, E>` this function returns
     ///
-    /// This is the fully qualified name of the `E` in `Result<T, E>`,
-    /// e.g. `"anyhow::Error"`.
-    pub fn error_type_name(&self) -> Option<&str> {
-        self.error_type_name.as_deref()
+    /// [`None`] means the function does not return a `core::result::Result`.
+    /// That includes an `async fn` whose awaited type is not one, and one
+    /// whose future could not be projected.
+    pub fn error_type(&self) -> Option<&ErrorType> {
+        self.error_type.as_ref()
+    }
+
+    /// Returns where the return type was read from
+    pub fn return_mode(&self) -> ReturnMode {
+        self.return_mode
     }
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::decorations::{TypePath, TypePathRef};
 
     #[test]
     fn fn_signature_with_return_type() {
         let ret = ResolvedType::new("Result<(), anyhow::Error>".into()).with_result(true);
-        let sig = FnSignature::new(Some(ret), Some("anyhow::Error".into()));
+        let error = ErrorType::Named(TypePath::new("anyhow", [] as [&str; 0], "Error"));
+
+        let sig = FnSignature::new(Some(ret), Some(error), ReturnMode::Direct);
 
         assert!(sig.return_type().unwrap().is_result());
-        assert_eq!(sig.error_type_name(), Some("anyhow::Error"));
+        assert!(
+            sig.error_type()
+                .unwrap()
+                .is(TypePathRef::new("anyhow", &[], "Error"))
+        );
+        assert_eq!(sig.return_mode(), ReturnMode::Direct);
     }
 
     #[test]
     fn fn_signature_without_return_type() {
-        let sig = FnSignature::new(None, None);
+        let sig = FnSignature::new(None, None, ReturnMode::Opaque);
 
         assert!(sig.return_type().is_none());
-        assert!(sig.error_type_name().is_none());
+        assert!(sig.error_type().is_none());
+        assert_eq!(sig.return_mode(), ReturnMode::Opaque);
     }
 
     #[test]

--- a/crates/whisker-rust/src/provider.rs
+++ b/crates/whisker-rust/src/provider.rs
@@ -1,20 +1,22 @@
+use std::ops::Range;
 use std::path::Path;
 use std::sync::{Arc, Mutex};
 
 use anyhow::Context as _;
-use ra_ap_hir::{Adt, HasAttrs, HirDisplay, Semantics, attach_db};
+use ra_ap_hir::{Adt, Enum, Function, HasAttrs, HirDisplay, Module, Semantics, Type, attach_db};
 use ra_ap_ide_db::base_db::SourceDatabase as _;
+use ra_ap_ide_db::famous_defs::FamousDefs;
 use ra_ap_ide_db::{ChangeWithProcMacros, RootDatabase};
 use ra_ap_load_cargo::{LoadCargoConfig, ProcMacroServerChoice};
 use ra_ap_project_model::{CargoConfig, ProjectManifest, ProjectWorkspace};
-use ra_ap_syntax::{AstNode, NodeOrToken, SyntaxNode, TextRange, TextSize, ast};
+use ra_ap_syntax::{AstNode, Edition, NodeOrToken, SyntaxNode, TextRange, TextSize, ast};
 use ra_ap_vfs::{AbsPathBuf, FileExcluded, FileId, Vfs, VfsPath};
 use whisker_types::{
     Coverage, CoverageGap, DecoratedNode, DecoratedTree, DecorationMap, DecorationProvider,
     ProviderName,
 };
 
-use crate::decorations::{AdtFlags, FnSignature, ResolvedType};
+use crate::decorations::{AdtFlags, ErrorType, FnSignature, ResolvedType, ReturnMode, TypePath};
 
 /// Decoration provider for Rust using rust-analyzer
 ///
@@ -262,18 +264,18 @@ impl DecorationProvider for RustDecorationProvider {
         let coverage = attach_db(&*db, || {
             let sema = Semantics::new(&*db);
 
-            if sema.file_to_module_def(file_id).is_none() {
+            let Some(module) = sema.file_to_module_def(file_id) else {
                 return Coverage::NotCovered(CoverageGap::Unreachable {
                     root: Arc::clone(&self.root),
                 });
-            }
+            };
 
             let db_text: &str = db.file_text(file_id).text(&*db);
             if db_text != tree.source() {
                 return Coverage::NotCovered(CoverageGap::StaleSource);
             }
 
-            Coverage::Covered(resolve_targets(&sema, file_id, &targets))
+            Coverage::Covered(resolve_targets(&sema, file_id, module, &targets))
         });
 
         Ok(coverage)
@@ -282,19 +284,30 @@ impl DecorationProvider for RustDecorationProvider {
 
 /// Resolves every collected target against rust-analyzer's parse
 ///
-/// The caller has already checked that `file_id` belongs to a module and
-/// that its recorded text matches the source the targets index into.
+/// The caller has already established that `file_id` belongs to `module`
+/// and that its recorded text matches the text the targets' byte ranges
+/// were taken from.
+///
+/// `module` identifies the crate. The crate supplies the edition for
+/// display and the `core` definitions of `Result` and `Option`. These
+/// resolve once per file, not once per target.
 fn resolve_targets(
     sema: &Semantics<'_, RootDatabase>,
     file_id: FileId,
+    module: Module,
     targets: &[Target],
 ) -> DecorationMap {
     let source_file = sema.parse_guess_edition(file_id);
     let syntax = source_file.syntax().clone();
 
+    let krate = module.krate(sema.db);
+    let famous = FamousDefs(sema, krate);
     let ctx = DecorateCtx {
         sema,
         syntax: &syntax,
+        edition: krate.edition(sema.db),
+        core_result: famous.core_result_Result(),
+        core_option: famous.core_option_Option(),
     };
 
     let mut decorations = DecorationMap::new();
@@ -367,17 +380,25 @@ enum Target {
     },
 }
 
-/// Converts a tree-sitter byte range into a rust-analyzer [`TextRange`]
+/// Converts a byte range into rust-analyzer's 32-bit one
 ///
-/// Rust-analyzer stores text offsets as 32 bits. When an offset does not
-/// fit, the function returns [`None`]. The caller then skips the target,
-/// because a truncated offset would name some other expression.
-fn text_range_of(node: &DecoratedNode<'_>) -> Option<TextRange> {
-    let range = node.raw().byte_range();
-    let start = u32::try_from(range.start).ok()?;
-    let end = u32::try_from(range.end).ok()?;
+/// Rust-analyzer addresses text with 32-bit offsets. An offset that does
+/// not fit yields [`None`], because a truncated offset would name some
+/// other expression.
+///
+/// The conversion is a separate function so that a unit test can reach the
+/// 32-bit boundary without a four-gigabyte file.
+fn text_range_from(range: Range<usize>) -> Option<TextRange> {
+    let Range { start, end } = range;
+    let start = u32::try_from(start).ok()?;
+    let end = u32::try_from(end).ok()?;
 
     Some(TextRange::new(TextSize::from(start), TextSize::from(end)))
+}
+
+/// Converts a tree-sitter node's byte range into rust-analyzer's
+fn text_range_of(node: &DecoratedNode<'_>) -> Option<TextRange> {
+    text_range_from(node.raw().byte_range())
 }
 
 fn collect_targets(node: &DecoratedNode<'_>, targets: &mut Vec<Target>) {
@@ -429,13 +450,20 @@ fn collect_targets(node: &DecoratedNode<'_>, targets: &mut Vec<Target>) {
     }
 }
 
+/// Shared state for resolving one file's targets
+///
+/// The edition and the `core` enums are per-crate, so `resolve_targets`
+/// fills them once for the whole file.
 struct DecorateCtx<'a, 'db> {
     sema: &'a Semantics<'db, RootDatabase>,
-    syntax: &'a ra_ap_syntax::SyntaxNode,
+    syntax: &'a SyntaxNode,
+    edition: Edition,
+    core_result: Option<Enum>,
+    core_option: Option<Enum>,
 }
 
 impl DecorateCtx<'_, '_> {
-    fn display_type(&self, ty: &ra_ap_hir::Type<'_>, func: &ra_ap_hir::Function) -> String {
+    fn display_type(&self, ty: &Type<'_>, func: &Function) -> String {
         let krate = func.module(self.sema.db).krate(self.sema.db);
         let target = krate.to_display_target(self.sema.db);
         format!("{}", ty.display(self.sema.db, target))
@@ -444,57 +472,152 @@ impl DecorateCtx<'_, '_> {
 
 /// Returns the smallest node in rust-analyzer's tree that covers `range`
 ///
-/// Tree-sitter's parse and rust-analyzer's parse agree on byte offsets but
-/// not on tree shape, so the function locates a node by its span. Callers
-/// climb from the covering node to the smallest [`ast::Expr`] or
-/// [`ast::Fn`] that encloses the whole span.
+/// The two parsers agree on byte offsets but not on tree shape, so this
+/// function locates a tree-sitter node by the span it occupies. From the
+/// smallest covering node, the callers climb to the smallest [`ast::Expr`]
+/// or [`ast::Fn`] that encloses the whole span.
 ///
-/// The function returns [`None`] for an empty range or a range outside the
-/// tree. Tree-sitter synthesizes zero-width nodes during error recovery,
-/// and a zero-width span "covers" some unrelated neighbor.
-fn covering_node(ctx: &DecorateCtx<'_, '_>, range: TextRange) -> Option<SyntaxNode> {
-    if range.is_empty() || !ctx.syntax.text_range().contains_range(range) {
+/// The function refuses an empty range. Tree-sitter synthesizes zero-width
+/// nodes during error recovery, and a zero-width span sits inside some
+/// token, so the broken node would take that token's type.
+///
+/// It also refuses a range past the end of `syntax`.
+/// [`SyntaxNode::covering_element`] panics on such a range, and one bad
+/// target would abort the whole run.
+///
+/// The function takes the tree instead of the whole [`DecorateCtx`] so
+/// that unit tests can call it without a loaded workspace.
+fn covering_node(syntax: &SyntaxNode, range: TextRange) -> Option<SyntaxNode> {
+    if range.is_empty() || !syntax.text_range().contains_range(range) {
         return None;
     }
 
-    match ctx.syntax.covering_element(range) {
+    match syntax.covering_element(range) {
         NodeOrToken::Node(node) => Some(node),
         NodeOrToken::Token(token) => token.parent(),
     }
 }
 
-fn find_enclosing_fn(ctx: &DecorateCtx<'_, '_>, range: TextRange) -> Option<ra_ap_hir::Function> {
-    let fn_node = covering_node(ctx, range)?
+fn find_enclosing_fn(ctx: &DecorateCtx<'_, '_>, range: TextRange) -> Option<Function> {
+    let fn_node = covering_node(ctx.syntax, range)?
         .ancestors()
         .find_map(ast::Fn::cast)?;
     ctx.sema.to_def(&fn_node)
 }
 
 fn find_expr_covering(ctx: &DecorateCtx<'_, '_>, range: TextRange) -> Option<ast::Expr> {
-    covering_node(ctx, range)?
+    covering_node(ctx.syntax, range)?
         .ancestors()
         .find_map(ast::Expr::cast)
+}
+
+/// Returns the return type as seen from inside the function's body
+///
+/// For an `async fn`, that is the future's output. In the body, `?` and
+/// `return` convert into the output, not into the opaque `impl Future`.
+///
+/// The projection uses [`Function::async_ret_type`], which returns a type
+/// only for an `async fn`. A `Future`-implementation test would also match
+/// `fn f() -> impl Future<Output = anyhow::Result<()>>`, where the body's
+/// `?` does not target that [`Result<T, E>`].
+///
+/// [`Result<T, E>`]: std::result::Result
+fn effective_return_type<'db>(
+    ctx: &DecorateCtx<'_, 'db>,
+    func: Function,
+) -> (Option<Type<'db>>, ReturnMode) {
+    if func.is_async(ctx.sema.db) {
+        match func.async_ret_type(ctx.sema.db) {
+            Some(ty) => (Some(ty), ReturnMode::Awaited),
+            None => (None, ReturnMode::Opaque),
+        }
+    } else {
+        (Some(func.ret_type(ctx.sema.db)), ReturnMode::Direct)
+    }
+}
+
+/// Returns whether `ty` is an instance of the enum `target` names
+///
+/// The comparison is by identity, not by rendered name: a user's own
+/// `myres::Result<T>` renders as `Result<..>` but does not match.
+fn is_instance_of(ty: &Type<'_>, target: Option<Enum>) -> bool {
+    let Some(target) = target else {
+        return false;
+    };
+
+    match ty.as_adt() {
+        Some(Adt::Enum(actual)) => actual == target,
+        Some(Adt::Struct(_)) => false,
+        Some(Adt::Union(_)) => false,
+        None => false,
+    }
+}
+
+/// Returns the path of `ty`'s definition, if it has one
+///
+/// The path is the definition's, not a re-export's.
+fn type_path(ctx: &DecorateCtx<'_, '_>, ty: &Type<'_>) -> Option<TypePath> {
+    let db = ctx.sema.db;
+    let adt = ty.as_adt()?;
+    let module = adt.module(db);
+    let krate = module.krate(db).display_name(db)?;
+    let modules: Vec<String> = module
+        .path_segments(db)
+        .map(|segment| segment.display(db, ctx.edition).to_string())
+        .collect();
+    let name = adt.name(db).display(db, ctx.edition).to_string();
+
+    Some(TypePath::new(&krate.to_string(), modules, &name))
+}
+
+/// Classifies the `E` of a [`Result<T, E>`]
+///
+/// A type parameter becomes [`ErrorType::Generic`]; a type with no
+/// definition path at all becomes [`ErrorType::Unnamed`]. Neither gets an
+/// invented name, because callers compare the result against real paths.
+///
+/// [`Result<T, E>`]: std::result::Result
+fn classify_error(ctx: &DecorateCtx<'_, '_>, ty: &Type<'_>) -> ErrorType {
+    match type_path(ctx, ty) {
+        Some(path) => ErrorType::Named(path),
+        None => match ty.as_type_param(ctx.sema.db) {
+            Some(_) => ErrorType::Generic,
+            None => ErrorType::Unnamed,
+        },
+    }
+}
+
+/// Returns the classified `E` when `ty` really is `core::result::Result<T, E>`
+fn result_error_type(ctx: &DecorateCtx<'_, '_>, ty: &Type<'_>) -> Option<ErrorType> {
+    let core_result = ctx.core_result?;
+    let (adt, args) = ty.as_adt_with_args()?;
+    let Adt::Enum(actual) = adt else {
+        return None;
+    };
+    if actual != core_result {
+        return None;
+    }
+
+    let error = args.into_iter().nth(1)??;
+    Some(classify_error(ctx, &error))
 }
 
 fn resolve_function(ctx: &DecorateCtx<'_, '_>, range: TextRange) -> Option<FnSignature> {
     let func = find_enclosing_fn(ctx, range)?;
 
-    let ret_type = func.ret_type(ctx.sema.db);
-    let display = ctx.display_type(&ret_type, &func);
-    let is_result = display.starts_with("Result<") || display.contains("::Result<");
-    let is_never = ret_type.is_never();
-
-    let resolved = ResolvedType::new(display.clone())
-        .with_result(is_result)
-        .with_never(is_never);
-
-    let error_type_name = if is_result {
-        extract_result_error_type(&display)
-    } else {
-        None
+    let (ret_type, return_mode) = effective_return_type(ctx, func);
+    let Some(ret_type) = ret_type else {
+        return Some(FnSignature::new(None, None, return_mode));
     };
 
-    Some(FnSignature::new(Some(resolved), error_type_name))
+    let display = ctx.display_type(&ret_type, &func);
+    let error_type = result_error_type(ctx, &ret_type);
+
+    let resolved = ResolvedType::new(display)
+        .with_result(is_instance_of(&ret_type, ctx.core_result))
+        .with_never(ret_type.is_never());
+
+    Some(FnSignature::new(Some(resolved), error_type, return_mode))
 }
 
 fn resolve_match_scrutinee(
@@ -539,8 +662,8 @@ fn resolve_expr_type(ctx: &DecorateCtx<'_, '_>, range: TextRange) -> Option<Reso
         None => format!("{ty:?}"),
     };
 
-    let is_result = display.starts_with("Result<") || display.contains("::Result<");
-    let is_option = display.starts_with("Option<") || display.contains("::Option<");
+    let is_result = is_instance_of(&ty, ctx.core_result);
+    let is_option = is_instance_of(&ty, ctx.core_option);
     let is_never = ty.is_never();
 
     Some(
@@ -551,30 +674,38 @@ fn resolve_expr_type(ctx: &DecorateCtx<'_, '_>, range: TextRange) -> Option<Reso
     )
 }
 
-fn extract_result_error_type(display: &str) -> Option<String> {
-    let inner = display.strip_prefix("Result<")?.strip_suffix('>')?;
-
-    let mut depth = 0;
-    for (i, ch) in inner.char_indices() {
-        match ch {
-            '<' => depth += 1,
-            '>' => depth -= 1,
-            ',' if depth == 0 => {
-                let error_part = inner[i + 1..].trim();
-                return Some(error_part.to_string());
-            }
-            _ => {}
-        }
-    }
-
-    None
-}
-
 #[cfg(test)]
 mod tests {
     use std::path::PathBuf;
 
+    use ra_ap_syntax::SourceFile;
+
     use super::*;
+
+    /// The source every `covering_node` test locates a range in
+    ///
+    /// `value` is several bytes long, so an empty range can sit strictly
+    /// inside a token, where only the guard prevents a match.
+    const COVERING_SOURCE: &str = "fn main() { let value = 1; }";
+
+    fn covering_source_tree() -> SyntaxNode {
+        SourceFile::parse(COVERING_SOURCE, Edition::CURRENT)
+            .tree()
+            .syntax()
+            .clone()
+    }
+
+    fn offset_of(needle: &str) -> u32 {
+        let found = COVERING_SOURCE
+            .find(needle)
+            .unwrap_or_else(|| panic!("the fixture source should contain {needle}"));
+
+        u32::try_from(found).expect("the fixture source is small")
+    }
+
+    fn range_at(offset: u32, len: u32) -> TextRange {
+        TextRange::new(TextSize::from(offset), TextSize::from(offset + len))
+    }
 
     /// Parses `source` as the contents of `file_path`, without decorating it
     fn parse_rust(source: &str, file_path: PathBuf) -> DecoratedTree {
@@ -616,33 +747,45 @@ mod tests {
         }
     }
 
+    /// A zero-width span must not take the type of the token around it
+    ///
+    /// Rowan resolves an empty range to the token that contains it. Without
+    /// the guard, a zero-width node would take that token's type.
     #[test]
-    fn extract_result_error_type_simple() {
-        assert_eq!(
-            extract_result_error_type("Result<(), anyhow::Error>"),
-            Some("anyhow::Error".into())
+    fn covering_node_with_empty_range_returns_none() {
+        let syntax = covering_source_tree();
+        let inside_an_identifier = TextSize::from(offset_of("value") + 1);
+
+        let covering = covering_node(
+            &syntax,
+            TextRange::new(inside_an_identifier, inside_an_identifier),
         );
+
+        assert!(covering.is_none());
     }
 
     #[test]
-    fn extract_result_error_type_nested_generics() {
-        assert_eq!(
-            extract_result_error_type("Result<Vec<String>, std::io::Error>"),
-            Some("std::io::Error".into())
-        );
+    fn covering_node_with_range_inside_the_file_returns_a_node() {
+        let syntax = covering_source_tree();
+        let value = offset_of("value");
+
+        let covering = covering_node(&syntax, range_at(value, 5)).expect("should cover `value`");
+
+        assert!(covering.text_range().contains_range(range_at(value, 5)));
     }
 
+    /// A span past the end of the tree must be skipped, not asserted on
+    ///
+    /// [`SyntaxNode::covering_element`] panics on a range outside the tree,
+    /// so the guard skips the target instead of aborting the run.
     #[test]
-    fn extract_result_error_type_no_match() {
-        assert_eq!(extract_result_error_type("Option<i32>"), None);
-    }
+    fn covering_node_with_range_past_the_end_returns_none() {
+        let syntax = covering_source_tree();
+        let past_the_end = u32::try_from(COVERING_SOURCE.len()).expect("fixture is small") + 1;
 
-    #[test]
-    fn extract_result_error_type_unit_ok() {
-        assert_eq!(
-            extract_result_error_type("Result<(), Box<dyn Error>>"),
-            Some("Box<dyn Error>".into())
-        );
+        let covering = covering_node(&syntax, range_at(past_the_end, 1));
+
+        assert!(covering.is_none());
     }
 
     #[cfg(unix)]
@@ -662,5 +805,27 @@ mod tests {
             error.to_string().contains("not valid UTF-8"),
             "unexpected error: {error:#}"
         );
+    }
+
+    /// A span past the 32-bit limit must produce no target at all
+    ///
+    /// A truncated offset would name an unrelated span. The conversion is a
+    /// separate function because a real file at this boundary would need
+    /// four gigabytes.
+    #[test]
+    fn text_range_from_with_offset_past_u32_returns_none() {
+        let past_u32 =
+            usize::try_from(u64::from(u32::MAX) + 1).expect("this test assumes a 64-bit target");
+
+        let converted = text_range_from(0..past_u32);
+
+        assert!(converted.is_none());
+    }
+
+    #[test]
+    fn text_range_from_with_offsets_within_u32_returns_the_range() {
+        let converted = text_range_from(3..7).expect("a small range should convert");
+
+        assert_eq!(converted, range_at(3, 4));
     }
 }

--- a/crates/whisker-rust/tests/fixtures/sample_project/Cargo.lock
+++ b/crates/whisker-rust/tests/fixtures/sample_project/Cargo.lock
@@ -9,8 +9,44 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
+name = "proc-macro2"
+version = "1.0.107"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "985e7ec9bb745e6ce6535b544d84d6cd6f7ad8bd711c398938ae983b91a766d9"
+dependencies = [
+ "unicode-ident",
+]
+
+[[package]]
+name = "quote"
+version = "1.0.47"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fbf4db142a473a8d80c26bbf18454ed458bf8d26c8219c331daecfdbd079001"
+dependencies = [
+ "proc-macro2",
+]
+
+[[package]]
 name = "sample_project"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "syn",
 ]
+
+[[package]]
+name = "syn"
+version = "3.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53e9bae58849f64dfa4f5d5ae372c8341f7305f82a3868709269343628b659a3"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
+
+[[package]]
+name = "unicode-ident"
+version = "1.0.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"

--- a/crates/whisker-rust/tests/fixtures/sample_project/Cargo.toml
+++ b/crates/whisker-rust/tests/fixtures/sample_project/Cargo.toml
@@ -7,3 +7,6 @@ edition = "2024"
 
 [dependencies]
 anyhow = "1"
+# `syn` declares `Error` in a private `error` module and re-exports it at the
+# crate root, so `Error`'s definition path and its public path differ.
+syn = "3"

--- a/crates/whisker-rust/tests/fixtures/sample_project/src/lib.rs
+++ b/crates/whisker-rust/tests/fixtures/sample_project/src/lib.rs
@@ -97,6 +97,87 @@ pub struct Config {
     pub debug: bool,
 }
 
+pub mod errors {
+    #[derive(Debug)]
+    pub struct Error;
+}
+
+pub mod myres {
+    pub enum Result<T> {
+        Ok(T),
+    }
+}
+
+pub struct Rendered;
+
+impl std::fmt::Display for Rendered {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "rendered")?;
+        Ok(())
+    }
+}
+
+pub fn returns_syn_result() -> syn::Result<()> {
+    let _ident: syn::Ident = syn::parse_str("whisker")?;
+    Ok(())
+}
+
+pub fn returns_local_error_result() -> Result<(), errors::Error> {
+    inner_local()?;
+    Ok(())
+}
+
+fn inner_local() -> Result<(), errors::Error> {
+    Ok(())
+}
+
+pub fn returns_boxed_error() -> Result<(), Box<dyn std::error::Error>> {
+    let _file = std::fs::read_to_string("boxed.txt")?;
+    Ok(())
+}
+
+pub fn returns_generic_error<E>() -> Result<(), E>
+where
+    E: From<std::io::Error>,
+{
+    let _file = std::fs::read_to_string("generic.txt")?;
+    Ok(())
+}
+
+pub async fn returns_anyhow_result_async() -> anyhow::Result<()> {
+    let _file = std::fs::read_to_string("async_anyhow_bare.txt")?;
+    Ok(())
+}
+
+pub async fn returns_io_result_async() -> std::io::Result<()> {
+    let _file = std::fs::read_to_string("async_io_bare.txt")?;
+    Ok(())
+}
+
+pub trait AsyncLoad {
+    fn load_async(&self) -> impl std::future::Future<Output = anyhow::Result<()>>;
+}
+
+impl AsyncLoad for Loader {
+    async fn load_async(&self) -> anyhow::Result<()> {
+        let _file = std::fs::read_to_string(&self.path)?;
+        Ok(())
+    }
+}
+
+pub fn closure_returning_io_result() -> anyhow::Result<()> {
+    let read = || -> std::io::Result<()> {
+        let _file = std::fs::read_to_string("closure.txt")?;
+        Ok(())
+    };
+    read()?;
+    Ok(())
+}
+
+pub fn user_defined_result() -> myres::Result<()> {
+    myres::Result::Ok(())
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/crates/whisker-rust/tests/provider_integration.rs
+++ b/crates/whisker-rust/tests/provider_integration.rs
@@ -3,7 +3,7 @@ use std::path::{Path, PathBuf};
 use std::sync::OnceLock;
 
 use anyhow_missing_context::AnyhowMissingContext;
-use whisker_rust::decorations::{AdtFlags, FnSignature, ResolvedType};
+use whisker_rust::decorations::{AdtFlags, FnSignature, ResolvedType, ReturnMode, TypePathRef};
 use whisker_rust::{RustDecorationProvider, RustLintPassAdapter};
 use whisker_types::{
     Coverage, CoverageGap, DecoratedNode, DecoratedTree, DecorationProvider, Diagnostic, LintPass,
@@ -143,6 +143,18 @@ fn flagged_within<'a>(
         .iter()
         .map(Diagnostic::span)
         .filter(|span| start <= span.start() && span.end() <= end)
+        .map(|span| &tree.source()[span.start()..span.end()])
+        .collect()
+}
+
+/// Returns the source text covered by every diagnostic in the file
+///
+/// A per-function expectation cannot notice a rule that fires somewhere
+/// else. A whole-file expectation fails on any change in the rule's reach.
+fn flagged_in_file<'a>(tree: &'a DecoratedTree, diagnostics: &[Diagnostic]) -> Vec<&'a str> {
+    diagnostics
+        .iter()
+        .map(Diagnostic::span)
         .map(|span| &tree.source()[span.start()..span.end()])
         .collect()
 }
@@ -311,6 +323,40 @@ fn fn_signature_on_anyhow_result_function() {
     );
 }
 
+/// An `async fn`'s signature must describe the awaited type
+///
+/// `Function::ret_type` reads the opaque future from the signature, and a
+/// regression to it fails both the mode and the error-type assertions.
+#[test]
+fn fn_signature_on_async_function_reports_the_awaited_type() {
+    let provider = load_provider();
+    let tree = parse_and_decorate_fixture(provider);
+    let root = tree.root_node();
+
+    let func = find_function_by_name(&root, "returns_anyhow_result_async")
+        .expect("should find returns_anyhow_result_async");
+
+    let sig = func
+        .decoration::<FnSignature>()
+        .expect("should have FnSignature decoration");
+
+    assert_eq!(sig.return_mode(), ReturnMode::Awaited);
+    let ret = sig.return_type().expect("should have return type");
+    assert!(
+        ret.is_result(),
+        "the awaited type should be Result, got display: {}",
+        ret.display()
+    );
+    let error = sig.error_type().expect("should have an error type");
+    assert!(
+        error.is(TypePathRef::new("anyhow", &[], "Error")),
+        "the awaited error should be anyhow's, got: {error:?}"
+    );
+}
+
+/// The error of `std::io::Result` resolves to `core::io::error::Error`
+///
+/// `std::io::Error` is a re-export, so the definition path names `core`.
 #[test]
 fn fn_signature_on_io_result_function() {
     let provider = load_provider();
@@ -330,6 +376,11 @@ fn fn_signature_on_io_result_function() {
         "return type should be Result, got display: {}",
         ret.display()
     );
+    let error = sig.error_type().expect("should have an error type");
+    assert!(
+        error.is(TypePathRef::new("core", &["io", "error"], "Error")),
+        "the error should be io's, got: {error:?}"
+    );
 }
 
 #[test]
@@ -346,7 +397,50 @@ fn fn_signature_on_non_result_function() {
 
     let ret = sig.return_type().expect("should have return type");
     assert!(!ret.is_result(), "return type should not be Result");
-    assert!(sig.error_type_name().is_none());
+    assert!(sig.error_type().is_none());
+}
+
+#[test]
+fn fn_signature_on_sync_function_reports_direct_mode() {
+    let provider = load_provider();
+    let tree = parse_and_decorate_fixture(provider);
+    let root = tree.root_node();
+
+    let func = find_function_by_name(&root, "returns_anyhow_result")
+        .expect("should find returns_anyhow_result");
+
+    let sig = func
+        .decoration::<FnSignature>()
+        .expect("should have FnSignature decoration");
+
+    assert_eq!(sig.return_mode(), ReturnMode::Direct);
+}
+
+/// A crate's own `Result` is not the standard one, however it renders
+///
+/// `myres::Result<()>` renders as `Result<()>`, which any prefix test on the
+/// rendering accepts. Only a comparison against the enum `FamousDefs`
+/// resolves can tell the two apart.
+#[test]
+fn fn_signature_on_user_defined_result_is_not_a_result() {
+    let provider = load_provider();
+    let tree = parse_and_decorate_fixture(provider);
+    let root = tree.root_node();
+
+    let func = find_function_by_name(&root, "user_defined_result")
+        .expect("should find user_defined_result");
+
+    let sig = func
+        .decoration::<FnSignature>()
+        .expect("should have FnSignature decoration");
+
+    let ret = sig.return_type().expect("should have return type");
+    assert!(
+        !ret.is_result(),
+        "a user-defined Result is not core's, got display: {}",
+        ret.display()
+    );
+    assert!(sig.error_type().is_none());
 }
 
 #[test]
@@ -473,13 +567,14 @@ fn local_enum_has_non_exhaustive_external_false() {
         .child_by_field_name("value")
         .expect("match should have value field");
 
-    let flags = scrutinee.decoration::<AdtFlags>();
-    if let Some(flags) = flags {
-        assert!(
-            !flags.non_exhaustive_external(),
-            "local enum should not be non_exhaustive_external"
-        );
-    }
+    let flags = scrutinee
+        .decoration::<AdtFlags>()
+        .expect("a local enum scrutinee should have AdtFlags");
+
+    assert!(
+        !flags.non_exhaustive_external(),
+        "local enum should not be non_exhaustive_external"
+    );
 }
 
 #[test]
@@ -524,13 +619,14 @@ fn if_let_with_non_diverging_else_is_not_never() {
         .child_by_field_name("alternative")
         .expect("should have else branch");
 
-    let ty = else_clause.decoration::<ResolvedType>();
-    if let Some(ty) = ty {
-        assert!(
-            !ty.is_never(),
-            "non-diverging else should not have never type"
-        );
-    }
+    let ty = else_clause
+        .decoration::<ResolvedType>()
+        .expect("else clause should have ResolvedType");
+
+    assert!(
+        !ty.is_never(),
+        "non-diverging else should not have never type"
+    );
 }
 
 /// The operand of `?` must be typed as the call, not as the callee
@@ -637,6 +733,48 @@ fn anyhow_missing_context_flags_a_bare_try_in_an_anyhow_function() {
     );
 }
 
+/// An `async fn` that returns `anyhow::Result` is still an anyhow function
+///
+/// The signature output is the opaque future, so a provider that reads the
+/// signature verbatim reports no error type and misses every `async fn`.
+#[test]
+fn anyhow_missing_context_flags_a_bare_try_in_an_async_anyhow_function() {
+    let provider = load_provider();
+    let tree = parse_and_decorate_fixture(provider);
+    let root = tree.root_node();
+    let func = find_function_by_name(&root, "returns_anyhow_result_async")
+        .expect("should find returns_anyhow_result_async");
+    let mut passes: Vec<Box<dyn LintPass>> = vec![AnyhowMissingContext::into_lint_pass()];
+
+    let diagnostics = whisker_core::walk(&tree, &mut passes);
+
+    assert_eq!(
+        flagged_within(&tree, &diagnostics, &func),
+        vec!["std::fs::read_to_string(\"async_anyhow_bare.txt\")?"]
+    );
+}
+
+/// An `async fn` in an impl block is reached the same way a free one is
+///
+/// The trait declares the method with an `impl Future` return type, a
+/// different shape from the `async fn` that implements it. The awaited
+/// type must come from the implementation, not the declaration.
+#[test]
+fn anyhow_missing_context_flags_a_bare_try_in_an_async_trait_method() {
+    let provider = load_provider();
+    let tree = parse_and_decorate_fixture(provider);
+    let root = tree.root_node();
+    let func = find_function_by_name(&root, "load_async").expect("should find load_async");
+    let mut passes: Vec<Box<dyn LintPass>> = vec![AnyhowMissingContext::into_lint_pass()];
+
+    let diagnostics = whisker_core::walk(&tree, &mut passes);
+
+    assert_eq!(
+        flagged_within(&tree, &diagnostics, &func),
+        vec!["std::fs::read_to_string(&self.path)?"]
+    );
+}
+
 #[test]
 fn anyhow_missing_context_flags_a_bare_try_on_a_method_call() {
     let provider = load_provider();
@@ -651,6 +789,173 @@ fn anyhow_missing_context_flags_a_bare_try_on_a_method_call() {
     assert_eq!(
         flagged_within(&tree, &diagnostics, &func),
         vec!["loader.load()?"]
+    );
+}
+
+/// Only the anyhow function is flagged, out of four that all render `Error`
+///
+/// `syn::Result`, `std::fmt::Result`, `std::io::Result`, and
+/// `anyhow::Result` all render their `E` as `Error`, so a rule that reads
+/// the rendering flags all four. The `syn` case also covers an `Error`
+/// whose definition path differs from its public re-export path.
+#[test]
+fn anyhow_missing_context_flags_only_the_anyhow_function_among_lookalike_errors() {
+    let provider = load_provider();
+    let tree = parse_and_decorate_fixture(provider);
+    let root = tree.root_node();
+    let mut passes: Vec<Box<dyn LintPass>> = vec![AnyhowMissingContext::into_lint_pass()];
+
+    let diagnostics = whisker_core::walk(&tree, &mut passes);
+
+    let anyhow_fn = find_function_by_name(&root, "returns_anyhow_result")
+        .expect("should find returns_anyhow_result");
+    let syn_fn =
+        find_function_by_name(&root, "returns_syn_result").expect("should find returns_syn_result");
+    let fmt_fn = find_function_by_name(&root, "fmt").expect("should find Display::fmt");
+    let io_fn =
+        find_function_by_name(&root, "returns_io_result").expect("should find returns_io_result");
+
+    assert_eq!(
+        flagged_within(&tree, &diagnostics, &anyhow_fn),
+        vec!["std::fs::read_to_string(\"anyhow_bare.txt\")?"]
+    );
+    assert!(flagged_within(&tree, &diagnostics, &syn_fn).is_empty());
+    assert!(flagged_within(&tree, &diagnostics, &fmt_fn).is_empty());
+    assert!(flagged_within(&tree, &diagnostics, &io_fn).is_empty());
+}
+
+/// An `async fn` that returns `std::io::Result` is not an anyhow function
+///
+/// The async projection must identify the awaited error type, not just
+/// make every `async fn` visible to the rule.
+#[test]
+fn anyhow_missing_context_ignores_a_bare_try_in_an_async_io_function() {
+    let provider = load_provider();
+    let tree = parse_and_decorate_fixture(provider);
+    let root = tree.root_node();
+    let func = find_function_by_name(&root, "returns_io_result_async")
+        .expect("should find returns_io_result_async");
+    let mut passes: Vec<Box<dyn LintPass>> = vec![AnyhowMissingContext::into_lint_pass()];
+
+    let diagnostics = whisker_core::walk(&tree, &mut passes);
+
+    assert!(flagged_within(&tree, &diagnostics, &func).is_empty());
+}
+
+/// A function that returns `std::io::Result` is outside this rule
+///
+/// `std::io::Result<()>` renders as `Result<(), Error>`, so a rule that
+/// reads the rendering cannot tell this `Error` from anyhow's.
+#[test]
+fn anyhow_missing_context_ignores_a_bare_try_in_an_io_function() {
+    let provider = load_provider();
+    let tree = parse_and_decorate_fixture(provider);
+    let root = tree.root_node();
+    let func =
+        find_function_by_name(&root, "returns_io_result").expect("should find returns_io_result");
+    let mut passes: Vec<Box<dyn LintPass>> = vec![AnyhowMissingContext::into_lint_pass()];
+
+    let diagnostics = whisker_core::walk(&tree, &mut passes);
+
+    assert!(flagged_within(&tree, &diagnostics, &func).is_empty());
+}
+
+/// `Box<dyn Error>` occupies the `E` slot as an ADT, and it is not anyhow's
+///
+/// The `E` resolves to `Box`, defined in `alloc`, so the rule sees a named
+/// error type with the wrong path.
+#[test]
+fn anyhow_missing_context_ignores_a_boxed_error() {
+    let provider = load_provider();
+    let tree = parse_and_decorate_fixture(provider);
+    let root = tree.root_node();
+    let func = find_function_by_name(&root, "returns_boxed_error")
+        .expect("should find returns_boxed_error");
+    let mut passes: Vec<Box<dyn LintPass>> = vec![AnyhowMissingContext::into_lint_pass()];
+
+    let diagnostics = whisker_core::walk(&tree, &mut passes);
+
+    assert!(flagged_within(&tree, &diagnostics, &func).is_empty());
+}
+
+/// An error type the signature leaves open cannot be anyhow's
+///
+/// A caller may instantiate `E` as `anyhow::Error`, but the body must
+/// compile for every `E` the bounds admit. `.context(..)` is not available
+/// there, so the rule reports nothing.
+#[test]
+fn anyhow_missing_context_ignores_a_generic_error() {
+    let provider = load_provider();
+    let tree = parse_and_decorate_fixture(provider);
+    let root = tree.root_node();
+    let func = find_function_by_name(&root, "returns_generic_error")
+        .expect("should find returns_generic_error");
+    let mut passes: Vec<Box<dyn LintPass>> = vec![AnyhowMissingContext::into_lint_pass()];
+
+    let diagnostics = whisker_core::walk(&tree, &mut passes);
+
+    assert!(flagged_within(&tree, &diagnostics, &func).is_empty());
+}
+
+/// A crate's own `Error` type must not match anyhow's
+///
+/// This shape produced most of the false positives when the rule first ran
+/// over whisker's own source.
+#[test]
+fn anyhow_missing_context_ignores_a_local_error_type() {
+    let provider = load_provider();
+    let tree = parse_and_decorate_fixture(provider);
+    let root = tree.root_node();
+    let func = find_function_by_name(&root, "returns_local_error_result")
+        .expect("should find returns_local_error_result");
+    let mut passes: Vec<Box<dyn LintPass>> = vec![AnyhowMissingContext::into_lint_pass()];
+
+    let diagnostics = whisker_core::walk(&tree, &mut passes);
+
+    assert!(flagged_within(&tree, &diagnostics, &func).is_empty());
+}
+
+/// A `?` in a closure belongs to the closure, not to the function around it
+///
+/// The closure returns `std::io::Result`, so `.context(..)` on its `?`
+/// would not compile. The function's own `read()?` is a genuine hit, so a
+/// removed barrier fails the expectation with an extra entry.
+#[test]
+fn anyhow_missing_context_ignores_a_try_inside_a_closure() {
+    let provider = load_provider();
+    let tree = parse_and_decorate_fixture(provider);
+    let root = tree.root_node();
+    let func = find_function_by_name(&root, "closure_returning_io_result")
+        .expect("should find closure_returning_io_result");
+    let mut passes: Vec<Box<dyn LintPass>> = vec![AnyhowMissingContext::into_lint_pass()];
+
+    let diagnostics = whisker_core::walk(&tree, &mut passes);
+
+    assert_eq!(flagged_within(&tree, &diagnostics, &func), vec!["read()?"]);
+}
+
+/// Every place the rule fires in the fixture, listed once
+///
+/// Per-function expectations once stayed green while the rule fired on a
+/// `std::io::Result` function nothing asserted about. The whole-file list
+/// pins the rule's reach.
+#[test]
+fn anyhow_missing_context_over_the_whole_file_reports_only_anyhow_bodies() {
+    let provider = load_provider();
+    let tree = parse_and_decorate_fixture(provider);
+    let mut passes: Vec<Box<dyn LintPass>> = vec![AnyhowMissingContext::into_lint_pass()];
+
+    let diagnostics = whisker_core::walk(&tree, &mut passes);
+
+    assert_eq!(
+        flagged_in_file(&tree, &diagnostics),
+        vec![
+            "std::fs::read_to_string(\"anyhow_bare.txt\")?",
+            "loader.load()?",
+            "std::fs::read_to_string(\"async_anyhow_bare.txt\")?",
+            "std::fs::read_to_string(&self.path)?",
+            "read()?",
+        ]
     );
 }
 
@@ -707,6 +1012,23 @@ fn wildcard_match_arm_ignores_a_scrutinee_that_is_not_an_enum() {
     assert!(flagged_within(&tree, &diagnostics, &func).is_empty());
 }
 
+/// Counts the fixture's `function_item` nodes and how many carry a signature
+///
+/// The walk recurses because a method inside an `impl` block is a
+/// `function_item` too. A top-level loop would never count the `async`
+/// trait method.
+fn count_fn_signatures(node: &DecoratedNode<'_>, functions: &mut usize, signatures: &mut usize) {
+    if node.kind() == "function_item" {
+        *functions += 1;
+        if node.decoration::<FnSignature>().is_some() {
+            *signatures += 1;
+        }
+    }
+    for child in node.named_children() {
+        count_fn_signatures(&child, functions, signatures);
+    }
+}
+
 #[test]
 fn every_function_item_has_fn_signature() {
     let provider = load_provider();
@@ -715,15 +1037,7 @@ fn every_function_item_has_fn_signature() {
 
     let mut fn_count = 0;
     let mut sig_count = 0;
-
-    for child in root.named_children() {
-        if child.kind() == "function_item" {
-            fn_count += 1;
-            if child.decoration::<FnSignature>().is_some() {
-                sig_count += 1;
-            }
-        }
-    }
+    count_fn_signatures(&root, &mut fn_count, &mut sig_count);
 
     assert!(fn_count > 0, "fixture should have functions");
     assert_eq!(

--- a/lints/anyhow_missing_context/src/lib.rs
+++ b/lints/anyhow_missing_context/src/lib.rs
@@ -1,17 +1,27 @@
 use whisker_rust::RustLintPass;
-use whisker_rust::decorations::{FnSignature, ResolvedType};
+use whisker_rust::decorations::{FnSignature, ResolvedType, TypePathRef};
 use whisker_types::{DecoratedNode, Diagnostic, LintPass, RuleId, Severity};
 
 const RULE_ID: RuleId = RuleId("lint.anyhow-missing-context");
+
+/// The definition path of `anyhow::Error`
+///
+/// `anyhow` declares `Error` at its crate root, so the module segment list
+/// is empty. The comparison uses the definition path, so another crate's
+/// `Error` never matches, whatever its rendered name.
+const ANYHOW_ERROR: TypePathRef<'static> = TypePathRef::new("anyhow", &[], "Error");
 
 /// Flags uses of `?` on [`Result`] types without a preceding `.context()`
 /// or `.with_context()` call, but only when the enclosing function returns
 /// `Result<T, anyhow::Error>`
 ///
-/// Using `?` without `.context()` propagates errors without adding
-/// information about what operation failed. Rich error context makes
-/// debugging significantly easier by providing a chain of explanations
-/// for how the error occurred.
+/// A `?` without `.context()` propagates an error with no information
+/// about the operation that failed. Context calls build a chain of
+/// explanations for how the error occurred, which makes debugging easier.
+///
+/// A `?` inside a closure, an `async` block, or a `try` block converts
+/// into that body's error type, not the enclosing function's. The rule
+/// leaves those alone, because `.context(..)` would not compile there.
 ///
 /// [`Result`]: std::result::Result
 pub struct AnyhowMissingContext;
@@ -50,10 +60,10 @@ impl RustLintPass for AnyhowMissingContext {
         let Some(fn_sig) = find_enclosing_fn_signature(node) else {
             return Vec::new();
         };
-        let Some(error_name) = fn_sig.error_type_name() else {
+        let Some(error_type) = fn_sig.error_type() else {
             return Vec::new();
         };
-        if !is_anyhow_error(error_name) {
+        if !error_type.is(ANYHOW_ERROR) {
             return Vec::new();
         }
 
@@ -70,25 +80,38 @@ impl RustLintPass for AnyhowMissingContext {
     }
 }
 
+/// Node kinds whose bodies own a `?`, so the ancestor walk stops at them
+///
+/// A closure, an `async` block, a `gen` block, a `const` block, and a
+/// `try` block each have their own return type. A `?` inside one converts
+/// into that type, not into the enclosing function's error type.
+const BODY_BARRIERS: &[&str] = &[
+    "async_block",
+    "closure_expression",
+    "const_block",
+    "gen_block",
+    "try_block",
+];
+
 /// Walks up the tree to find the enclosing `function_item` and returns
 /// its [`FnSignature`] decoration, if present
+///
+/// Returns [`None`] when the walk meets a [`BODY_BARRIERS`] kind first.
+/// That accepts a false negative: the rule does not flag a `?` inside a
+/// closure that itself returns `anyhow::Result`. A missed diagnostic costs
+/// less than a suggestion that does not compile.
 fn find_enclosing_fn_signature<'a>(node: &DecoratedNode<'a>) -> Option<&'a FnSignature> {
     let mut current = node.parent();
     while let Some(ancestor) = current {
+        if BODY_BARRIERS.contains(&ancestor.kind()) {
+            return None;
+        }
         if ancestor.kind() == "function_item" {
             return ancestor.decoration::<FnSignature>();
         }
         current = ancestor.parent();
     }
     None
-}
-
-/// Returns whether the error type name refers to `anyhow::Error`
-///
-/// Rust-analyzer may display the type as fully qualified `"anyhow::Error"`
-/// or as just `"Error"` depending on context. Both forms are accepted.
-fn is_anyhow_error(name: &str) -> bool {
-    name == "anyhow::Error" || name == "Error"
 }
 
 /// Returns whether the operand is a `.context()` or `.with_context()` call
@@ -111,7 +134,7 @@ fn is_context_call(operand: &DecoratedNode<'_>) -> bool {
 
 #[cfg(test)]
 mod tests {
-    use whisker_rust::decorations::{FnSignature, ResolvedType};
+    use whisker_rust::decorations::{ErrorType, FnSignature, ResolvedType, ReturnMode, TypePath};
     use whisker_testing::{assert_diagnostic, assert_no_diagnostics, decorate, execute, parse};
     use whisker_types::{DecorationMap, Language, LintPass, Severity};
 
@@ -122,21 +145,29 @@ mod tests {
     }
 
     fn result_type() -> ResolvedType {
-        ResolvedType::new("Result<(), anyhow::Error>".into()).with_result(true)
+        ResolvedType::new("Result<(), Error>".into()).with_result(true)
     }
 
     fn option_type() -> ResolvedType {
         ResolvedType::new("Option<String>".into()).with_option(true)
     }
 
+    /// Returns the signature the provider reports for `anyhow::Result<()>`
     fn anyhow_fn_sig() -> FnSignature {
-        let ret = ResolvedType::new("Result<(), anyhow::Error>".into()).with_result(true);
-        FnSignature::new(Some(ret), Some("anyhow::Error".into()))
+        let ret = ResolvedType::new("Result<(), Error>".into()).with_result(true);
+        let error = ErrorType::Named(TypePath::new("anyhow", [] as [&str; 0], "Error"));
+        FnSignature::new(Some(ret), Some(error), ReturnMode::Direct)
     }
 
+    /// Returns the signature the provider reports for `std::io::Result<()>`
+    ///
+    /// The rendering matches `anyhow_fn_sig`, so only the definition path
+    /// tells the two apart. The path names `core`, because `std::io::Error`
+    /// is a re-export of `core::io::error::Error`.
     fn non_anyhow_fn_sig() -> FnSignature {
-        let ret = ResolvedType::new("Result<(), std::io::Error>".into()).with_result(true);
-        FnSignature::new(Some(ret), Some("std::io::Error".into()))
+        let ret = ResolvedType::new("Result<(), Error>".into()).with_result(true);
+        let error = ErrorType::Named(TypePath::new("core", ["io", "error"], "Error"));
+        FnSignature::new(Some(ret), Some(error), ReturnMode::Direct)
     }
 
     /// Walks the tree to find the first node with the given kind
@@ -188,6 +219,48 @@ mod tests {
             .has_rule_id("lint.anyhow-missing-context")
             .has_severity(Severity::Warn)
             .message_contains("without error context");
+    }
+
+    /// A `?` inside an `async` block converts into that block's error type
+    ///
+    /// The block is its own body, so the enclosing `fn`'s signature says
+    /// nothing about what the `?` there produces.
+    #[test]
+    fn in_async_block_inside_anyhow_fn_is_not_flagged() {
+        let source = "fn foo() -> Result<(), Error> { async { something()?; } }";
+        let mut tree = parse(source, Language::Rust);
+        let operand_id = find_try_operand_id(&tree);
+        let fn_id = find_node_by_kind(&tree.root_node(), "function_item").expect("should find fn");
+
+        let mut map = DecorationMap::new();
+        map.insert(operand_id, result_type());
+        map.insert(fn_id, anyhow_fn_sig());
+        decorate(&mut tree, map);
+
+        let diagnostics = execute(&tree, &mut passes());
+
+        assert_no_diagnostics(&diagnostics);
+    }
+
+    /// A `?` inside a closure converts into the closure's error type
+    ///
+    /// The enclosing function's signature does not apply inside the
+    /// closure's body.
+    #[test]
+    fn in_closure_inside_anyhow_fn_is_not_flagged() {
+        let source = "fn foo() -> Result<(), Error> { let f = || { something()?; }; }";
+        let mut tree = parse(source, Language::Rust);
+        let operand_id = find_try_operand_id(&tree);
+        let fn_id = find_node_by_kind(&tree.root_node(), "function_item").expect("should find fn");
+
+        let mut map = DecorationMap::new();
+        map.insert(operand_id, result_type());
+        map.insert(fn_id, anyhow_fn_sig());
+        decorate(&mut tree, map);
+
+        let diagnostics = execute(&tree, &mut passes());
+
+        assert_no_diagnostics(&diagnostics);
     }
 
     #[test]


### PR DESCRIPTION
`anyhow_missing_context` exists to catch `foo()?` used without `.context(..)`
in a function returning `anyhow::Result`. Running it over this repository
produced ten diagnostics, seven of them wrong: four in `whisker-macros`, which
does not depend on anyhow at all, two on `fn fmt(..) -> fmt::Result`, where
`.context()` is not even expressible, and one on a `serde_json::Error`. The
rule's own documentation promises it fires only for `anyhow::Error`.

The provider now resolves a function's error type to the item that defines it
and hands the rule a canonical path, which the rule compares against a
constant. Whether a type is a `Result` or an `Option` goes through the same
route, not through its rendering.

One more blind spot went with it. `Function::ret_type` gives an `async fn` the
opaque future, not the awaited type, so the error type was absent for every
async function. Every whisker CLI command is async, so the rule could not see
any of them. `Function::async_ret_type` exists for exactly this case and is
now used.

The old tests never noticed any of this because they hand-build their
decorations, so the rule was only ever exercised against input the real
provider would never produce. The tests here run the actual provider over a
fixture holding `anyhow::Result`, `syn::Result`, `io::Result`, `fmt::Result`,
a boxed error, a generic error, async functions, and a closure returning a
different error type than the function around it. They assert against the
whole file, not one function at a time, because a per-function expectation
cannot fail on a rule that starts firing somewhere else.
