### PR TITLE
Flag inline Markdown links in doc comments

### DIFF
--- a/.config/whisker.toml
+++ b/.config/whisker.toml
@@ -41,6 +41,9 @@ path = "lints/no_matches_macro"
 path = "lints/no_todo_comments"
 
 [[lints]]
+path = "lints/reference_style_links"
+
+[[lints]]
 path = "lints/repeated_primitive_params"
 
 [[lints]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [workspace]
 members = ["crates/*"]
-exclude = ["examples/*", "lints/anyhow_missing_context", "lints/bool_param", "lints/derive_order", "lints/explicit_destructuring", "lints/if_let_with_else", "lints/missing_examples_doc", "lints/missing_trait_tests", "lints/no_commented_out_code", "lints/no_inline_comments", "lints/no_matches_macro", "lints/no_todo_comments", "lints/repeated_primitive_params", "lints/shadow_transformations", "lints/wildcard_match_arm"]
+exclude = ["examples/*", "lints/anyhow_missing_context", "lints/bool_param", "lints/derive_order", "lints/explicit_destructuring", "lints/if_let_with_else", "lints/missing_examples_doc", "lints/missing_trait_tests", "lints/no_commented_out_code", "lints/no_inline_comments", "lints/no_matches_macro", "lints/no_todo_comments", "lints/reference_style_links", "lints/repeated_primitive_params", "lints/shadow_transformations", "lints/wildcard_match_arm"]
 
 # Opt-in to the new feature resolver introduced in Rust 1.85 and Edition 2024.
 # https://doc.rust-lang.org/cargo/reference/resolver.html#resolver-versions

--- a/lints/reference_style_links/Cargo.toml
+++ b/lints/reference_style_links/Cargo.toml
@@ -1,0 +1,36 @@
+# A lint is its own cargo package, built as a cdylib and loaded by whisker at
+# check time. It is not a workspace member: the handshake compares the whisker
+# it was compiled against with the whisker loading it, and a package outside
+# the workspace resolves its own dependencies, which is what a lint written
+# outside this repository does too. The lockfile beside this manifest pins
+# that resolution.
+[package]
+name = "reference_style_links"
+version = "0.1.0"
+edition = "2024"
+license = "Apache-2.0 OR MIT"
+publish = false
+
+[lib]
+crate-type = ["cdylib", "rlib"]
+
+# The provider feature stays off: a lint needs the generated trait and the
+# decoration types, not the rust-analyzer stack that produces decorations.
+# The exported declaration is a `no_mangle` static, so two rules linked into
+# one binary would collide. The cdylib whisker loads keeps it; a rule used as
+# an ordinary rlib dependency, as whisker-rust's provider tests do, turns it
+# off.
+[features]
+default = ["plugin"]
+plugin = []
+
+[dependencies]
+whisker-rust = { path = "../../crates/whisker-rust", default-features = false }
+whisker-types = { path = "../../crates/whisker-types" }
+
+[dev-dependencies]
+whisker-testing = { path = "../../crates/whisker-testing" }
+
+[lints.clippy]
+missing_errors_doc = "warn"
+missing_panics_doc = "warn"

--- a/lints/reference_style_links/src/doc_block.rs
+++ b/lints/reference_style_links/src/doc_block.rs
@@ -1,0 +1,238 @@
+use std::path::Path;
+use std::sync::Arc;
+
+use whisker_types::{DecoratedNode, Span};
+
+/// The Markdown of one doc comment, joined the way rustdoc joins it
+///
+/// Rustdoc reads the consecutive `///` lines above an item as one document.
+/// A code fence can open on one line and close on a later one, so a rule
+/// that reads each comment line alone never sees the fence close. This type
+/// joins the lines and remembers where each one starts in the file. An
+/// offset in the joined text maps back to a [`Span`].
+///
+/// [`Span`]: whisker_types::Span
+pub(crate) struct DocBlock {
+    file: Arc<Path>,
+    content: String,
+    lines: Vec<Line>,
+}
+
+/// Where one line of the joined text came from
+#[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug)]
+struct Line {
+    /// Offset of the line's first byte in the joined text
+    content_start: usize,
+    /// Offset of the same byte in the source file
+    file_start: usize,
+}
+
+impl DocBlock {
+    /// Joins a run of comment nodes into one Markdown document
+    ///
+    /// Each node contributes the text of its `doc` field, which is what
+    /// follows the `///`, `//!`, `/**`, or `/*!` marker. For a line comment
+    /// that field also covers the newline, so the join drops it and puts one
+    /// back between lines. The join then strips the indentation every
+    /// non-blank line shares, or the space after `///` would read as an
+    /// indented code block.
+    ///
+    /// Returns [`None`] when no node carries such a field, which is the case
+    /// for an ordinary comment.
+    ///
+    /// [`None`]: std::option::Option::None
+    pub(crate) fn from_comments(comments: &[DecoratedNode<'_>]) -> Option<Self> {
+        let file = Arc::clone(comments.first()?.span().file_arc());
+
+        let mut raw: Vec<(usize, &str)> = Vec::new();
+        for comment in comments {
+            let Some(doc) = comment.child_by_field_name("doc") else {
+                continue;
+            };
+            let start = doc.raw().start_byte();
+            let body = doc.text();
+            let body = body.strip_suffix('\n').unwrap_or(body);
+            let body = body.strip_suffix('\r').unwrap_or(body);
+
+            let mut offset = 0;
+            for line in body.split('\n') {
+                let text = line.strip_suffix('\r').unwrap_or(line);
+                raw.push((start + offset, text));
+                offset += line.len() + 1;
+            }
+        }
+
+        if raw.is_empty() {
+            return None;
+        }
+
+        let indent = raw
+            .iter()
+            .filter(|(_, text)| !text.trim().is_empty())
+            .map(|(_, text)| leading_space_count(text))
+            .min()
+            .unwrap_or(0);
+
+        let mut content = String::new();
+        let mut lines = Vec::with_capacity(raw.len());
+        for (index, (file_start, text)) in raw.iter().enumerate() {
+            if index > 0 {
+                content.push('\n');
+            }
+            let strip = indent.min(leading_space_count(text));
+            lines.push(Line {
+                content_start: content.len(),
+                file_start: file_start + strip,
+            });
+            content.push_str(&text[strip..]);
+        }
+
+        Some(Self {
+            file,
+            content,
+            lines,
+        })
+    }
+
+    /// Returns the joined Markdown text
+    pub(crate) fn content(&self) -> &str {
+        &self.content
+    }
+
+    /// Returns the span of the file text that `start..end` came from
+    ///
+    /// # Panics
+    ///
+    /// Panics if `start` is greater than `end`.
+    pub(crate) fn span(&self, start: usize, end: usize) -> Span {
+        Span::new(
+            Arc::clone(&self.file),
+            self.to_file_offset(start),
+            self.to_file_offset(end),
+        )
+    }
+
+    /// Converts an offset in the joined text to an offset in the file
+    fn to_file_offset(&self, offset: usize) -> usize {
+        let index = self
+            .lines
+            .partition_point(|line| line.content_start <= offset)
+            .saturating_sub(1);
+        let line = self.lines[index];
+
+        line.file_start + (offset - line.content_start)
+    }
+}
+
+/// Counts the spaces a line starts with
+fn leading_space_count(text: &str) -> usize {
+    text.bytes().take_while(|byte| *byte == b' ').count()
+}
+
+#[cfg(test)]
+mod tests {
+    use whisker_testing::parse;
+    use whisker_types::{DecoratedTree, Language};
+
+    use super::*;
+
+    /// Collects the comment nodes of a parsed file in source order
+    fn comments(tree: &DecoratedTree) -> Vec<DecoratedNode<'_>> {
+        fn walk<'a>(node: &DecoratedNode<'a>, found: &mut Vec<DecoratedNode<'a>>) {
+            if node.kind() == "line_comment" || node.kind() == "block_comment" {
+                found.push(node.clone());
+            }
+            for child in node.named_children() {
+                walk(&child, found);
+            }
+        }
+
+        let mut found = Vec::new();
+        walk(&tree.root_node(), &mut found);
+        found
+    }
+
+    #[test]
+    fn content_joins_consecutive_lines() {
+        let tree = parse("/// first\n/// second\nfn f() {}", Language::Rust);
+        let nodes = comments(&tree);
+
+        let block = DocBlock::from_comments(&nodes).expect("should build a block");
+
+        assert_eq!(block.content(), "first\nsecond");
+    }
+
+    #[test]
+    fn content_keeps_extra_indentation() {
+        let tree = parse("/// a\n///     b\nfn f() {}", Language::Rust);
+        let nodes = comments(&tree);
+
+        let block = DocBlock::from_comments(&nodes).expect("should build a block");
+
+        assert_eq!(block.content(), "a\n    b");
+    }
+
+    #[test]
+    fn from_comments_with_empty_slice_returns_none() {
+        let nodes: Vec<DecoratedNode<'_>> = Vec::new();
+
+        let block = DocBlock::from_comments(&nodes);
+
+        assert!(block.is_none());
+    }
+
+    #[test]
+    fn from_comments_with_plain_comment_returns_none() {
+        let tree = parse("// plain\nfn f() {}", Language::Rust);
+        let nodes = comments(&tree);
+
+        let block = DocBlock::from_comments(&nodes);
+
+        assert!(block.is_none());
+    }
+
+    #[test]
+    fn span_maps_an_offset_on_a_later_line() {
+        let source = "/// first\n/// second\nfn f() {}";
+        let tree = parse(source, Language::Rust);
+        let nodes = comments(&tree);
+        let block = DocBlock::from_comments(&nodes).expect("should build a block");
+
+        let span = block.span(6, 12);
+
+        assert_eq!(&source[span.start()..span.end()], "second");
+    }
+
+    #[test]
+    fn span_maps_an_offset_on_the_first_line() {
+        let source = "/// first\n/// second\nfn f() {}";
+        let tree = parse(source, Language::Rust);
+        let nodes = comments(&tree);
+        let block = DocBlock::from_comments(&nodes).expect("should build a block");
+
+        let span = block.span(0, 5);
+
+        assert_eq!(&source[span.start()..span.end()], "first");
+    }
+
+    #[test]
+    fn trait_send() {
+        fn assert_send<T: Send>() {}
+        assert_send::<DocBlock>();
+        assert_send::<Line>();
+    }
+
+    #[test]
+    fn trait_sync() {
+        fn assert_sync<T: Sync>() {}
+        assert_sync::<DocBlock>();
+        assert_sync::<Line>();
+    }
+
+    #[test]
+    fn trait_unpin() {
+        fn assert_unpin<T: Unpin>() {}
+        assert_unpin::<DocBlock>();
+        assert_unpin::<Line>();
+    }
+}

--- a/lints/reference_style_links/src/inline_link.rs
+++ b/lints/reference_style_links/src/inline_link.rs
@@ -1,0 +1,760 @@
+mod link_kind;
+
+pub(crate) use self::link_kind::LinkKind;
+
+/// One inline Markdown link inside a doc comment
+///
+/// The offsets index the joined text of a [`DocBlock`], not the source
+/// file, because this module never sees the file. [`DocBlock::span`] turns
+/// them back into a span.
+///
+/// [`DocBlock`]: crate::doc_block::DocBlock
+/// [`DocBlock::span`]: crate::doc_block::DocBlock::span
+#[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug)]
+pub(crate) struct InlineLink {
+    kind: LinkKind,
+    start: usize,
+    end: usize,
+}
+
+impl InlineLink {
+    /// Finds every inline link in a Markdown document
+    ///
+    /// The search follows CommonMark closely, so text that only looks like a
+    /// link stays unflagged. It skips fenced and indented code blocks, code
+    /// spans, and bracket runs that a backslash escapes. Reference links
+    /// such as `[text]` and `[text][label]` are the forms this rule asks
+    /// for, so they never match.
+    pub(crate) fn find_all(content: &str) -> Vec<Self> {
+        let bytes = content.as_bytes();
+        let mut links = Vec::new();
+
+        for prose in prose_ranges(content) {
+            let ProseRange { start, end } = prose;
+            scan(bytes, start, end, &mut links);
+        }
+
+        links
+    }
+
+    /// Returns the form the author wrote
+    pub(crate) fn kind(self) -> LinkKind {
+        self.kind
+    }
+
+    /// Returns the offset of the link's first byte
+    pub(crate) fn start(self) -> usize {
+        self.start
+    }
+
+    /// Returns the offset one past the link's last byte
+    pub(crate) fn end(self) -> usize {
+        self.end
+    }
+}
+
+/// A run of consecutive lines that hold Markdown prose
+#[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug)]
+struct ProseRange {
+    /// Offset of the run's first byte
+    start: usize,
+    /// Offset one past the run's last byte
+    end: usize,
+}
+
+/// What a line contributes to the document
+#[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug)]
+enum LineRole {
+    /// The line holds prose, so the link scanner reads it
+    Prose,
+    /// The line holds code or nothing, so the link scanner skips it
+    Skip,
+}
+
+/// The kind of block the block scanner is inside
+#[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug)]
+enum BlockState {
+    /// Inside a fenced code block opened by `marker` repeated `length` times
+    Fenced { marker: u8, length: usize },
+    /// Inside a code block that four spaces of indentation introduced
+    IndentedCode,
+    /// Outside any code block
+    Prose,
+}
+
+/// Whether a line carries anything but whitespace
+#[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug)]
+enum Fill {
+    /// The line is empty or holds only whitespace
+    Blank,
+    /// The line holds content
+    Text,
+}
+
+/// One line of the document, split at the end of its indentation
+#[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug)]
+struct Line<'a> {
+    /// The number of spaces the line starts with
+    indent: usize,
+    /// The line without its leading spaces
+    rest: &'a str,
+    /// Whether `rest` holds anything but whitespace
+    fill: Fill,
+}
+
+impl<'a> Line<'a> {
+    /// Splits one line of the document
+    fn new(text: &'a str) -> Self {
+        let indent = text.bytes().take_while(|byte| *byte == b' ').count();
+        let rest = &text[indent..];
+        let fill = match rest.trim_end().is_empty() {
+            true => Fill::Blank,
+            false => Fill::Text,
+        };
+
+        Self { indent, rest, fill }
+    }
+}
+
+/// Splits a document into the byte ranges that hold prose
+///
+/// A code block can span many lines, so the rule cannot judge one comment
+/// line on its own. Blank lines end a range as well, because neither a code
+/// span nor a link may cross a paragraph break.
+fn prose_ranges(content: &str) -> Vec<ProseRange> {
+    let mut ranges: Vec<ProseRange> = Vec::new();
+    let mut state = BlockState::Prose;
+    let mut previous = Fill::Blank;
+    let mut offset = 0;
+
+    for text in content.split('\n') {
+        let start = offset;
+        let end = offset + text.len();
+        offset = end + 1;
+
+        let line = Line::new(text);
+        let (next, role) = advance(state, line, previous);
+        state = next;
+        previous = line.fill;
+
+        let extends = match ranges.last() {
+            Some(last) => last.end + 1 == start,
+            None => false,
+        };
+
+        match role {
+            LineRole::Prose => match extends {
+                true => {
+                    let last = ranges.last_mut().expect("a range exists to extend");
+                    last.end = end;
+                }
+                false => ranges.push(ProseRange { start, end }),
+            },
+            LineRole::Skip => {}
+        }
+    }
+
+    ranges
+}
+
+/// Advances the block scanner across one line
+fn advance(state: BlockState, line: Line<'_>, previous: Fill) -> (BlockState, LineRole) {
+    match state {
+        BlockState::Fenced { marker, length } => {
+            match line.indent <= 3 && closes_fence(line.rest, marker, length) {
+                true => (BlockState::Prose, LineRole::Skip),
+                false => (BlockState::Fenced { marker, length }, LineRole::Skip),
+            }
+        }
+        BlockState::IndentedCode => match line.fill == Fill::Blank || line.indent >= 4 {
+            true => (BlockState::IndentedCode, LineRole::Skip),
+            false => classify(line, previous),
+        },
+        BlockState::Prose => classify(line, previous),
+    }
+}
+
+/// Classifies a line that starts outside any code block
+fn classify(line: Line<'_>, previous: Fill) -> (BlockState, LineRole) {
+    if let Some(fence) = opens_fence(line.rest, line.indent) {
+        return (fence, LineRole::Skip);
+    }
+
+    match line.fill {
+        Fill::Blank => (BlockState::Prose, LineRole::Skip),
+        Fill::Text => match previous == Fill::Blank && line.indent >= 4 {
+            true => (BlockState::IndentedCode, LineRole::Skip),
+            false => (BlockState::Prose, LineRole::Prose),
+        },
+    }
+}
+
+/// Returns the fence a line opens, if it opens one
+fn opens_fence(rest: &str, indent: usize) -> Option<BlockState> {
+    if indent > 3 {
+        return None;
+    }
+    let marker = rest.bytes().next()?;
+    if marker != b'`' && marker != b'~' {
+        return None;
+    }
+    let length = rest.bytes().take_while(|byte| *byte == marker).count();
+    if length < 3 {
+        return None;
+    }
+    let info = &rest[length..];
+    if marker == b'`' && info.contains('`') {
+        return None;
+    }
+    Some(BlockState::Fenced { marker, length })
+}
+
+/// Returns whether a line closes the fence that is currently open
+fn closes_fence(rest: &str, marker: u8, length: usize) -> bool {
+    let count = rest.bytes().take_while(|byte| *byte == marker).count();
+    count >= length && rest[count..].trim().is_empty()
+}
+
+/// Collects the inline links in one run of prose
+fn scan(bytes: &[u8], start: usize, end: usize, links: &mut Vec<InlineLink>) {
+    let mut index = start;
+
+    while index < end {
+        let byte = bytes[index];
+
+        if byte == b'\\' {
+            index += 2;
+        } else if byte == b'`' {
+            index = skip_code_span(bytes, index, end);
+        } else if byte == b'!' && bytes.get(index + 1) == Some(&b'[') && index + 1 < end {
+            index = match link_end(bytes, index + 1, end) {
+                Some(link) => {
+                    links.push(InlineLink {
+                        kind: LinkKind::Image,
+                        start: index,
+                        end: link,
+                    });
+                    link
+                }
+                None => index + 1,
+            };
+        } else if byte == b'[' {
+            index = match link_end(bytes, index, end) {
+                Some(link) => {
+                    links.push(InlineLink {
+                        kind: LinkKind::Text,
+                        start: index,
+                        end: link,
+                    });
+                    link
+                }
+                None => index + 1,
+            };
+        } else {
+            index += 1;
+        }
+    }
+}
+
+/// Returns the offset just past an inline link that starts at `open`
+///
+/// `open` is the offset of the `[` that begins the link text. Returns
+/// [`None`] for a reference link, for an unclosed bracket, and for a `(`
+/// group that is not a well-formed destination.
+///
+/// [`None`]: std::option::Option::None
+fn link_end(bytes: &[u8], open: usize, end: usize) -> Option<usize> {
+    let mut index = open + 1;
+    let mut depth = 0usize;
+
+    let close = loop {
+        if index >= end {
+            return None;
+        }
+        let byte = bytes[index];
+        if byte == b'\\' {
+            index += 2;
+        } else if byte == b'`' {
+            index = skip_code_span(bytes, index, end);
+        } else if byte == b'[' {
+            depth += 1;
+            index += 1;
+        } else if byte == b']' {
+            if depth == 0 {
+                break index;
+            }
+            depth -= 1;
+            index += 1;
+        } else {
+            index += 1;
+        }
+    };
+
+    let paren = close + 1;
+    if paren >= end || bytes[paren] != b'(' {
+        return None;
+    }
+
+    destination_end(bytes, paren + 1, end)
+}
+
+/// Returns the offset just past the `)` that closes the destination and its
+/// optional title
+fn destination_end(bytes: &[u8], open: usize, end: usize) -> Option<usize> {
+    let mut index = skip_whitespace(bytes, open, end);
+    if index >= end {
+        return None;
+    }
+
+    if bytes[index] == b'<' {
+        index += 1;
+        loop {
+            if index >= end {
+                return None;
+            }
+            let byte = bytes[index];
+            if byte == b'\\' {
+                index += 2;
+            } else if byte == b'\n' || byte == b'<' {
+                return None;
+            } else if byte == b'>' {
+                index += 1;
+                break;
+            } else {
+                index += 1;
+            }
+        }
+    } else {
+        let mut depth = 0usize;
+        while index < end {
+            let byte = bytes[index];
+            if byte == b'\\' {
+                index += 2;
+            } else if byte.is_ascii_whitespace() || byte.is_ascii_control() {
+                break;
+            } else if byte == b'(' {
+                depth += 1;
+                index += 1;
+            } else if byte == b')' {
+                if depth == 0 {
+                    break;
+                }
+                depth -= 1;
+                index += 1;
+            } else {
+                index += 1;
+            }
+        }
+    }
+
+    let index = skip_whitespace(bytes, index, end);
+    if index < end && bytes[index] == b')' {
+        return Some(index + 1);
+    }
+
+    title_end(bytes, index, end)
+}
+
+/// Returns the offset just past the `)` that follows a link title
+fn title_end(bytes: &[u8], open: usize, end: usize) -> Option<usize> {
+    if open >= end {
+        return None;
+    }
+
+    let closer = match bytes[open] {
+        b'"' => b'"',
+        b'\'' => b'\'',
+        b'(' => b')',
+        _ => return None,
+    };
+
+    let mut index = open + 1;
+    loop {
+        if index >= end {
+            return None;
+        }
+        let byte = bytes[index];
+        if byte == b'\\' {
+            index += 2;
+        } else if byte == closer {
+            index += 1;
+            break;
+        } else {
+            index += 1;
+        }
+    }
+
+    let index = skip_whitespace(bytes, index, end);
+    match index < end && bytes[index] == b')' {
+        true => Some(index + 1),
+        false => None,
+    }
+}
+
+/// Returns the offset just past a code span
+///
+/// A backtick run that nothing of the same length closes is literal text in
+/// CommonMark, not the opening of a span. The result is then the offset just
+/// past those backticks, so one stray backtick cannot hide every link after
+/// it.
+fn skip_code_span(bytes: &[u8], open: usize, end: usize) -> usize {
+    let length = backtick_run(bytes, open, end);
+    let mut index = open + length;
+
+    while index < end {
+        if bytes[index] != b'`' {
+            index += 1;
+            continue;
+        }
+        let run = backtick_run(bytes, index, end);
+        if run == length {
+            return index + run;
+        }
+        index += run;
+    }
+
+    open + length
+}
+
+/// Counts the backticks that start at `open`
+fn backtick_run(bytes: &[u8], open: usize, end: usize) -> usize {
+    let mut index = open;
+    while index < end && bytes[index] == b'`' {
+        index += 1;
+    }
+    index - open
+}
+
+/// Returns the offset of the first byte that is not ASCII whitespace
+fn skip_whitespace(bytes: &[u8], open: usize, end: usize) -> usize {
+    let mut index = open;
+    while index < end && bytes[index].is_ascii_whitespace() {
+        index += 1;
+    }
+    index
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn kinds(content: &str) -> Vec<LinkKind> {
+        InlineLink::find_all(content)
+            .into_iter()
+            .map(InlineLink::kind)
+            .collect()
+    }
+
+    fn texts(content: &str) -> Vec<&str> {
+        InlineLink::find_all(content)
+            .into_iter()
+            .map(|link| &content[link.start()..link.end()])
+            .collect()
+    }
+
+    #[test]
+    fn find_all_with_angle_bracket_destination_matches() {
+        let content = "See [the docs](<https://example.com/a b>) now";
+
+        let found = texts(content);
+
+        assert_eq!(found, vec!["[the docs](<https://example.com/a b>)"]);
+    }
+
+    #[test]
+    fn find_all_with_autolink_finds_nothing() {
+        let content = "See <https://example.com/docs> for details";
+
+        let found = texts(content);
+
+        assert!(found.is_empty());
+    }
+
+    #[test]
+    fn find_all_with_backslash_escaped_bracket_finds_nothing() {
+        let content = "Literal \\[text\\](url) stays literal";
+
+        let found = texts(content);
+
+        assert!(found.is_empty());
+    }
+
+    #[test]
+    fn find_all_with_balanced_parens_in_destination_matches_whole_link() {
+        let content = "See [x](https://example.com/a_(b)_c) now";
+
+        let found = texts(content);
+
+        assert_eq!(found, vec!["[x](https://example.com/a_(b)_c)"]);
+    }
+
+    #[test]
+    fn find_all_with_bare_url_finds_nothing() {
+        let content = "See https://example.com/docs for details";
+
+        let found = texts(content);
+
+        assert!(found.is_empty());
+    }
+
+    #[test]
+    fn find_all_with_blank_line_between_bracket_and_paren_finds_nothing() {
+        let content = "See [foo]\n\n(a parenthetical)";
+
+        let found = texts(content);
+
+        assert!(found.is_empty());
+    }
+
+    #[test]
+    fn find_all_with_bracket_inside_code_span_finds_nothing() {
+        let content = "Write `[text](url)` to make a link";
+
+        let found = texts(content);
+
+        assert!(found.is_empty());
+    }
+
+    #[test]
+    fn find_all_with_code_span_in_link_text_matches() {
+        let content = "Uses [`HashMap`](std::collections::HashMap) internally";
+
+        let found = texts(content);
+
+        assert_eq!(found, vec!["[`HashMap`](std::collections::HashMap)"]);
+    }
+
+    #[test]
+    fn find_all_with_collapsed_reference_link_finds_nothing() {
+        let content = "See [the docs][] for details";
+
+        let found = texts(content);
+
+        assert!(found.is_empty());
+    }
+
+    #[test]
+    fn find_all_with_empty_destination_matches() {
+        let content = "See [the docs]() for details";
+
+        let found = texts(content);
+
+        assert_eq!(found, vec!["[the docs]()"]);
+    }
+
+    #[test]
+    fn find_all_with_empty_input_finds_nothing() {
+        let content = "";
+
+        let found = texts(content);
+
+        assert!(found.is_empty());
+    }
+
+    #[test]
+    fn find_all_with_fenced_block_after_prose_reads_the_prose() {
+        let content = "See [a](b) here\n\n```rust\nlet x = [c](d);\n```";
+
+        let found = texts(content);
+
+        assert_eq!(found, vec!["[a](b)"]);
+    }
+
+    #[test]
+    fn find_all_with_fenced_block_finds_nothing() {
+        let content = "# Examples\n\n```\nlet url = [text](https://example.com);\n```";
+
+        let found = texts(content);
+
+        assert!(found.is_empty());
+    }
+
+    #[test]
+    fn find_all_with_full_reference_link_finds_nothing() {
+        let content = "See [the docs][docs] for details";
+
+        let found = texts(content);
+
+        assert!(found.is_empty());
+    }
+
+    #[test]
+    fn find_all_with_image_link_reports_an_image() {
+        let content = "![diagram](https://example.com/diagram.png)";
+
+        let found = kinds(content);
+
+        assert_eq!(found, vec![LinkKind::Image]);
+    }
+
+    #[test]
+    fn find_all_with_indented_code_block_finds_nothing() {
+        let content = "Example:\n\n    let url = [text](https://example.com);\n";
+
+        let found = texts(content);
+
+        assert!(found.is_empty());
+    }
+
+    #[test]
+    fn find_all_with_inline_link_reports_a_text_link() {
+        let content = "See [the docs](https://example.com/docs) for details";
+
+        let found = kinds(content);
+
+        assert_eq!(found, vec![LinkKind::Text]);
+    }
+
+    #[test]
+    fn find_all_with_link_split_across_lines_matches() {
+        let content = "See [the\ndocs](https://example.com) for details";
+
+        let found = texts(content);
+
+        assert_eq!(found, vec!["[the\ndocs](https://example.com)"]);
+    }
+
+    #[test]
+    fn find_all_with_nested_brackets_matches_the_inner_link() {
+        let content = "Text [outer [inner](https://example.com)] tail";
+
+        let found = texts(content);
+
+        assert_eq!(found, vec!["[inner](https://example.com)"]);
+    }
+
+    #[test]
+    fn find_all_with_non_ascii_after_backslash_finds_the_link() {
+        let content = "Caf\\é [a](b) tail";
+
+        let found = texts(content);
+
+        assert_eq!(found, vec!["[a](b)"]);
+    }
+
+    #[test]
+    fn find_all_with_reference_definition_finds_nothing() {
+        let content = "See [the docs]\n\n[the docs]: https://example.com/docs";
+
+        let found = texts(content);
+
+        assert!(found.is_empty());
+    }
+
+    #[test]
+    fn find_all_with_shortcut_reference_link_finds_nothing() {
+        let content = "Returns [`Option<T>`] if the value exists";
+
+        let found = texts(content);
+
+        assert!(found.is_empty());
+    }
+
+    #[test]
+    fn find_all_with_space_before_paren_finds_nothing() {
+        let content = "See [the docs] (https://example.com/docs)";
+
+        let found = texts(content);
+
+        assert!(found.is_empty());
+    }
+
+    #[test]
+    fn find_all_with_tilde_fence_finds_nothing() {
+        let content = "~~~\n[text](https://example.com)\n~~~";
+
+        let found = texts(content);
+
+        assert!(found.is_empty());
+    }
+
+    #[test]
+    fn find_all_with_titled_link_matches_whole_link() {
+        let content = "See [x](https://example.com \"a title\") now";
+
+        let found = texts(content);
+
+        assert_eq!(found, vec!["[x](https://example.com \"a title\")"]);
+    }
+
+    #[test]
+    fn find_all_with_two_links_on_one_line_matches_both() {
+        let content = "See [a](https://example.com/a) and [b](https://example.com/b)";
+
+        let found = texts(content);
+
+        assert_eq!(
+            found,
+            vec!["[a](https://example.com/a)", "[b](https://example.com/b)"]
+        );
+    }
+
+    #[test]
+    fn find_all_with_unclosed_bracket_finds_nothing() {
+        let content = "See [the docs for details";
+
+        let found = texts(content);
+
+        assert!(found.is_empty());
+    }
+
+    #[test]
+    fn find_all_with_unclosed_fence_skips_the_rest() {
+        let content = "Prose [a](b)\n\n```\n[c](d)\nstill code";
+
+        let found = texts(content);
+
+        assert_eq!(found, vec!["[a](b)"]);
+    }
+
+    #[test]
+    fn find_all_with_unmatched_backtick_finds_the_link() {
+        let content = "A stray ` tick then [a](https://example.com)";
+
+        let found = texts(content);
+
+        assert_eq!(found, vec!["[a](https://example.com)"]);
+    }
+
+    #[test]
+    fn find_all_with_word_after_destination_finds_nothing() {
+        let content = "The value [x](y z) is undefined";
+
+        let found = texts(content);
+
+        assert!(found.is_empty());
+    }
+
+    #[test]
+    fn trait_send() {
+        fn assert_send<T: Send>() {}
+        assert_send::<BlockState>();
+        assert_send::<Fill>();
+        assert_send::<InlineLink>();
+        assert_send::<Line<'_>>();
+        assert_send::<LineRole>();
+        assert_send::<ProseRange>();
+    }
+
+    #[test]
+    fn trait_sync() {
+        fn assert_sync<T: Sync>() {}
+        assert_sync::<BlockState>();
+        assert_sync::<Fill>();
+        assert_sync::<InlineLink>();
+        assert_sync::<Line<'_>>();
+        assert_sync::<LineRole>();
+        assert_sync::<ProseRange>();
+    }
+
+    #[test]
+    fn trait_unpin() {
+        fn assert_unpin<T: Unpin>() {}
+        assert_unpin::<BlockState>();
+        assert_unpin::<Fill>();
+        assert_unpin::<InlineLink>();
+        assert_unpin::<Line<'_>>();
+        assert_unpin::<LineRole>();
+        assert_unpin::<ProseRange>();
+    }
+}

--- a/lints/reference_style_links/src/inline_link/link_kind.rs
+++ b/lints/reference_style_links/src/inline_link/link_kind.rs
@@ -1,0 +1,61 @@
+/// The two inline link forms Markdown allows
+///
+/// The rule keeps them apart so the advice names the form the author wrote.
+#[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug)]
+pub(crate) enum LinkKind {
+    /// An image link, written `![alt](url)`
+    Image,
+    /// A text link, written `[text](url)`
+    Text,
+}
+
+impl LinkKind {
+    /// Returns the diagnostic message for this form
+    pub(crate) fn message(self) -> &'static str {
+        match self {
+            LinkKind::Image => "replace this inline image link with a reference-style image link",
+            LinkKind::Text => "replace this inline link with a reference-style link",
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn message_for_image_names_an_image_link() {
+        let kind = LinkKind::Image;
+
+        let message = kind.message();
+
+        assert!(message.contains("inline image link"));
+    }
+
+    #[test]
+    fn message_for_text_names_a_link() {
+        let kind = LinkKind::Text;
+
+        let message = kind.message();
+
+        assert!(message.contains("inline link"));
+    }
+
+    #[test]
+    fn trait_send() {
+        fn assert_send<T: Send>() {}
+        assert_send::<LinkKind>();
+    }
+
+    #[test]
+    fn trait_sync() {
+        fn assert_sync<T: Sync>() {}
+        assert_sync::<LinkKind>();
+    }
+
+    #[test]
+    fn trait_unpin() {
+        fn assert_unpin<T: Unpin>() {}
+        assert_unpin::<LinkKind>();
+    }
+}

--- a/lints/reference_style_links/src/lib.rs
+++ b/lints/reference_style_links/src/lib.rs
@@ -1,0 +1,374 @@
+mod doc_block;
+mod inline_link;
+
+use std::slice;
+
+use whisker_rust::RustLintPass;
+use whisker_types::{DecoratedNode, Diagnostic, RuleId, Severity};
+
+use self::doc_block::DocBlock;
+use self::inline_link::InlineLink;
+
+const RULE_ID: RuleId = RuleId::new("lint.reference-style-links");
+
+/// Flags inline Markdown links in doc comments
+///
+/// An inline link buries the URL in the prose and repeats it at every
+/// mention. A reference-style link keeps the sentence readable and gives
+/// the target one definition.
+///
+/// The rule reads the link syntax only. It leaves `[text]`, `[text][]`, and
+/// `[text][label]` alone, because those are the forms it asks for. Rustdoc
+/// resolves most bracketed paths on its own, so a doc comment that uses one
+/// needs no definition at the bottom.
+///
+/// A backticked identifier in running prose is out of scope. Nothing in the
+/// syntax says whether the name is a type, a field, a crate, or a CLI flag,
+/// so a rule that demanded brackets around it would be guessing.
+pub struct ReferenceStyleLinks;
+
+impl RustLintPass for ReferenceStyleLinks {
+    fn check_block_comment(&mut self, node: &DecoratedNode<'_>) -> Vec<Diagnostic> {
+        check(slice::from_ref(node))
+    }
+
+    fn check_line_comment(&mut self, node: &DecoratedNode<'_>) -> Vec<Diagnostic> {
+        let Some(group) = doc_comment_group(node) else {
+            return Vec::new();
+        };
+
+        check(&group)
+    }
+}
+
+/// Which marker introduces a doc comment
+///
+/// A `///` run and a `//!` run never form one document, so the rule must
+/// not join them.
+#[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug)]
+enum DocMarker {
+    /// The `//!` marker
+    Inner,
+    /// The `///` marker
+    Outer,
+}
+
+impl DocMarker {
+    /// Returns the marker of a doc comment line, if the node is one
+    fn of(node: &DecoratedNode<'_>) -> Option<Self> {
+        if node.kind() != "line_comment" {
+            return None;
+        }
+        node.child_by_field_name("doc")?;
+
+        match node.child_by_field_name("inner") {
+            Some(_) => Some(DocMarker::Inner),
+            None => node.child_by_field_name("outer").map(|_| DocMarker::Outer),
+        }
+    }
+}
+
+/// Reports every inline link in one doc comment
+fn check(comments: &[DecoratedNode<'_>]) -> Vec<Diagnostic> {
+    let Some(block) = DocBlock::from_comments(comments) else {
+        return Vec::new();
+    };
+
+    InlineLink::find_all(block.content())
+        .into_iter()
+        .map(|link| {
+            Diagnostic::new(
+                RULE_ID,
+                Severity::Warn,
+                link.kind().message().into(),
+                block.span(link.start(), link.end()),
+            )
+        })
+        .collect()
+}
+
+/// Returns the run of doc comment lines that `node` starts
+///
+/// Returns [`None`] when `node` is not a doc comment, or when the line
+/// above it belongs to the same run. The walker visits every line of a run,
+/// so only the first line may report; otherwise one link would produce a
+/// diagnostic on every line of its doc comment.
+///
+/// [`None`]: std::option::Option::None
+fn doc_comment_group<'a>(node: &DecoratedNode<'a>) -> Option<Vec<DecoratedNode<'a>>> {
+    DocMarker::of(node)?;
+
+    let parent = node.parent()?;
+    let siblings = parent.named_children();
+    let index = siblings
+        .iter()
+        .position(|sibling| sibling.id() == node.id())?;
+
+    if index > 0 && continues(&siblings[index - 1], node) {
+        return None;
+    }
+
+    let mut group = vec![node.clone()];
+    for candidate in siblings.iter().skip(index + 1) {
+        if !continues(
+            group.last().expect("the run starts with one line"),
+            candidate,
+        ) {
+            break;
+        }
+        group.push(candidate.clone());
+    }
+
+    Some(group)
+}
+
+/// Returns whether `candidate` carries on the doc comment `previous` started
+///
+/// The two lines must use the same marker and sit on adjacent rows. A blank
+/// source line and an ordinary comment both end a run. Rustdoc joins those
+/// runs back together, so a code fence that spans the gap escapes the rule.
+///
+/// The comparison uses the start rows. A `line_comment` node covers the
+/// newline that ends it, so its end row is already the row below.
+fn continues(previous: &DecoratedNode<'_>, candidate: &DecoratedNode<'_>) -> bool {
+    let Some(previous_marker) = DocMarker::of(previous) else {
+        return false;
+    };
+    let Some(candidate_marker) = DocMarker::of(candidate) else {
+        return false;
+    };
+    if previous_marker != candidate_marker {
+        return false;
+    }
+
+    previous.raw().start_position().row + 1 == candidate.raw().start_position().row
+}
+
+#[cfg(feature = "plugin")]
+whisker_rust::export_lints![ReferenceStyleLinks];
+
+#[cfg(test)]
+mod tests {
+    use whisker_rust::RustLintPassAdapter;
+    use whisker_testing::{assert_diagnostic, assert_no_diagnostics, execute, parse};
+    use whisker_types::{Language, LintPass};
+
+    use super::*;
+
+    fn passes() -> Vec<Box<dyn LintPass>> {
+        vec![Box::new(RustLintPassAdapter::new(ReferenceStyleLinks))]
+    }
+
+    fn run(source: &str) -> Vec<Diagnostic> {
+        let tree = parse(source, Language::Rust);
+
+        execute(&tree, &mut passes())
+    }
+
+    #[test]
+    fn attribute_doc_is_not_flagged() {
+        let source = "#[doc = \"See [a](https://example.com)\"]\nfn f() {}";
+
+        let diagnostics = run(source);
+
+        assert_no_diagnostics(&diagnostics);
+    }
+
+    #[test]
+    fn block_doc_comment_with_inline_link_is_flagged() {
+        let source = "/** See [a](https://example.com) now */\nfn f() {}";
+
+        let diagnostics = run(source);
+
+        assert_eq!(diagnostics.len(), 1);
+    }
+
+    #[test]
+    fn field_doc_comment_with_inline_link_is_flagged_once() {
+        let source =
+            "struct S {\n    /// See\n    /// [a](https://example.com)\n    field: u32,\n}";
+
+        let diagnostics = run(source);
+
+        assert_eq!(diagnostics.len(), 1);
+    }
+
+    #[test]
+    fn image_link_is_flagged_as_an_image() {
+        let source = "/// ![diagram](https://example.com/d.png)\nfn f() {}";
+
+        let diagnostics = run(source);
+
+        assert_eq!(diagnostics.len(), 1);
+        assert_diagnostic(&diagnostics[0])
+            .has_rule_id("lint.reference-style-links")
+            .has_severity(Severity::Warn)
+            .message_contains("image");
+    }
+
+    #[test]
+    fn inline_intra_doc_link_is_flagged() {
+        let source = "/// Uses [`HashMap`](std::collections::HashMap) internally\nfn f() {}";
+
+        let diagnostics = run(source);
+
+        assert_eq!(diagnostics.len(), 1);
+    }
+
+    #[test]
+    fn inline_link_in_doc_comment_is_flagged() {
+        let source = "/// See [the docs](https://example.com/docs) for details\nfn f() {}";
+
+        let diagnostics = run(source);
+
+        assert_eq!(diagnostics.len(), 1);
+        assert_diagnostic(&diagnostics[0])
+            .has_rule_id("lint.reference-style-links")
+            .has_severity(Severity::Warn)
+            .message_contains("reference-style link");
+    }
+
+    #[test]
+    fn inline_link_in_plain_block_comment_is_not_flagged() {
+        let source = "/* See [a](https://example.com) */\nfn f() {}";
+
+        let diagnostics = run(source);
+
+        assert_no_diagnostics(&diagnostics);
+    }
+
+    #[test]
+    fn inline_link_in_plain_comment_is_not_flagged() {
+        let source = "// See [a](https://example.com)\nfn f() {}";
+
+        let diagnostics = run(source);
+
+        assert_no_diagnostics(&diagnostics);
+    }
+
+    #[test]
+    fn inline_link_reports_the_span_of_the_link() {
+        let source = "/// See [a](https://example.com) now\nfn f() {}";
+
+        let diagnostics = run(source);
+
+        assert_eq!(diagnostics.len(), 1);
+        let span = diagnostics[0].span();
+        assert_eq!(
+            &source[span.start()..span.end()],
+            "[a](https://example.com)"
+        );
+    }
+
+    #[test]
+    fn inner_and_outer_doc_comments_are_separate_blocks() {
+        let source = "//! ```\n/// [a](https://example.com)\nfn f() {}";
+
+        let diagnostics = run(source);
+
+        assert_eq!(diagnostics.len(), 1);
+    }
+
+    #[test]
+    fn inner_doc_comment_with_inline_link_is_flagged() {
+        let source = "//! See [a](https://example.com)\nfn f() {}";
+
+        let diagnostics = run(source);
+
+        assert_eq!(diagnostics.len(), 1);
+    }
+
+    #[test]
+    fn link_across_two_doc_comment_lines_is_flagged_once() {
+        let source = "/// See [the\n/// docs](https://example.com) now\nfn f() {}";
+
+        let diagnostics = run(source);
+
+        assert_eq!(diagnostics.len(), 1);
+    }
+
+    #[test]
+    fn link_in_code_span_is_not_flagged() {
+        let source = "/// Write `[text](url)` for a link\nfn f() {}";
+
+        let diagnostics = run(source);
+
+        assert_no_diagnostics(&diagnostics);
+    }
+
+    #[test]
+    fn link_in_fenced_example_is_not_flagged() {
+        let source = "/// # Examples\n///\n/// ```\n/// let a = \"[x](https://example.com)\";\n/// ```\nfn f() {}";
+
+        let diagnostics = run(source);
+
+        assert_no_diagnostics(&diagnostics);
+    }
+
+    #[test]
+    fn plain_comment_between_doc_lines_splits_the_blocks() {
+        let source = "/// ```\n// break\n/// [a](https://example.com)\nfn f() {}";
+
+        let diagnostics = run(source);
+
+        assert_eq!(diagnostics.len(), 1);
+    }
+
+    #[test]
+    fn reference_definition_is_not_flagged() {
+        let source = "/// See [the docs]\n///\n/// [the docs]: https://example.com/docs\nfn f() {}";
+
+        let diagnostics = run(source);
+
+        assert_no_diagnostics(&diagnostics);
+    }
+
+    #[test]
+    fn shortcut_reference_link_is_not_flagged() {
+        let source = "/// Returns [`Option<T>`] if the value exists\n///\n/// [`Option<T>`]: std::option::Option\nfn f() {}";
+
+        let diagnostics = run(source);
+
+        assert_no_diagnostics(&diagnostics);
+    }
+
+    #[test]
+    fn trait_send() {
+        fn assert_send<T: Send>() {}
+        assert_send::<DocMarker>();
+        assert_send::<ReferenceStyleLinks>();
+    }
+
+    #[test]
+    fn trait_sync() {
+        fn assert_sync<T: Sync>() {}
+        assert_sync::<DocMarker>();
+        assert_sync::<ReferenceStyleLinks>();
+    }
+
+    #[test]
+    fn trait_unpin() {
+        fn assert_unpin<T: Unpin>() {}
+        assert_unpin::<DocMarker>();
+        assert_unpin::<ReferenceStyleLinks>();
+    }
+
+    #[test]
+    fn two_doc_comments_each_report_their_link() {
+        let source = "/// [a](https://example.com/a)\nfn f() {}\n\n/// [b](https://example.com/b)\nfn g() {}";
+
+        let diagnostics = run(source);
+
+        assert_eq!(diagnostics.len(), 2);
+    }
+
+    #[test]
+    fn two_links_in_one_doc_comment_report_twice() {
+        let source =
+            "/// See [a](https://example.com/a)\n/// and [b](https://example.com/b)\nfn f() {}";
+
+        let diagnostics = run(source);
+
+        assert_eq!(diagnostics.len(), 2);
+    }
+}


### PR DESCRIPTION
Closes #16.

## What the rule should actually require

The issue has two halves and I implemented one, deliberately.

**Bare `` `Type` `` in prose is undetectable.** Nothing in a doc comment says whether a backticked identifier is a type, a field, a crate, a CLI flag, or a string literal. A lint for it would be noise. The rule's own doc comment states that limit, so it sits with the code and not only here.

**`[`Type`]` without an explicit definition is correct, not a violation.** Rustdoc resolves most bracketed paths itself, `cargo doc -D warnings` passes clean on `whisker-types`, and CLAUDE.md's own prose uses the bare form. An earlier agent's judgement subagent demanded a definition for every one; that was wrong, and this settles it.

So the lint targets the **inline link form** — `[text](destination)` and `![alt](destination)` — which is objectively detectable and is what "reference-style links" actually means. Shortcut, collapsed, and full reference links never fire; whether a definition exists is rustdoc's business, and `cargo doc` already errors on broken intra-doc links.

Silent inside fenced and indented code blocks, code spans, behind backslash escapes, on reference definitions, autolinks, bare URLs, and ordinary `//` comments. Links spanning two comment lines are found and reported once.

## Zero findings, and that is a true negative

The only two `](` occurrences in doc comments repo-wide are in this crate's own `link_kind.rs`, both inside code spans, correctly ignored. I proved the lint fires end to end through the real CLI with a temporary fixture — it flagged an inline link and an image link, ignored a URL inside a fenced `# Examples` block and a `[`HashMap`]` shortcut reference, with spans on the links. Fixture removed.

## One real bug, found by dumping the tree

`line_comment` nodes in tree-sitter-rust **include their trailing newline**, and so does the `doc_comment` field. The first row-adjacency test therefore never matched, so every comment line became its own document and fence tracking was dead.

69 tests. Running whisker's own lints against this code caught three `bool` parameters in the scanner helpers; they became a `Fill` enum and a `Line` struct rather than suppressions.

Two known blind spots: `#[doc = "..."]` attributes, and a doc run split by a blank line, which rustdoc rejoins and this treats as separate documents.
