### PR TITLE
Configure scoped GitHub access for Claude

### DIFF
--- a/.claude/.gitignore
+++ b/.claude/.gitignore
@@ -1,0 +1,10 @@
+# Ignore the (optional) GitHub token we use to enable remote control for Claude
+.github_access_token
+
+# Ignore the scoped settings for the GitHub CLI
+.gh/
+
+# Ignore local state Claude Code writes into this directory
+.cc-writes/
+settings.local.json
+worktrees/

--- a/.claude/justfile
+++ b/.claude/justfile
@@ -1,0 +1,92 @@
+# `set dotenv-command` requires just 1.54.0 or newer. Older versions reject it as
+# an unknown setting, which reads as a syntax error rather than a stale toolchain.
+set dotenv-command := "op inject --in-file .github_access_token"
+set positional-arguments
+
+[private]
+default:
+    @just --list
+
+# Ensure the repository is cloned over HTTPS
+#
+# The configuration set up by the following recipes only works if the
+# repository's remote uses HTTPS. This recipe checks the remote URL and fails if
+# it is not an HTTPS URL.
+[doc("Ensure the repository is cloned over HTTPS")]
+[private]
+require-https:
+    #!/usr/bin/env bash
+    set -euo pipefail
+
+    url="$(git remote get-url origin)"
+
+    case "$url" in
+      https://github.com/*) ;;
+      *) printf 'error: origin is %s\n' "$url" >&2
+         printf 'hint: this expects a dedicated HTTPS clone, not your main checkout\n' >&2
+         exit 1 ;;
+    esac
+
+# Set up GitHub authentication
+#
+# This recipe sets up GitHub authentication for the current repository by
+# configuring a local Git credential helper that uses an access token stored in
+# the `AONYX_GITHUB_TOKEN` environment variable. This allows you to authenticate
+# with GitHub without having to unlock 1Password every time.
+#
+# The helper reads the environment on every call and bakes in no token, so a
+# rotation in 1Password takes effect at the next `just launch`. This recipe only
+# needs re-running in a fresh clone.
+[doc("Set up GitHub authentication")]
+setup: require-https
+    #!/usr/bin/env bash
+    set -euo pipefail
+
+    # Configure Git to use a custom credential helper that reads the token from
+    # the environment variable
+    key='credential.https://github.com.helper'
+    git config --local --unset-all "$key" || true
+    git config --local --add "$key" ""
+    git config --local --add "$key" \
+      '!f() { [ -n "${AONYX_GITHUB_TOKEN:-}" ] || { printf "error: AONYX_GITHUB_TOKEN is not set; start the session with just launch\n" >&2; exit 1; }; printf "username=%s\n" "x-access-token"; printf "password=%s\n" "$AONYX_GITHUB_TOKEN"; }; f'
+
+    # Disable commit signing
+    git config --local commit.gpgsign false
+    git config --local tag.gpgsign false
+
+# Launch a Claude Code session with scoped GitHub Access
+#
+# This recipe launches a Claude Code session that uses HTTPS and a scoped API
+# key to access GitHub. This makes it possible to automate Claude sessions and
+# drive them remotely without having to unlock 1Password to sign commits or push
+# to GitHub.
+#
+# The access token is read from the `.github_access_token` file, which is loaded
+# as a dotenv file. This makes it possible to read the token from 1Password when
+# the just recipe is run, and then use it to authenticate with GitHub without
+# having to unlock 1Password each time.
+#
+# ```env
+# AONYX_GITHUB_TOKEN="{{ op://Agents/aonyx-github-token/token }}"
+# ```
+[doc("Launch a Claude Code session with scoped GitHub Access")]
+launch *args: require-https
+    #!/usr/bin/env bash
+    set -euo pipefail
+
+    if [ -z "${AONYX_GITHUB_TOKEN:-}" ]; then
+      printf 'error: AONYX_GITHUB_TOKEN is not set\n' >&2
+      printf 'hint: .github_access_token must assign it an op:// reference\n' >&2
+      exit 1
+    fi
+
+    # Never prompt the user for credentials
+    export GIT_TERMINAL_PROMPT=0 GIT_ASKPASS=/bin/false
+
+    # Scope gh to the token, and hide the admin credential in the keyring so it
+    # cannot be recovered by unsetting GH_TOKEN
+    export GH_TOKEN="$AONYX_GITHUB_TOKEN"
+    export GH_CONFIG_DIR="{{ justfile_directory() }}/.gh"
+    mkdir -p "$GH_CONFIG_DIR"
+
+    flox activate -- claude "$@"


### PR DESCRIPTION
Copied from aonyx-ai/aonyx#110.

Claude uses the developer's own Git and GitHub configuration, and this repository's SSH key lives in 1Password, so signing a commit or pushing needs someone present to unlock it. That rules out driving a session remotely, and it has cost real time in this repo already.

`just setup` configures a local credential helper that reads a fine-grained token from an environment variable, and disables commit signing locally — the signing key being the thing that needs unlocking. `just launch` reads the token from 1Password once, scopes `gh` to it via a private `GH_CONFIG_DIR`, and starts a session. It refuses to start if the token resolves to nothing rather than exporting an empty `GH_TOKEN`, and passes its arguments through to `claude` intact, so `just launch -p "fix the bug"` arrives as one argument rather than four.

The `require-https` guard refuses to run against an SSH remote, so this cannot be applied to a normal checkout by accident. It needs a dedicated HTTPS clone; this repository's usual remote is SSH and stays that way.

These recipes need just 1.54.0 or newer for `set dotenv-command`. The just pinned in the flox environment is 1.51.0 and rejects the setting outright, so run them with the system just; `launch` enters the flox environment itself.

The ignore list also covers `worktrees/`, `settings.local.json`, and `.cc-writes/`, which Claude Code writes into `.claude/`. Without that, tracking part of the directory makes the rest show up as untracked noise.
