### PR TITLE
Flag TODO comments and point at the tracker

### DIFF
--- a/.config/whisker.toml
+++ b/.config/whisker.toml
@@ -24,3 +24,6 @@ path = "lints/if_let_with_else"
 
 [[lints]]
 path = "lints/no_matches_macro"
+
+[[lints]]
+path = "lints/no_todo_comments"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,14 +1,6 @@
 [workspace]
 members = ["crates/*"]
-exclude = [
-  "examples/*",
-  "lints/anyhow_missing_context",
-  "lints/bool_param",
-  "lints/derive_order",
-  "lints/if_let_with_else",
-  "lints/no_matches_macro",
-  "lints/wildcard_match_arm",
-]
+exclude = ["examples/*", "lints/anyhow_missing_context", "lints/bool_param", "lints/derive_order", "lints/if_let_with_else", "lints/no_matches_macro", "lints/no_todo_comments", "lints/wildcard_match_arm"]
 
 # Opt-in to the new feature resolver introduced in Rust 1.85 and Edition 2024.
 # https://doc.rust-lang.org/cargo/reference/resolver.html#resolver-versions

--- a/lints/no_todo_comments/Cargo.toml
+++ b/lints/no_todo_comments/Cargo.toml
@@ -1,0 +1,36 @@
+# A lint is its own cargo package, built as a cdylib and loaded by whisker at
+# check time. It is not a workspace member: the handshake compares the whisker
+# it was compiled against with the whisker loading it, and a package outside
+# the workspace resolves its own dependencies, which is what a lint written
+# outside this repository does too. The lockfile beside this manifest pins
+# that resolution.
+[package]
+name = "no_todo_comments"
+version = "0.1.0"
+edition = "2024"
+license = "Apache-2.0 OR MIT"
+publish = false
+
+[lib]
+crate-type = ["cdylib", "rlib"]
+
+# The provider feature stays off: a lint needs the generated trait and the
+# decoration types, not the rust-analyzer stack that produces decorations.
+# The exported declaration is a `no_mangle` static, so two rules linked into
+# one binary would collide. The cdylib whisker loads keeps it; a rule used as
+# an ordinary rlib dependency, as whisker-rust's provider tests do, turns it
+# off.
+[features]
+default = ["plugin"]
+plugin = []
+
+[dependencies]
+whisker-rust = { path = "../../crates/whisker-rust", default-features = false }
+whisker-types = { path = "../../crates/whisker-types" }
+
+[dev-dependencies]
+whisker-testing = { path = "../../crates/whisker-testing" }
+
+[lints.clippy]
+missing_errors_doc = "warn"
+missing_panics_doc = "warn"

--- a/lints/no_todo_comments/src/lib.rs
+++ b/lints/no_todo_comments/src/lib.rs
@@ -1,0 +1,444 @@
+use std::sync::Arc;
+
+use whisker_rust::RustLintPass;
+use whisker_types::{DecoratedNode, Diagnostic, RuleId, Severity, Span};
+
+const RULE_ID: RuleId = RuleId::new("lint.no-todo-comments");
+
+/// The markers this rule looks for
+///
+/// No marker is a prefix of another, so at most one can match a line.
+const MARKERS: &[&str] = &["TODO", "FIXME", "HACK", "XXX"];
+
+/// Flags `TODO`, `FIXME`, `HACK`, and `XXX` markers in comments
+///
+/// A marker left in the source is invisible to anyone who does not open
+/// that file, so the work is easy to lose. The issue tracker holds that
+/// work instead.
+///
+/// The rule matches an uppercase marker at the start of a comment line and
+/// nowhere else. A sentence or a URL that contains the word does not match.
+pub struct NoTodoComments;
+
+/// A marker that a comment contains
+///
+/// The offset counts bytes from the start of the comment, so a caller adds
+/// the comment's own start to reach a file offset.
+#[derive(Copy, Clone, Eq, PartialEq, Debug)]
+struct FoundMarker {
+    offset: usize,
+    marker: &'static str,
+}
+
+/// Returns whether `rest` starts at a word boundary
+///
+/// `TODOS` must not match, so `rest` must be empty or start with a
+/// character that is not a letter, a digit, or an underscore.
+fn is_word_break(rest: &str) -> bool {
+    match rest.chars().next() {
+        None => true,
+        Some(character) => !character.is_alphanumeric() && character != '_',
+    }
+}
+
+/// Returns each marker that starts a line of `text`, with its byte offset
+///
+/// The scan reads one line at a time. It removes the leading whitespace,
+/// the comment punctuation (`/`, `*`, and `!`), and the whitespace again.
+/// Then it checks whether what remains starts with a marker.
+///
+/// The punctuation trim stops at the first character that is not `/`, `*`,
+/// or `!`. So `/// // TODO` keeps its inner `//` and does not match.
+fn find_markers(text: &str) -> Vec<FoundMarker> {
+    let mut found = Vec::new();
+    let mut line_start = 0;
+
+    for line in text.split_inclusive('\n') {
+        let content = line.trim_start();
+        let content = content.trim_start_matches(['/', '*', '!']);
+        let content = content.trim_start();
+
+        for marker in MARKERS.iter().copied() {
+            let Some(rest) = content.strip_prefix(marker) else {
+                continue;
+            };
+            if !is_word_break(rest) {
+                continue;
+            }
+
+            found.push(FoundMarker {
+                offset: line_start + line.len() - content.len(),
+                marker,
+            });
+            break;
+        }
+
+        line_start += line.len();
+    }
+
+    found
+}
+
+/// Returns one diagnostic for each marker in a comment
+///
+/// Tree-sitter nests a `doc_comment` node inside the `line_comment` or
+/// `block_comment` that carries it, and the walker visits both nodes. This
+/// pass hooks only the outer two kinds, because hooking the child as well
+/// would report every marker in a doc comment twice.
+fn check_comment(node: &DecoratedNode<'_>) -> Vec<Diagnostic> {
+    let span = node.span();
+    let mut diagnostics = Vec::new();
+
+    for FoundMarker { offset, marker } in find_markers(node.text()) {
+        let start = span.start() + offset;
+        diagnostics.push(Diagnostic::new(
+            RULE_ID,
+            Severity::Warn,
+            format!("`{marker}` comment: track this work in the issue tracker instead"),
+            Span::new(Arc::clone(span.file_arc()), start, start + marker.len()),
+        ));
+    }
+
+    diagnostics
+}
+
+impl RustLintPass for NoTodoComments {
+    fn check_block_comment(&mut self, node: &DecoratedNode<'_>) -> Vec<Diagnostic> {
+        check_comment(node)
+    }
+
+    fn check_line_comment(&mut self, node: &DecoratedNode<'_>) -> Vec<Diagnostic> {
+        check_comment(node)
+    }
+}
+
+#[cfg(feature = "plugin")]
+whisker_rust::export_lints![NoTodoComments];
+
+#[cfg(test)]
+mod tests {
+    use whisker_rust::RustLintPassAdapter;
+    use whisker_testing::{assert_diagnostic, assert_no_diagnostics, execute, parse};
+    use whisker_types::{Language, LintPass, Severity};
+
+    use super::*;
+
+    fn passes() -> Vec<Box<dyn LintPass>> {
+        vec![Box::new(RustLintPassAdapter::new(NoTodoComments))]
+    }
+
+    #[test]
+    fn block_comment_with_marker_on_inner_line_is_flagged() {
+        let source = "/*\n * FIXME: this breaks on empty input\n */\nfn f() {}";
+
+        let diagnostics = execute(&parse(source, Language::Rust), &mut passes());
+
+        assert_eq!(diagnostics.len(), 1);
+        assert_diagnostic(&diagnostics[0]).message_contains("`FIXME`");
+    }
+
+    #[test]
+    fn block_comment_with_mid_line_marker_is_not_flagged() {
+        let source = "/* we removed the TODO already */\nfn f() {}";
+
+        let diagnostics = execute(&parse(source, Language::Rust), &mut passes());
+
+        assert_no_diagnostics(&diagnostics);
+    }
+
+    #[test]
+    fn block_comment_with_two_markers_is_flagged_twice() {
+        let source = "/*\n * TODO: one\n * HACK: two\n */\nfn f() {}";
+
+        let diagnostics = execute(&parse(source, Language::Rust), &mut passes());
+
+        assert_eq!(diagnostics.len(), 2);
+        assert_diagnostic(&diagnostics[0]).message_contains("`TODO`");
+        assert_diagnostic(&diagnostics[1]).message_contains("`HACK`");
+    }
+
+    #[test]
+    fn doc_attribute_with_marker_is_not_flagged() {
+        let source = "#[doc = \"TODO: document this\"]\nfn f() {}";
+
+        let diagnostics = execute(&parse(source, Language::Rust), &mut passes());
+
+        assert_no_diagnostics(&diagnostics);
+    }
+
+    #[test]
+    fn doc_comment_with_marker_is_flagged_once() {
+        let source = "/// TODO: document this\nfn f() {}";
+
+        let diagnostics = execute(&parse(source, Language::Rust), &mut passes());
+
+        assert_eq!(diagnostics.len(), 1);
+        assert_diagnostic(&diagnostics[0]).has_span("<test>", 4, 8);
+    }
+
+    #[test]
+    fn find_markers_with_inner_comment_punctuation_returns_empty() {
+        let markers = find_markers("/// // TODO: refactor this later");
+
+        assert!(markers.is_empty());
+    }
+
+    #[test]
+    fn find_markers_with_lowercase_marker_returns_empty() {
+        let markers = find_markers("// todo: refactor this later");
+
+        assert!(markers.is_empty());
+    }
+
+    #[test]
+    fn find_markers_with_marker_after_text_returns_empty() {
+        let markers = find_markers("// see the TODO in the tracker");
+
+        assert!(markers.is_empty());
+    }
+
+    #[test]
+    fn find_markers_with_marker_at_end_of_text_returns_marker() {
+        let markers = find_markers("// XXX");
+
+        assert_eq!(
+            markers,
+            vec![FoundMarker {
+                offset: 3,
+                marker: "XXX",
+            }]
+        );
+    }
+
+    #[test]
+    fn find_markers_with_marker_prefix_of_word_returns_empty() {
+        let markers = find_markers("// TODOS live in the tracker\n// XXXX\n// HACKY");
+
+        assert!(markers.is_empty());
+    }
+
+    #[test]
+    fn find_markers_with_no_delimiter_returns_marker() {
+        let markers = find_markers("//TODO: fix");
+
+        assert_eq!(
+            markers,
+            vec![FoundMarker {
+                offset: 2,
+                marker: "TODO",
+            }]
+        );
+    }
+
+    #[test]
+    fn find_markers_with_repeated_punctuation_returns_marker() {
+        let markers = find_markers("//// TODO: fix");
+
+        assert_eq!(
+            markers,
+            vec![FoundMarker {
+                offset: 5,
+                marker: "TODO",
+            }]
+        );
+    }
+
+    #[test]
+    fn find_markers_with_star_prefixed_line_returns_offset_of_marker() {
+        let markers = find_markers("/*\n * TODO: fix\n */");
+
+        assert_eq!(
+            markers,
+            vec![FoundMarker {
+                offset: 6,
+                marker: "TODO",
+            }]
+        );
+    }
+
+    #[test]
+    fn hack_comment_is_flagged() {
+        let source = "// HACK: works around a borrow checker limit\nfn f() {}";
+
+        let diagnostics = execute(&parse(source, Language::Rust), &mut passes());
+
+        assert_eq!(diagnostics.len(), 1);
+        assert_diagnostic(&diagnostics[0]).message_contains("`HACK`");
+    }
+
+    #[test]
+    fn inner_doc_comment_with_marker_is_flagged_once() {
+        let source = "//! XXX: this module needs a rewrite\nfn f() {}";
+
+        let diagnostics = execute(&parse(source, Language::Rust), &mut passes());
+
+        assert_eq!(diagnostics.len(), 1);
+        assert_diagnostic(&diagnostics[0]).has_span("<test>", 4, 7);
+    }
+
+    #[test]
+    fn marker_in_doc_example_is_not_flagged() {
+        let source = "/// ```ignore\n/// // TODO: refactor this later\n/// ```\nfn f() {}";
+
+        let diagnostics = execute(&parse(source, Language::Rust), &mut passes());
+
+        assert_no_diagnostics(&diagnostics);
+    }
+
+    #[test]
+    fn marker_in_prose_is_not_flagged() {
+        let source =
+            "/// Returns the TODO count for a user\nfn f() {}\n// we removed the FIXME already\n";
+
+        let diagnostics = execute(&parse(source, Language::Rust), &mut passes());
+
+        assert_no_diagnostics(&diagnostics);
+    }
+
+    #[test]
+    fn marker_in_string_literal_is_not_flagged() {
+        let source = "fn f() { let _ = \"// TODO: fix\"; let _ = \"FIXME\"; }";
+
+        let diagnostics = execute(&parse(source, Language::Rust), &mut passes());
+
+        assert_no_diagnostics(&diagnostics);
+    }
+
+    #[test]
+    fn marker_in_url_is_not_flagged() {
+        let source =
+            "/// See https://example.com/issues/TODO\n// https://example.com/FIXME\nfn f() {}";
+
+        let diagnostics = execute(&parse(source, Language::Rust), &mut passes());
+
+        assert_no_diagnostics(&diagnostics);
+    }
+
+    #[test]
+    fn marker_inside_function_body_is_flagged() {
+        let source = "fn f() {\n    // TODO: handle the empty case\n}";
+
+        let diagnostics = execute(&parse(source, Language::Rust), &mut passes());
+
+        assert_eq!(diagnostics.len(), 1);
+    }
+
+    #[test]
+    fn nested_block_comment_with_marker_is_flagged_once() {
+        let source = "/* outer\n/* TODO: inner */\n*/\nfn f() {}";
+
+        let diagnostics = execute(&parse(source, Language::Rust), &mut passes());
+
+        assert_eq!(diagnostics.len(), 1);
+        assert_diagnostic(&diagnostics[0]).has_span("<test>", 12, 16);
+    }
+
+    #[test]
+    fn outer_block_doc_comment_with_marker_is_flagged_once() {
+        let source = "/** TODO: document this */\nfn f() {}";
+
+        let diagnostics = execute(&parse(source, Language::Rust), &mut passes());
+
+        assert_eq!(diagnostics.len(), 1);
+        assert_diagnostic(&diagnostics[0]).has_span("<test>", 4, 8);
+    }
+
+    #[test]
+    fn plain_comment_is_not_flagged() {
+        let source = "// this function adds two numbers\nfn f() {}";
+
+        let diagnostics = execute(&parse(source, Language::Rust), &mut passes());
+
+        assert_no_diagnostics(&diagnostics);
+    }
+
+    #[test]
+    fn todo_comment_is_flagged() {
+        let source = "// TODO: refactor this later\nfn helper() {}";
+
+        let diagnostics = execute(&parse(source, Language::Rust), &mut passes());
+
+        assert_eq!(diagnostics.len(), 1);
+        assert_diagnostic(&diagnostics[0])
+            .has_rule_id("lint.no-todo-comments")
+            .has_severity(Severity::Warn)
+            .message_contains("issue tracker")
+            .has_span("<test>", 3, 7);
+    }
+
+    #[test]
+    fn todo_macro_is_not_flagged() {
+        let source = "fn f() { todo!() }";
+
+        let diagnostics = execute(&parse(source, Language::Rust), &mut passes());
+
+        assert_no_diagnostics(&diagnostics);
+    }
+
+    #[test]
+    fn todo_with_author_is_flagged() {
+        let source = "// TODO(marts): finish this\nfn f() {}";
+
+        let diagnostics = execute(&parse(source, Language::Rust), &mut passes());
+
+        assert_eq!(diagnostics.len(), 1);
+        assert_diagnostic(&diagnostics[0]).has_span("<test>", 3, 7);
+    }
+
+    #[test]
+    fn trait_send() {
+        fn assert_send<T: Send>() {}
+        assert_send::<NoTodoComments>();
+    }
+
+    #[test]
+    fn trait_send_found_marker() {
+        fn assert_send<T: Send>() {}
+        assert_send::<FoundMarker>();
+    }
+
+    #[test]
+    fn trait_sync() {
+        fn assert_sync<T: Sync>() {}
+        assert_sync::<NoTodoComments>();
+    }
+
+    #[test]
+    fn trait_sync_found_marker() {
+        fn assert_sync<T: Sync>() {}
+        assert_sync::<FoundMarker>();
+    }
+
+    #[test]
+    fn trait_unpin() {
+        fn assert_unpin<T: Unpin>() {}
+        assert_unpin::<NoTodoComments>();
+    }
+
+    #[test]
+    fn trait_unpin_found_marker() {
+        fn assert_unpin<T: Unpin>() {}
+        assert_unpin::<FoundMarker>();
+    }
+
+    #[test]
+    fn two_line_comments_with_markers_are_flagged_twice() {
+        let source = "// TODO: one\n// FIXME: two\nfn f() {}";
+
+        let diagnostics = execute(&parse(source, Language::Rust), &mut passes());
+
+        assert_eq!(diagnostics.len(), 2);
+        assert_diagnostic(&diagnostics[0]).has_span("<test>", 3, 7);
+        assert_diagnostic(&diagnostics[1]).has_span("<test>", 16, 21);
+    }
+
+    #[test]
+    fn xxx_comment_is_flagged() {
+        let source = "// XXX\nfn f() {}";
+
+        let diagnostics = execute(&parse(source, Language::Rust), &mut passes());
+
+        assert_eq!(diagnostics.len(), 1);
+        assert_diagnostic(&diagnostics[0]).message_contains("`XXX`");
+    }
+}


### PR DESCRIPTION
Closes #11.

Flags an uppercase `TODO`, `FIXME`, `HACK`, or `XXX` at the start of a comment line, in both `line_comment` and `block_comment`. The span covers the marker word rather than the whole comment, so the caret stays useful inside a long block.

The precision decisions, each pinned by a test:

- **Line-anchored, not substring.** Matching only after stripping leading whitespace and comment punctuation kills prose mentions, URLs, and trailing asides in one rule.
- **Uppercase only.** `todo`, `hack`, and `xxx` are ordinary English words, and the marker convention is uppercase anyway, so case-insensitivity would cost far more precision than it buys recall.
- **Word boundary required.** `TODOS`, `XXXX`, and `HACKY` do not fire.
- **String literals are out of scope structurally**, since the pass reads comment nodes.
- **Doc comments are in scope and report once.** `///` and `/**` are `line_comment`/`block_comment` with a `doc_comment` child, so hooking the outer kinds avoids double-reporting.

34 tests. Applying the matcher to every `.rs` file in the repo gives zero hits, so this does not fire on whisker's own source.

The crate omits the `.cargo/config.toml` that five older lint crates carry — it pins `linker = dylint-link`, which is Dylint residue. Those five are dead weight worth removing separately.
