### PR TITLE
Flag imports written inside function bodies

### DIFF
--- a/.config/whisker.toml
+++ b/.config/whisker.toml
@@ -20,6 +20,9 @@ path = "lints/derive_order"
 path = "lints/explicit_destructuring"
 
 [[lints]]
+path = "lints/function_scoped_import"
+
+[[lints]]
 path = "lints/if_let_with_else"
 
 [[lints]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -579,6 +579,14 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7ab85b9b05e3978cc9a9cf8fea7f01b494e1a09ed3037e16ba39edc7a29eb61a"
 
 [[package]]
+name = "function_scoped_import"
+version = "0.1.0"
+dependencies = [
+ "whisker-rust",
+ "whisker-types",
+]
+
+[[package]]
 name = "futures-core"
 version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2861,6 +2869,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "anyhow_missing_context",
+ "function_scoped_import",
  "proptest",
  "ra_ap_hir",
  "ra_ap_ide_db",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [workspace]
 members = ["crates/*"]
-exclude = ["examples/*", "lints/anyhow_missing_context", "lints/bool_param", "lints/derive_order", "lints/explicit_destructuring", "lints/if_let_with_else", "lints/long_doc_sentence", "lints/missing_examples_doc", "lints/missing_trait_tests", "lints/no_commented_out_code", "lints/no_em_dash_aside", "lints/no_inline_comments", "lints/no_matches_macro", "lints/no_todo_comments", "lints/pub_field", "lints/reference_style_links", "lints/repeated_primitive_params", "lints/shadow_transformations", "lints/wildcard_match_arm"]
+exclude = ["examples/*", "lints/anyhow_missing_context", "lints/bool_param", "lints/derive_order", "lints/explicit_destructuring", "lints/function_scoped_import", "lints/if_let_with_else", "lints/long_doc_sentence", "lints/missing_examples_doc", "lints/missing_trait_tests", "lints/no_commented_out_code", "lints/no_em_dash_aside", "lints/no_inline_comments", "lints/no_matches_macro", "lints/no_todo_comments", "lints/pub_field", "lints/reference_style_links", "lints/repeated_primitive_params", "lints/shadow_transformations", "lints/wildcard_match_arm"]
 
 # Opt-in to the new feature resolver introduced in Rust 1.85 and Edition 2024.
 # https://doc.rust-lang.org/cargo/reference/resolver.html#resolver-versions

--- a/crates/whisker-rust/Cargo.toml
+++ b/crates/whisker-rust/Cargo.toml
@@ -40,6 +40,7 @@ whisker-types.workspace = true
 # integration tests assert on diagnostics that real lints draw from real
 # decorations, not on the decorations alone.
 anyhow_missing_context = { path = "../../lints/anyhow_missing_context", default-features = false }
+function_scoped_import = { path = "../../lints/function_scoped_import", default-features = false }
 proptest.workspace = true
 whisker-core.workspace = true
 wildcard_match_arm = { path = "../../lints/wildcard_match_arm", default-features = false }

--- a/crates/whisker-rust/src/decorations.rs
+++ b/crates/whisker-rust/src/decorations.rs
@@ -7,6 +7,7 @@
 mod adt_flags;
 mod error_type;
 mod fn_signature;
+mod import_source;
 mod resolved_type;
 mod return_mode;
 mod type_path;
@@ -15,6 +16,7 @@ mod type_path_ref;
 pub use adt_flags::AdtFlags;
 pub use error_type::ErrorType;
 pub use fn_signature::FnSignature;
+pub use import_source::ImportSource;
 pub use resolved_type::ResolvedType;
 pub use return_mode::ReturnMode;
 pub use type_path::TypePath;

--- a/crates/whisker-rust/src/decorations/import_source.rs
+++ b/crates/whisker-rust/src/decorations/import_source.rs
@@ -1,0 +1,44 @@
+use whisker_macros::Decoration;
+
+/// What the qualifier of a `use` path names
+///
+/// Spelling does not answer this. `Message` in `use Message::Ping` names an
+/// enum, and an uppercase name such as `Shapes` can still name a module.
+///
+/// The provider attaches it to a `use_declaration` whose path has a
+/// qualifier. `use serde;` has none, so it carries no decoration.
+#[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug, Decoration)]
+#[decoration(cardinality = "one")]
+pub enum ImportSource {
+    /// A module or a crate root
+    Module,
+    /// An enum, so the import names its variants
+    Enum,
+    /// Anything else, such as a struct or a trait
+    Other,
+    /// A qualifier rust-analyzer resolved to nothing
+    Unresolved,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn trait_send_import_source() {
+        fn assert_send<T: Send>() {}
+        assert_send::<ImportSource>();
+    }
+
+    #[test]
+    fn trait_sync_import_source() {
+        fn assert_sync<T: Sync>() {}
+        assert_sync::<ImportSource>();
+    }
+
+    #[test]
+    fn trait_unpin_import_source() {
+        fn assert_unpin<T: Unpin>() {}
+        assert_unpin::<ImportSource>();
+    }
+}

--- a/crates/whisker-rust/src/provider.rs
+++ b/crates/whisker-rust/src/provider.rs
@@ -3,7 +3,10 @@ use std::path::Path;
 use std::sync::{Arc, Mutex};
 
 use anyhow::Context as _;
-use ra_ap_hir::{Adt, Enum, Function, HasAttrs, HirDisplay, Module, Semantics, Type, attach_db};
+use ra_ap_hir::{
+    Adt, Enum, Function, HasAttrs, HirDisplay, Module, ModuleDef, PathResolution, Semantics, Type,
+    attach_db,
+};
 use ra_ap_ide_db::base_db::SourceDatabase as _;
 use ra_ap_ide_db::famous_defs::FamousDefs;
 use ra_ap_ide_db::{ChangeWithProcMacros, RootDatabase};
@@ -16,7 +19,9 @@ use whisker_types::{
     ProviderName,
 };
 
-use crate::decorations::{AdtFlags, ErrorType, FnSignature, ResolvedType, ReturnMode, TypePath};
+use crate::decorations::{
+    AdtFlags, ErrorType, FnSignature, ImportSource, ResolvedType, ReturnMode, TypePath,
+};
 
 /// Decoration provider for Rust using rust-analyzer
 ///
@@ -345,6 +350,11 @@ fn resolve_targets(
                     decorations.insert(*operand_node_id, ty);
                 }
             }
+            Target::Import { node_id, range } => {
+                if let Some(source) = resolve_import(&ctx, *range) {
+                    decorations.insert(*node_id, source);
+                }
+            }
         }
     }
     decorations
@@ -377,6 +387,10 @@ enum Target {
     TryExpr {
         operand_range: TextRange,
         operand_node_id: usize,
+    },
+    Import {
+        node_id: usize,
+        range: TextRange,
     },
 }
 
@@ -439,6 +453,14 @@ fn collect_targets(node: &DecoratedNode<'_>, targets: &mut Vec<Target>) {
                 targets.push(Target::TryExpr {
                     operand_range,
                     operand_node_id: operand.id(),
+                });
+            }
+        }
+        "use_declaration" => {
+            if let Some(range) = text_range_of(node) {
+                targets.push(Target::Import {
+                    node_id: node.id(),
+                    range,
                 });
             }
         }
@@ -674,6 +696,75 @@ fn resolve_expr_type(ctx: &DecorateCtx<'_, '_>, range: TextRange) -> Option<Reso
     )
 }
 
+/// Returns what the qualifier of a `use` declaration names
+///
+/// The target range covers the whole declaration, so the covering node in
+/// rust-analyzer's tree is the [`ast::Use`] itself, and the qualifier comes
+/// from its use tree. A declaration with no qualifier, such as `use serde;`,
+/// yields [`None`] and so gets no decoration.
+///
+/// A qualifier rust-analyzer resolves to nothing becomes
+/// [`ImportSource::Unresolved`]. A rule can then separate a failed lookup
+/// from a file this provider never covered.
+fn resolve_import(ctx: &DecorateCtx<'_, '_>, range: TextRange) -> Option<ImportSource> {
+    let use_item = covering_node(ctx.syntax, range)?
+        .ancestors()
+        .find_map(ast::Use::cast)?;
+    let qualifier = import_qualifier(&use_item.use_tree()?)?;
+
+    match ctx.sema.resolve_path(&qualifier) {
+        Some(resolution) => Some(import_source_of(resolution)),
+        None => Some(ImportSource::Unresolved),
+    }
+}
+
+/// Returns the path a use tree reaches through to name what it imports
+///
+/// A tree that ends in a list or a star, as `use a::B::{C, D}` and
+/// `use a::B::*` do, holds the qualifier as its own path. Any other tree
+/// holds the imported name as the last segment, so the qualifier is the
+/// path without it.
+fn import_qualifier(tree: &ast::UseTree) -> Option<ast::Path> {
+    let path = tree.path()?;
+    let path_is_the_qualifier = tree.use_tree_list().is_some() || tree.star_token().is_some();
+
+    match path_is_the_qualifier {
+        true => Some(path),
+        false => path.qualifier(),
+    }
+}
+
+/// Classifies the item a resolved qualifier names
+///
+/// A module and an enum each get their own answer. An import out of an
+/// enum names variants; an import out of a module does not. Everything
+/// else is [`ImportSource::Other`].
+fn import_source_of(resolution: PathResolution<'_>) -> ImportSource {
+    match resolution {
+        PathResolution::Def(def) => match def {
+            ModuleDef::Module(_) => ImportSource::Module,
+            ModuleDef::Adt(Adt::Enum(_)) => ImportSource::Enum,
+            ModuleDef::Adt(Adt::Struct(_))
+            | ModuleDef::Adt(Adt::Union(_))
+            | ModuleDef::Function(_)
+            | ModuleDef::EnumVariant(_)
+            | ModuleDef::Const(_)
+            | ModuleDef::Static(_)
+            | ModuleDef::Trait(_)
+            | ModuleDef::TypeAlias(_)
+            | ModuleDef::BuiltinType(_)
+            | ModuleDef::Macro(_) => ImportSource::Other,
+        },
+        PathResolution::Local(_)
+        | PathResolution::TypeParam(_)
+        | PathResolution::ConstParam(_)
+        | PathResolution::SelfType(_)
+        | PathResolution::BuiltinAttr(_)
+        | PathResolution::ToolModule(_)
+        | PathResolution::DeriveHelper(_) => ImportSource::Other,
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use std::path::PathBuf;
@@ -786,6 +877,65 @@ mod tests {
         let covering = covering_node(&syntax, range_at(past_the_end, 1));
 
         assert!(covering.is_none());
+    }
+
+    /// Returns the text of the qualifier in `source`'s first `use` item
+    ///
+    /// Yields [`None`] when that item reaches through no qualifier.
+    fn qualifier_of(source: &str) -> Option<String> {
+        let file = SourceFile::parse(source, Edition::CURRENT).tree();
+        let use_item = file
+            .syntax()
+            .descendants()
+            .find_map(ast::Use::cast)
+            .expect("the source should hold a `use` item");
+        let tree = use_item.use_tree().expect("a `use` item has a tree");
+
+        import_qualifier(&tree).map(|path| path.syntax().text().to_string())
+    }
+
+    #[test]
+    fn import_qualifier_with_a_list_returns_the_whole_path() {
+        let qualifier = qualifier_of("use a::B::{C, D};");
+
+        assert_eq!(qualifier.as_deref(), Some("a::B"));
+    }
+
+    #[test]
+    fn import_qualifier_with_a_plain_path_drops_the_last_segment() {
+        let qualifier = qualifier_of("use a::B::C;");
+
+        assert_eq!(qualifier.as_deref(), Some("a::B"));
+    }
+
+    #[test]
+    fn import_qualifier_with_a_rename_drops_the_last_segment() {
+        let qualifier = qualifier_of("use a::B::C as D;");
+
+        assert_eq!(qualifier.as_deref(), Some("a::B"));
+    }
+
+    #[test]
+    fn import_qualifier_with_a_star_returns_the_whole_path() {
+        let qualifier = qualifier_of("use a::B::*;");
+
+        assert_eq!(qualifier.as_deref(), Some("a::B"));
+    }
+
+    /// A list with no path in front of it has no single qualifier
+    #[test]
+    fn import_qualifier_with_no_path_returns_none() {
+        let qualifier = qualifier_of("use {a::b, c::d};");
+
+        assert!(qualifier.is_none());
+    }
+
+    /// A `use` that names one segment reaches through nothing
+    #[test]
+    fn import_qualifier_with_one_segment_returns_none() {
+        let qualifier = qualifier_of("use serde;");
+
+        assert!(qualifier.is_none());
     }
 
     #[cfg(unix)]

--- a/crates/whisker-rust/tests/fixtures/sample_project/src/lib.rs
+++ b/crates/whisker-rust/tests/fixtures/sample_project/src/lib.rs
@@ -178,6 +178,42 @@ pub fn user_defined_result() -> myres::Result<()> {
     myres::Result::Ok(())
 }
 
+#[allow(non_snake_case)]
+pub mod Shapes {
+    pub fn draw() {}
+}
+
+pub fn import_enum_variants(color: Color) -> bool {
+    use Color::{Green, Red};
+
+    match color {
+        Red => true,
+        Green => false,
+        Color::Blue => false,
+    }
+}
+
+pub fn import_enum_variants_by_glob(color: Color) -> bool {
+    use Color::*;
+
+    match color {
+        Red => true,
+        Green | Blue => false,
+    }
+}
+
+pub fn import_from_module() -> usize {
+    use std::collections::HashMap;
+
+    HashMap::<u8, u8>::new().len()
+}
+
+pub fn import_from_uppercase_module() {
+    use Shapes::draw;
+
+    draw();
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/crates/whisker-rust/tests/provider_integration.rs
+++ b/crates/whisker-rust/tests/provider_integration.rs
@@ -5,7 +5,10 @@ use std::path::{Path, PathBuf};
 use std::sync::OnceLock;
 
 use anyhow_missing_context::AnyhowMissingContext;
-use whisker_rust::decorations::{AdtFlags, FnSignature, ResolvedType, ReturnMode, TypePathRef};
+use function_scoped_import::FunctionScopedImport;
+use whisker_rust::decorations::{
+    AdtFlags, FnSignature, ImportSource, ResolvedType, ReturnMode, TypePathRef,
+};
 use whisker_rust::{RustDecorationProvider, RustLintPassAdapter};
 use whisker_types::{
     Coverage, CoverageGap, DecoratedNode, DecoratedTree, DecorationProvider, Diagnostic, LintPass,
@@ -50,6 +53,30 @@ fn not_utf8_project() -> PathBuf {
     .expect("should write the fixture module that is not UTF-8");
     std::fs::write(root.join("src/notes.md"), b"notes \xff\xfe\n")
         .expect("should write the fixture include_str target that is not UTF-8");
+
+    root
+}
+
+/// Writes a Cargo project whose `use` paths rustc rejects
+///
+/// Rustc refuses a struct as an import prefix, and it refuses an unknown
+/// crate, so neither import can sit in a fixture that compiles. This
+/// function generates them instead. Rust-analyzer names the struct and
+/// resolves the unknown crate to nothing, and the provider must report
+/// both outcomes rather than fall silent.
+fn rejected_imports_project() -> PathBuf {
+    let root = Path::new(env!("CARGO_TARGET_TMPDIR")).join("rejected_imports_project");
+    std::fs::create_dir_all(root.join("src")).expect("should create the fixture directories");
+    std::fs::write(
+        root.join("Cargo.toml"),
+        "[workspace]\n\n[package]\nname = \"rejected_imports_project\"\nversion = \"0.1.0\"\nedition = \"2024\"\n",
+    )
+    .expect("should write the fixture manifest");
+    std::fs::write(
+        root.join("src/lib.rs"),
+        "pub struct Loader;\n\nimpl Loader {\n    pub fn load() -> u8 {\n        0\n    }\n}\n\npub fn import_an_associated_function() -> u8 {\n    use Loader::load;\n\n    load()\n}\n\npub fn import_from_an_unknown_crate() -> u8 {\n    use nowhere::thing;\n\n    thing()\n}\n",
+    )
+    .expect("should write the fixture crate root");
 
     root
 }
@@ -121,6 +148,19 @@ fn find_first_node_of_kind<'a>(node: &DecoratedNode<'a>, kind: &str) -> Option<D
         }
     }
     None
+}
+
+/// Returns the [`ImportSource`] on the first `use` inside the named function
+fn import_source_in(tree: &DecoratedTree, function: &str) -> ImportSource {
+    let root = tree.root_node();
+    let func =
+        find_function_by_name(&root, function).unwrap_or_else(|| panic!("should find {function}"));
+    let import = find_first_node_of_kind(&func, "use_declaration")
+        .unwrap_or_else(|| panic!("{function} should hold a `use`"));
+
+    *import
+        .decoration::<ImportSource>()
+        .unwrap_or_else(|| panic!("the `use` in {function} should have an ImportSource"))
 }
 
 /// Returns the operand of the first `?` expression inside `node`
@@ -218,6 +258,32 @@ fn decorate_with_code_under_cfg_test_resolves_types() {
         .decoration::<ResolvedType>()
         .expect("a scrutinee under cfg(test) should have ResolvedType");
     assert!(ty.is_enum(), "Color should be an enum");
+}
+
+/// A qualifier reports `Other` when it names another item, and
+/// `Unresolved` when it names nothing
+#[test]
+fn decorate_with_imports_rustc_rejects_reports_other_and_unresolved() {
+    let root = rejected_imports_project();
+    let provider = RustDecorationProvider::load(&root).expect("should load the fixture");
+    let file_path = root.join("src/lib.rs");
+    let source = std::fs::read_to_string(&file_path).expect("should read the fixture crate root");
+    let mut tree = parse_source(source, file_path);
+
+    let coverage = provider.decorate(&tree).expect("decorate should succeed");
+
+    match coverage {
+        Coverage::Covered(decorations) => tree.merge_decorations(decorations),
+        Coverage::NotCovered(gap) => panic!("the crate root should be covered, got: {gap}"),
+    }
+    assert_eq!(
+        import_source_in(&tree, "import_an_associated_function"),
+        ImportSource::Other
+    );
+    assert_eq!(
+        import_source_in(&tree, "import_from_an_unknown_crate"),
+        ImportSource::Unresolved
+    );
 }
 
 #[test]
@@ -443,6 +509,50 @@ fn fn_signature_on_user_defined_result_is_not_a_result() {
         ret.display()
     );
     assert!(sig.error_type().is_none());
+}
+
+/// A list import and a glob import out of an enum both report the enum
+///
+/// Both shapes hold the qualifier as the use tree's own path, so one
+/// lookup serves them.
+#[test]
+fn import_source_on_an_enum_qualifier_is_enum() {
+    let provider = load_provider();
+    let tree = parse_and_decorate_fixture(provider);
+
+    assert_eq!(
+        import_source_in(&tree, "import_enum_variants"),
+        ImportSource::Enum
+    );
+    assert_eq!(
+        import_source_in(&tree, "import_enum_variants_by_glob"),
+        ImportSource::Enum
+    );
+}
+
+#[test]
+fn import_source_on_a_module_qualifier_is_module() {
+    let provider = load_provider();
+    let tree = parse_and_decorate_fixture(provider);
+
+    assert_eq!(
+        import_source_in(&tree, "import_from_module"),
+        ImportSource::Module
+    );
+}
+
+/// A module whose name starts with a capital is still a module
+///
+/// The name looks like a type, and only the resolution says otherwise.
+#[test]
+fn import_source_on_an_uppercase_module_is_module() {
+    let provider = load_provider();
+    let tree = parse_and_decorate_fixture(provider);
+
+    assert_eq!(
+        import_source_in(&tree, "import_from_uppercase_module"),
+        ImportSource::Module
+    );
 }
 
 #[test]
@@ -958,6 +1068,25 @@ fn anyhow_missing_context_over_the_whole_file_reports_only_anyhow_bodies() {
             "std::fs::read_to_string(&self.path)?",
             "read()?",
         ]
+    );
+}
+
+/// Every place the `function_scoped_import` rule fires in the fixture
+///
+/// Among imports inside function bodies, the rule spares only those whose
+/// qualifier resolves to an enum.
+#[test]
+fn function_scoped_import_over_the_whole_file_spares_only_variant_imports() {
+    let provider = load_provider();
+    let tree = parse_and_decorate_fixture(provider);
+    let mut passes: Vec<Box<dyn LintPass>> =
+        vec![Box::new(RustLintPassAdapter::new(FunctionScopedImport))];
+
+    let diagnostics = whisker_core::walk(&tree, &mut passes);
+
+    assert_eq!(
+        flagged_in_file(&tree, &diagnostics),
+        vec!["use std::collections::HashMap;", "use Shapes::draw;"]
     );
 }
 

--- a/lints/function_scoped_import/Cargo.toml
+++ b/lints/function_scoped_import/Cargo.toml
@@ -1,0 +1,36 @@
+# A lint is its own cargo package, built as a cdylib and loaded by whisker at
+# check time. It is not a workspace member: the handshake compares the whisker
+# it was compiled against with the whisker loading it, and a package outside
+# the workspace resolves its own dependencies, which is what a lint written
+# outside this repository does too. The lockfile beside this manifest pins
+# that resolution.
+[package]
+name = "function_scoped_import"
+version = "0.1.0"
+edition = "2024"
+license = "Apache-2.0 OR MIT"
+publish = false
+
+[lib]
+crate-type = ["cdylib", "rlib"]
+
+# The provider feature stays off: a lint needs the generated trait and the
+# decoration types, not the rust-analyzer stack that produces decorations.
+# The exported declaration is a `no_mangle` static, so two rules linked into
+# one binary would collide. The cdylib whisker loads keeps it; a rule used as
+# an ordinary rlib dependency, as whisker-rust's provider tests do, turns it
+# off.
+[features]
+default = ["plugin"]
+plugin = []
+
+[dependencies]
+whisker-rust = { path = "../../crates/whisker-rust", default-features = false }
+whisker-types = { path = "../../crates/whisker-types" }
+
+[dev-dependencies]
+whisker-testing = { path = "../../crates/whisker-testing" }
+
+[lints.clippy]
+missing_errors_doc = "warn"
+missing_panics_doc = "warn"

--- a/lints/function_scoped_import/src/lib.rs
+++ b/lints/function_scoped_import/src/lib.rs
@@ -1,0 +1,468 @@
+use whisker_rust::decorations::ImportSource;
+use whisker_rust::{RustLintPass, RustLintPassAdapter};
+use whisker_types::{DecoratedNode, Diagnostic, LintPass, RuleId, Severity};
+
+const RULE_ID: RuleId = RuleId::new("lint.function-scoped-import");
+
+/// Flags `use` statements inside function bodies
+///
+/// An import in a function body hides what the module depends on. A `cfg`
+/// gate on the import or on an enclosing item silences the lint, because
+/// the narrow scope is then deliberate. The lint also spares an import
+/// whose qualifier resolves to an enum, because a variant import belongs
+/// beside the match that uses it.
+pub struct FunctionScopedImport;
+
+impl FunctionScopedImport {
+    /// Creates a boxed [`LintPass`] suitable for the whisker pipeline
+    ///
+    /// # Examples
+    ///
+    /// ```ignore
+    /// let pass = FunctionScopedImport::into_lint_pass();
+    /// ```
+    pub fn into_lint_pass() -> Box<dyn LintPass> {
+        Box::new(RustLintPassAdapter::new(Self))
+    }
+}
+
+/// Returns whether the node sits in a block rather than at module level
+///
+/// The walk stops at the nearest scope, so a `use` at the top of a module
+/// nested in a function counts as module level.
+fn is_inside_block(node: &DecoratedNode<'_>) -> bool {
+    let mut current = node.parent();
+    loop {
+        let Some(ancestor) = current else {
+            return false;
+        };
+        match ancestor.kind() {
+            "block" => return true,
+            "declaration_list" | "source_file" => return false,
+            _ => current = ancestor.parent(),
+        }
+    }
+}
+
+/// Returns whether the node or an enclosing item carries a `cfg` attribute
+///
+/// An item writes its gate in front of itself, and a module or a file writes
+/// it inside, so both spellings count at every level of the walk.
+fn is_cfg_gated(node: &DecoratedNode<'_>) -> bool {
+    let mut current = Some(node.clone());
+    loop {
+        let Some(item) = current else {
+            return false;
+        };
+        if has_cfg_attribute(&item) || has_inner_cfg_attribute(&item) {
+            return true;
+        }
+        current = item.parent();
+    }
+}
+
+/// Returns whether a `cfg` attribute precedes the node
+///
+/// Tree-sitter makes each attribute a sibling of the item it decorates.
+/// The search reads backward from the node over attributes and comments.
+/// It stops at the first sibling that is neither.
+fn has_cfg_attribute(node: &DecoratedNode<'_>) -> bool {
+    let Some(parent) = node.parent() else {
+        return false;
+    };
+    let siblings = parent.named_children();
+    let Some(index) = siblings
+        .iter()
+        .position(|sibling| sibling.id() == node.id())
+    else {
+        return false;
+    };
+
+    for sibling in siblings[..index].iter().rev() {
+        match sibling.kind() {
+            "attribute_item" => {
+                if is_cfg_attribute(sibling) {
+                    return true;
+                }
+            }
+            "line_comment" | "block_comment" => {}
+            _ => return false,
+        }
+    }
+    false
+}
+
+/// Returns whether a `cfg` attribute opens the node's own children
+///
+/// A file and a module body gate everything under them with `#![cfg(..)]`,
+/// which tree-sitter puts inside the `source_file` or the
+/// `declaration_list` rather than in front of the item. The search stops at
+/// the first child that is neither an inner attribute nor a comment.
+fn has_inner_cfg_attribute(node: &DecoratedNode<'_>) -> bool {
+    for child in node.named_children() {
+        match child.kind() {
+            "inner_attribute_item" => {
+                if is_cfg_attribute(&child) {
+                    return true;
+                }
+            }
+            "line_comment" | "block_comment" => {}
+            _ => return false,
+        }
+    }
+    false
+}
+
+/// Returns whether an attribute item names `cfg`
+///
+/// An `attribute_item` and an `inner_attribute_item` both hold the
+/// attribute as their first named child, so one check serves either.
+/// `cfg_attr` does not count, because it applies another attribute instead
+/// of removing the item.
+fn is_cfg_attribute(node: &DecoratedNode<'_>) -> bool {
+    let Some(attribute) = node.named_child(0) else {
+        return false;
+    };
+    let Some(path) = attribute.named_child(0) else {
+        return false;
+    };
+    path.kind() == "identifier" && path.text() == "cfg"
+}
+
+/// Returns whether the import names variants of an enum
+///
+/// Only the provider's resolution of the qualifier answers this; a
+/// capitalized qualifier proves nothing on its own. An undecorated node
+/// therefore keeps the diagnostic, because the exemption needs proof.
+fn imports_enum_variants(node: &DecoratedNode<'_>) -> bool {
+    match node.decoration::<ImportSource>() {
+        Some(ImportSource::Enum) => true,
+        Some(ImportSource::Module) => false,
+        Some(ImportSource::Other) => false,
+        Some(ImportSource::Unresolved) => false,
+        None => false,
+    }
+}
+
+impl RustLintPass for FunctionScopedImport {
+    fn check_use_declaration(&mut self, node: &DecoratedNode<'_>) -> Vec<Diagnostic> {
+        if !is_inside_block(node) {
+            return Vec::new();
+        }
+
+        if imports_enum_variants(node) {
+            return Vec::new();
+        }
+        if is_cfg_gated(node) {
+            return Vec::new();
+        }
+
+        vec![Diagnostic::new(
+            RULE_ID,
+            Severity::Warn,
+            "`use` sits inside a function body; move it to the top of the module".into(),
+            node.span(),
+        )]
+    }
+}
+
+#[cfg(feature = "plugin")]
+whisker_rust::export_lints![FunctionScopedImport];
+
+#[cfg(test)]
+mod tests {
+    use whisker_testing::{assert_diagnostic, assert_no_diagnostics, decorate, execute, parse};
+    use whisker_types::{DecorationMap, Language};
+
+    use super::*;
+
+    fn run(source: &str) -> Vec<Diagnostic> {
+        let tree = parse(source, Language::Rust);
+        let mut passes = vec![FunctionScopedImport::into_lint_pass()];
+        execute(&tree, &mut passes)
+    }
+
+    /// Runs the rule with `import_source` on every `use` in `source`
+    ///
+    /// The rule reads a decoration the Rust provider makes, and these tests
+    /// run no provider, so they attach it by hand.
+    fn run_with(source: &str, import_source: ImportSource) -> Vec<Diagnostic> {
+        let mut tree = parse(source, Language::Rust);
+        let mut ids = Vec::new();
+        collect_use_declaration_ids(&tree.root_node(), &mut ids);
+
+        let mut map = DecorationMap::new();
+        for id in ids {
+            map.insert(id, import_source);
+        }
+        decorate(&mut tree, map);
+
+        let mut passes = vec![FunctionScopedImport::into_lint_pass()];
+        execute(&tree, &mut passes)
+    }
+
+    fn collect_use_declaration_ids(node: &DecoratedNode<'_>, ids: &mut Vec<usize>) {
+        if node.kind() == "use_declaration" {
+            ids.push(node.id());
+        }
+        for child in node.named_children() {
+            collect_use_declaration_ids(&child, ids);
+        }
+    }
+
+    /// A struct or a trait qualifier names no variant
+    ///
+    /// The qualifier is capitalized like an enum, and the resolution says
+    /// otherwise.
+    #[test]
+    fn associated_function_import_is_flagged() {
+        let diagnostics = run_with("fn f() { use Type::associated_fn; }", ImportSource::Other);
+
+        assert_eq!(diagnostics.len(), 1);
+    }
+
+    #[test]
+    fn cfg_attr_on_function_is_flagged() {
+        let diagnostics = run("#[cfg_attr(test, allow(dead_code))]\nfn f() { use a::b; }");
+
+        assert_eq!(diagnostics.len(), 1);
+    }
+
+    #[test]
+    fn cfg_gate_after_other_attribute_is_not_flagged() {
+        let diagnostics = run("#[allow(dead_code)]\n#[cfg(test)]\nfn f() { use a::b; }");
+
+        assert_no_diagnostics(&diagnostics);
+    }
+
+    #[test]
+    fn cfg_gate_behind_doc_comment_is_not_flagged() {
+        let diagnostics = run("#[cfg(test)]\n/// Helps\nfn f() { use a::b; }");
+
+        assert_no_diagnostics(&diagnostics);
+    }
+
+    #[test]
+    fn cfg_gate_on_earlier_item_is_flagged() {
+        let diagnostics = run("#[cfg(test)]\nstruct A;\nfn f() { use a::b; }");
+
+        assert_eq!(diagnostics.len(), 1);
+    }
+
+    #[test]
+    fn cfg_gated_function_is_not_flagged() {
+        let diagnostics = run("#[cfg(test)]\nfn f() { use crate::test_utils::mock_client; }");
+
+        assert_no_diagnostics(&diagnostics);
+    }
+
+    #[test]
+    fn cfg_gated_import_is_not_flagged() {
+        let diagnostics = run("fn f() { #[cfg(unix)] use std::os::unix::fs::PermissionsExt; }");
+
+        assert_no_diagnostics(&diagnostics);
+    }
+
+    #[test]
+    fn cfg_gated_module_is_not_flagged() {
+        let diagnostics = run("#[cfg(test)]\nmod tests { fn f() { use crate::a::b; } }");
+
+        assert_no_diagnostics(&diagnostics);
+    }
+
+    #[test]
+    fn closure_body_import_is_flagged() {
+        let diagnostics = run("fn f() { let g = || { use a::b; }; }");
+
+        assert_eq!(diagnostics.len(), 1);
+    }
+
+    #[test]
+    fn enum_variant_glob_import_is_not_flagged() {
+        let diagnostics = run_with(
+            "fn f() { use Message::*; match m { Ping => {} } }",
+            ImportSource::Enum,
+        );
+
+        assert_no_diagnostics(&diagnostics);
+    }
+
+    /// An import with no [`ImportSource`] at all is still reported
+    ///
+    /// The exemption needs proof from the provider, and an undecorated node
+    /// carries none.
+    #[test]
+    fn enum_variant_import_without_a_decoration_is_flagged() {
+        let diagnostics = run("fn f() { use crate::Message::{Ping, Pong}; }");
+
+        assert_eq!(diagnostics.len(), 1);
+    }
+
+    #[test]
+    fn enum_variant_list_import_is_not_flagged() {
+        let diagnostics = run_with(
+            "fn f() { use crate::Message::{Ping, Pong}; }",
+            ImportSource::Enum,
+        );
+
+        assert_no_diagnostics(&diagnostics);
+    }
+
+    #[test]
+    fn enum_variant_single_import_is_not_flagged() {
+        let diagnostics = run_with("fn f() { use self::Message::Ping; }", ImportSource::Enum);
+
+        assert_no_diagnostics(&diagnostics);
+    }
+
+    #[test]
+    fn function_import_is_flagged() {
+        let diagnostics = run("fn f() { use std::collections::HashMap; }");
+
+        assert_eq!(diagnostics.len(), 1);
+        assert_diagnostic(&diagnostics[0])
+            .has_rule_id("lint.function-scoped-import")
+            .has_severity(Severity::Warn)
+            .message_contains("top of the module");
+    }
+
+    #[test]
+    fn impl_method_import_is_flagged() {
+        let diagnostics = run("impl Foo { fn f(&self) { use a::b; } }");
+
+        assert_eq!(diagnostics.len(), 1);
+    }
+
+    #[test]
+    fn inner_allow_on_module_is_flagged() {
+        let diagnostics = run("mod m { #![allow(dead_code)]\nfn f() { use a::b; } }");
+
+        assert_eq!(diagnostics.len(), 1);
+    }
+
+    #[test]
+    fn inner_cfg_gate_on_file_is_not_flagged() {
+        let diagnostics = run("#![cfg(feature = \"extra\")]\nfn f() { use a::b; }");
+
+        assert_no_diagnostics(&diagnostics);
+    }
+
+    #[test]
+    fn inner_cfg_gate_on_module_is_not_flagged() {
+        let diagnostics = run("mod m { #![cfg(test)]\nfn f() { use a::b; } }");
+
+        assert_no_diagnostics(&diagnostics);
+    }
+
+    #[test]
+    fn module_glob_import_in_function_is_flagged() {
+        let diagnostics = run("fn f() { use std::collections::*; }");
+
+        assert_eq!(diagnostics.len(), 1);
+    }
+
+    #[test]
+    fn module_level_import_is_not_flagged() {
+        let diagnostics = run("use std::collections::HashMap;\nfn f() {}");
+
+        assert_no_diagnostics(&diagnostics);
+    }
+
+    #[test]
+    fn module_nested_in_function_is_not_flagged() {
+        let diagnostics = run("fn f() { mod inner { use std::collections::HashMap; } }");
+
+        assert_no_diagnostics(&diagnostics);
+    }
+
+    #[test]
+    fn multiple_function_imports_are_each_flagged() {
+        let diagnostics = run("fn f() { use a::b; use c::d; }");
+
+        assert_eq!(diagnostics.len(), 2);
+    }
+
+    #[test]
+    fn nested_block_import_is_flagged() {
+        let diagnostics = run("fn f() { { use a::b; } }");
+
+        assert_eq!(diagnostics.len(), 1);
+    }
+
+    #[test]
+    fn renamed_import_in_function_is_flagged() {
+        let diagnostics = run("fn f() { use std::fmt::Write as _; }");
+
+        assert_eq!(diagnostics.len(), 1);
+    }
+
+    #[test]
+    fn single_segment_import_is_flagged() {
+        let diagnostics = run("fn f() { use serde; }");
+
+        assert_eq!(diagnostics.len(), 1);
+    }
+
+    #[test]
+    fn super_glob_import_in_function_is_flagged() {
+        let diagnostics = run("fn f() { use super::*; }");
+
+        assert_eq!(diagnostics.len(), 1);
+    }
+
+    #[test]
+    fn test_module_import_is_not_flagged() {
+        let diagnostics = run("#[cfg(test)]\nmod tests { use super::*; }");
+
+        assert_no_diagnostics(&diagnostics);
+    }
+
+    #[test]
+    fn trait_method_import_is_flagged() {
+        let diagnostics = run("trait T { fn f(&self) { use a::b; } }");
+
+        assert_eq!(diagnostics.len(), 1);
+    }
+
+    #[test]
+    fn trait_send() {
+        fn assert_send<T: Send>() {}
+        assert_send::<FunctionScopedImport>();
+    }
+
+    #[test]
+    fn trait_sync() {
+        fn assert_sync<T: Sync>() {}
+        assert_sync::<FunctionScopedImport>();
+    }
+
+    #[test]
+    fn trait_unpin() {
+        fn assert_unpin<T: Unpin>() {}
+        assert_unpin::<FunctionScopedImport>();
+    }
+
+    #[test]
+    fn unresolved_import_is_flagged() {
+        let diagnostics = run_with("fn f() { use nowhere::thing; }", ImportSource::Unresolved);
+
+        assert_eq!(diagnostics.len(), 1);
+    }
+
+    /// A qualifier spelled like a type does not earn the exemption
+    ///
+    /// Only the resolution tells this apart from a variant import.
+    #[test]
+    fn uppercase_module_import_is_flagged() {
+        let diagnostics = run_with("fn f() { use Shapes::draw; }", ImportSource::Module);
+
+        assert_eq!(diagnostics.len(), 1);
+    }
+
+    #[test]
+    fn use_list_without_path_is_flagged() {
+        let diagnostics = run("fn f() { use {a::b, c::d}; }");
+
+        assert_eq!(diagnostics.len(), 1);
+    }
+}


### PR DESCRIPTION
Closes #19.

Fires on a `use_declaration` whose nearest enclosing scope is a `block` — function bodies, closures, trait default methods, impl methods, bare nested blocks. A `mod` inside a function is module scope, so it stays silent.

CLAUDE.md carves out two exceptions and both are honored.

**`cfg`-gated functions.** tree-sitter makes `attribute_item` a preceding sibling rather than a child, so the check reads backward through the parent's named children, skipping comments, since a doc comment really does sit between the attribute and the `fn`. A file or a module body gates itself from the inside instead, with `#![cfg(..)]`, which tree-sitter puts among the leading children of the `source_file` or the `declaration_list`, so the check reads forward from there as well. It applies at every ancestor. `cfg_attr` deliberately does not count, because it applies another attribute rather than removing the item.

**Enum variant imports**, which CLAUDE.md permits for pattern matching. This is resolved rather than guessed. `collect_targets` now decorates `use_declaration`, and the provider resolves the qualifier through rust-analyzer's `Semantics::resolve_path` into a new `ImportSource` decoration: `Module`, `Enum`, `Other`, or `Unresolved`. The match over `PathResolution` and `ModuleDef` is exhaustive, so a new rust-analyzer variant breaks the build rather than silently falling through.

`ImportSource` is a separate decoration rather than a reuse of `ResolvedType`, because a use qualifier is frequently not a type at all — a `ResolvedType` with `is_enum: false` would collapse "this is a module" and "we could not tell" into one value, which is the ambiguity being removed.

An earlier revision guessed from capitalisation: exempt the qualifier when its last segment starts uppercase. The counterexample is a compiling one, now in the fixture — `#[allow(non_snake_case)] pub mod Shapes` with `use Shapes::draw;`, an uppercase module the old rule exempted and this one flags.

Worth recording, since it was the stated reason for wanting resolution: **`use Type::associated_fn` does not compile.** `use Trait::assoc_fn` is E0658 and `use Struct::assoc_fn` is E0432. In compiling Rust a use qualifier is only ever a module, a crate, or an enum, so that trade-off was about code that cannot exist.

When a qualifier cannot be resolved, or a declaration has no qualifier at all, the import is reported. The exemption requires proof; the rule's default stands without it. Falling back to the old guess would make behaviour depend on something invisible.

34 lint tests plus provider integration tests against real rust-analyzer decorations, including a runtime-generated fixture holding `use Loader::load;` and `use nowhere::thing;` that confirms the struct resolves to `Other` and the unknown crate to `Unresolved`.

Dogfood is unchanged: `whisker check . --keep-going` gives identical tallies before and after, and this rule fires zero times. The `cfg` exception is load-bearing for that — imports in a `#[cfg(unix)]` test and inside `#[cfg(test)] mod tests` would otherwise fire, and both are shapes CLAUDE.md permits.
