### PR TITLE
Route per-file check failures through one mode

### DIFF
--- a/crates/whisker/src/commands/check.rs
+++ b/crates/whisker/src/commands/check.rs
@@ -1,4 +1,5 @@
 mod check_outcome;
+mod error_recovery;
 mod failure_threshold;
 
 use std::collections::HashMap;
@@ -12,6 +13,7 @@ use whisker_rust::{RustDecorationProvider, RustLintPassAdapter};
 use whisker_types::{DecorationProvider, Diagnostic, Language, LintPass};
 
 use self::check_outcome::CheckOutcome;
+use self::error_recovery::ErrorRecovery;
 use self::failure_threshold::FailureThreshold;
 
 /// Run whisker lints against a project
@@ -67,6 +69,11 @@ pub async fn check(args: CheckArgs, _context: Context) -> CommandResult {
         false => FailureThreshold::Errors,
     };
 
+    let recovery = match keep_going {
+        true => ErrorRecovery::Continue,
+        false => ErrorRecovery::Abort,
+    };
+
     let files = discover_files(&path)?;
 
     if files.is_empty() {
@@ -86,14 +93,10 @@ pub async fn check(args: CheckArgs, _context: Context) -> CommandResult {
 
     for file in &files {
         let source = match std::fs::read_to_string(file) {
-            Ok(s) => s,
+            Ok(source) => source,
             Err(e) => {
-                if keep_going {
-                    eprintln!("error: {}: {e:#}", file.display());
-                    outcome = CheckOutcome::Failure;
-                    continue;
-                }
-                return Err(anyhow::anyhow!("read {}: {e}", file.display()));
+                recovery.record(&mut outcome, file, anyhow::Error::new(e))?;
+                continue;
             }
         };
 
@@ -107,14 +110,7 @@ pub async fn check(args: CheckArgs, _context: Context) -> CommandResult {
                     all_diagnostics.extend(diagnostics);
                 }
             }
-            Err(e) => {
-                if keep_going {
-                    eprintln!("error: {}: {e:#}", file.display());
-                    outcome = CheckOutcome::Failure;
-                } else {
-                    return Err(e);
-                }
-            }
+            Err(e) => recovery.record(&mut outcome, file, e)?,
         }
     }
 

--- a/crates/whisker/src/commands/check/error_recovery.rs
+++ b/crates/whisker/src/commands/check/error_recovery.rs
@@ -1,0 +1,116 @@
+use std::path::Path;
+
+use super::check_outcome::CheckOutcome;
+
+/// What `whisker check` does with a file it cannot read or analyze
+///
+/// Read failures and analysis failures both go through
+/// [`ErrorRecovery::record`], so one place decides whether a per-file
+/// failure ends the run. The `--keep-going` flag selects
+/// [`ErrorRecovery::Continue`].
+// r[impl cli.check.keep-going]
+#[derive(Copy, Clone, Eq, PartialEq, Hash, Debug)]
+pub(crate) enum ErrorRecovery {
+    /// The first failing file ends the run with its error
+    Abort,
+    /// Whisker reports each failing file, continues, and still fails the run
+    Continue,
+}
+
+impl ErrorRecovery {
+    /// Records a failure for one file
+    ///
+    /// Under [`ErrorRecovery::Continue`], the error goes to stderr and
+    /// `outcome` becomes [`CheckOutcome::Failure`].
+    ///
+    /// # Errors
+    ///
+    /// Under [`ErrorRecovery::Abort`], returns `error` with the file name
+    /// added, so the caller can end the run with it.
+    pub(crate) fn record(
+        self,
+        outcome: &mut CheckOutcome,
+        file: &Path,
+        error: anyhow::Error,
+    ) -> anyhow::Result<()> {
+        match self {
+            Self::Abort => Err(error.context(format!("check {}", file.display()))),
+            Self::Continue => {
+                eprintln!("error: {}: {error:#}", file.display());
+                *outcome = CheckOutcome::Failure;
+                Ok(())
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn test_error() -> anyhow::Error {
+        anyhow::anyhow!("something broke")
+    }
+
+    #[test]
+    fn trait_send() {
+        fn assert_send<T: Send>() {}
+        assert_send::<ErrorRecovery>();
+    }
+
+    #[test]
+    fn trait_sync() {
+        fn assert_sync<T: Sync>() {}
+        assert_sync::<ErrorRecovery>();
+    }
+
+    #[test]
+    fn trait_unpin() {
+        fn assert_unpin<T: Unpin>() {}
+        assert_unpin::<ErrorRecovery>();
+    }
+
+    #[test]
+    fn record_with_abort_leaves_the_outcome_untouched() {
+        let mut outcome = CheckOutcome::Success;
+
+        let _error = ErrorRecovery::Abort
+            .record(&mut outcome, Path::new("bad.rs"), test_error())
+            .expect_err("abort should fail the run");
+
+        assert_eq!(outcome, CheckOutcome::Success);
+    }
+
+    #[test]
+    fn record_with_abort_names_the_failing_file() {
+        let mut outcome = CheckOutcome::Success;
+
+        let error = ErrorRecovery::Abort
+            .record(&mut outcome, Path::new("bad.rs"), test_error())
+            .expect_err("abort should fail the run");
+
+        assert_eq!(format!("{error:#}"), "check bad.rs: something broke");
+    }
+
+    #[test]
+    fn record_with_continue_keeps_an_earlier_failure() {
+        let mut outcome = CheckOutcome::Failure;
+
+        ErrorRecovery::Continue
+            .record(&mut outcome, Path::new("bad.rs"), test_error())
+            .expect("continue should not fail the run");
+
+        assert_eq!(outcome, CheckOutcome::Failure);
+    }
+
+    #[test]
+    fn record_with_continue_marks_the_outcome_failed() {
+        let mut outcome = CheckOutcome::Success;
+
+        ErrorRecovery::Continue
+            .record(&mut outcome, Path::new("bad.rs"), test_error())
+            .expect("continue should not fail the run");
+
+        assert_eq!(outcome, CheckOutcome::Failure);
+    }
+}

--- a/crates/whisker/tests/check.rs
+++ b/crates/whisker/tests/check.rs
@@ -56,8 +56,10 @@ fn check_with_deny_warnings_fails_on_warnings() {
 
 /// The fixture is not valid UTF-8, so the read fails and produces no
 /// diagnostic. Only the recorded failure can make the exit code non-zero.
-/// The `.rs.bin` name keeps directory walks away from the fixture, so the
-/// test names it directly.
+/// The assertion names the `error: {path}:` line because only the recovering
+/// path prints it; aborting prints `Error: check {path}:`. The `.rs.bin`
+/// name keeps directory walks away from the fixture, so the test names it
+/// directly.
 #[test]
 fn check_with_keep_going_and_unreadable_file_fails() {
     whisker()
@@ -69,8 +71,9 @@ fn check_with_keep_going_and_unreadable_file_fails() {
         .assert()
         .code(1)
         .stderr(predicate::str::contains(
-            "stream did not contain valid UTF-8",
-        ));
+            "error: tests/fixtures/invalid_utf8.rs.bin: stream did not contain valid UTF-8",
+        ))
+        .stderr(predicate::str::contains("Error:").not());
 }
 
 #[test]
@@ -80,6 +83,28 @@ fn check_with_keep_going_succeeds() {
         .assert()
         .success()
         .stderr(predicate::str::is_empty());
+}
+
+/// Pins the hard-failure path that the `--keep-going` test has to be
+/// distinguished from
+///
+/// Without the flag the same fixture ends the run, and the error names the
+/// file it came from so a failure deep in a walk stays attributable. The
+/// cause arrives as a separate line because anyhow renders the context chain
+/// as a report rather than a single line.
+// r[verify cli.check.keep-going]
+#[test]
+fn check_with_unreadable_file_and_no_keep_going_fails() {
+    whisker()
+        .args(["check", "tests/fixtures/invalid_utf8.rs.bin"])
+        .assert()
+        .code(1)
+        .stderr(predicate::str::contains(
+            "Error: check tests/fixtures/invalid_utf8.rs.bin",
+        ))
+        .stderr(predicate::str::contains(
+            "stream did not contain valid UTF-8",
+        ));
 }
 
 // r[verify cli.check.deny-warnings]


### PR DESCRIPTION
The check loop had two places that decided what to do with a file it could not
process: one for a read that fails, one for a pipeline run that fails. Each
re-derived the meaning of `keep_going` from the raw flag. Only the read site
was pinned by a test, so deleting the failure recording from the analysis site
left the suite green, and nothing stopped the two branches from drifting into
disagreement about whether a failure reaches the exit code.

Both sites now call `ErrorRecovery::record`. One place turns the mode into
behavior, and the flag becomes that mode where the arguments are destructured
instead of being re-interpreted deep in the loop. The aborting path also gained
the file name as error context, which it was missing whenever the pipeline was
the thing that failed.

The old keep-going test asserted only on the underlying I/O message, which both
paths print and both exit 1 on, so it passed even with the flag's whole
recovery branch removed. It now names the line only the recovering path emits,
and a companion test pins the aborting path it has to be told apart from.
