### PR TITLE
Flag public struct fields and point at getset

### DIFF
--- a/.config/whisker.toml
+++ b/.config/whisker.toml
@@ -41,6 +41,9 @@ path = "lints/no_matches_macro"
 path = "lints/no_todo_comments"
 
 [[lints]]
+path = "lints/pub_field"
+
+[[lints]]
 path = "lints/reference_style_links"
 
 [[lints]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [workspace]
 members = ["crates/*"]
-exclude = ["examples/*", "lints/anyhow_missing_context", "lints/bool_param", "lints/derive_order", "lints/explicit_destructuring", "lints/if_let_with_else", "lints/missing_examples_doc", "lints/missing_trait_tests", "lints/no_commented_out_code", "lints/no_inline_comments", "lints/no_matches_macro", "lints/no_todo_comments", "lints/reference_style_links", "lints/repeated_primitive_params", "lints/shadow_transformations", "lints/wildcard_match_arm"]
+exclude = ["examples/*", "lints/anyhow_missing_context", "lints/bool_param", "lints/derive_order", "lints/explicit_destructuring", "lints/if_let_with_else", "lints/missing_examples_doc", "lints/missing_trait_tests", "lints/no_commented_out_code", "lints/no_inline_comments", "lints/no_matches_macro", "lints/no_todo_comments", "lints/pub_field", "lints/reference_style_links", "lints/repeated_primitive_params", "lints/shadow_transformations", "lints/wildcard_match_arm"]
 
 # Opt-in to the new feature resolver introduced in Rust 1.85 and Edition 2024.
 # https://doc.rust-lang.org/cargo/reference/resolver.html#resolver-versions

--- a/lints/pub_field/Cargo.toml
+++ b/lints/pub_field/Cargo.toml
@@ -1,0 +1,36 @@
+# A lint is its own cargo package, built as a cdylib and loaded by whisker at
+# check time. It is not a workspace member: the handshake compares the whisker
+# it was compiled against with the whisker loading it, and a package outside
+# the workspace resolves its own dependencies, which is what a lint written
+# outside this repository does too. The lockfile beside this manifest pins
+# that resolution.
+[package]
+name = "pub_field"
+version = "0.1.0"
+edition = "2024"
+license = "Apache-2.0 OR MIT"
+publish = false
+
+[lib]
+crate-type = ["cdylib", "rlib"]
+
+# The provider feature stays off: a lint needs the generated trait and the
+# decoration types, not the rust-analyzer stack that produces decorations.
+# The exported declaration is a `no_mangle` static, so two rules linked into
+# one binary would collide. The cdylib whisker loads keeps it; a rule used as
+# an ordinary rlib dependency, as whisker-rust's provider tests do, turns it
+# off.
+[features]
+default = ["plugin"]
+plugin = []
+
+[dependencies]
+whisker-rust = { path = "../../crates/whisker-rust", default-features = false }
+whisker-types = { path = "../../crates/whisker-types" }
+
+[dev-dependencies]
+whisker-testing = { path = "../../crates/whisker-testing" }
+
+[lints.clippy]
+missing_errors_doc = "warn"
+missing_panics_doc = "warn"

--- a/lints/pub_field/src/lib.rs
+++ b/lints/pub_field/src/lib.rs
@@ -1,0 +1,342 @@
+use whisker_rust::{RustLintPass, RustLintPassAdapter};
+use whisker_types::{DecoratedNode, Diagnostic, LintPass, RuleId, Severity};
+
+const RULE_ID: RuleId = RuleId::new("lint.pub-field");
+
+/// Flags `pub` fields on struct definitions
+///
+/// A public field lets a caller read and write state the type owns. The
+/// house convention is a private field with an accessor, so the type keeps
+/// control of its own invariants.
+///
+/// Restricted forms such as `pub(crate)` narrow the exposure on purpose, so
+/// the rule leaves them alone. Enums and unions are out of scope.
+pub struct PubField;
+
+impl PubField {
+    /// Creates a boxed [`LintPass`] suitable for the whisker pipeline
+    ///
+    /// # Examples
+    ///
+    /// ```ignore
+    /// let pass = PubField::into_lint_pass();
+    /// ```
+    pub fn into_lint_pass() -> Box<dyn LintPass> {
+        Box::new(RustLintPassAdapter::new(Self))
+    }
+}
+
+/// Returns whether the given node is a bare `pub` visibility modifier
+///
+/// A restricted form such as `pub(crate)` holds its scope as a named child,
+/// so a bare `pub` is the one with no named children.
+fn is_bare_pub(node: &DecoratedNode<'_>) -> bool {
+    node.kind() == "visibility_modifier" && node.named_child_count() == 0
+}
+
+/// Returns a diagnostic for every public field of a named-field struct
+fn named_field_diagnostics(body: &DecoratedNode<'_>) -> Vec<Diagnostic> {
+    let mut diagnostics = Vec::new();
+
+    for field in body.named_children() {
+        if field.kind() != "field_declaration" {
+            continue;
+        }
+        let Some(visibility) = field.named_children().into_iter().find(is_bare_pub) else {
+            continue;
+        };
+        let Some(name) = field.child_by_field_name("name") else {
+            continue;
+        };
+
+        diagnostics.push(Diagnostic::new(
+            RULE_ID,
+            Severity::Warn,
+            format!(
+                "field `{}` is public; make it private and derive a getter with `getset`",
+                name.text()
+            ),
+            visibility.span(),
+        ));
+    }
+
+    diagnostics
+}
+
+/// Returns a diagnostic for every public field of a tuple struct
+///
+/// The body holds no per-field node. Each `visibility_modifier` is a flat
+/// sibling of the type it qualifies. The loop counts the commas before each
+/// modifier to recover the field index. A comma that belongs to a type sits
+/// inside that type and never reaches the loop.
+fn ordered_field_diagnostics(body: &DecoratedNode<'_>) -> Vec<Diagnostic> {
+    let mut diagnostics = Vec::new();
+    let mut index = 0usize;
+
+    for position in 0..body.child_count() as u32 {
+        let Some(child) = body.child(position) else {
+            continue;
+        };
+
+        if child.kind() == "," {
+            index += 1;
+            continue;
+        }
+        if !is_bare_pub(&child) {
+            continue;
+        }
+
+        diagnostics.push(Diagnostic::new(
+            RULE_ID,
+            Severity::Warn,
+            format!("field {index} is public; make it private and add an accessor method"),
+            child.span(),
+        ));
+    }
+
+    diagnostics
+}
+
+impl RustLintPass for PubField {
+    fn check_struct_item(&mut self, node: &DecoratedNode<'_>) -> Vec<Diagnostic> {
+        let Some(body) = node.child_by_field_name("body") else {
+            return Vec::new();
+        };
+
+        match body.kind() {
+            "field_declaration_list" => named_field_diagnostics(&body),
+            "ordered_field_declaration_list" => ordered_field_diagnostics(&body),
+            _ => Vec::new(),
+        }
+    }
+}
+
+#[cfg(feature = "plugin")]
+whisker_rust::export_lints![PubField];
+
+#[cfg(test)]
+mod tests {
+    use whisker_testing::{assert_diagnostic, assert_no_diagnostics, execute, parse};
+    use whisker_types::{Language, LintPass, Severity};
+
+    use super::*;
+
+    fn adapt() -> Box<dyn LintPass> {
+        PubField::into_lint_pass()
+    }
+
+    fn run(source: &str) -> Vec<Diagnostic> {
+        let tree = parse(source, Language::Rust);
+        let mut passes = vec![adapt()];
+        execute(&tree, &mut passes)
+    }
+
+    #[test]
+    fn enum_variant_fields_not_flagged() {
+        let diagnostics = run("pub enum Gap { Outside { pub root: u32 }, Unreachable(pub u32) }");
+
+        assert_no_diagnostics(&diagnostics);
+    }
+
+    #[test]
+    fn named_field_diagnostic_spans_the_visibility_modifier() {
+        let diagnostics = run("struct Config { pub verbose: u32 }");
+
+        assert_eq!(diagnostics.len(), 1);
+        assert_diagnostic(&diagnostics[0]).has_span("<test>", 16, 19);
+    }
+
+    #[test]
+    fn named_pub_field_flagged() {
+        let diagnostics = run("struct Config { pub verbose: u32 }");
+
+        assert_eq!(diagnostics.len(), 1);
+        assert_diagnostic(&diagnostics[0])
+            .has_rule_id("lint.pub-field")
+            .has_severity(Severity::Warn)
+            .message_contains("field `verbose` is public")
+            .message_contains("getset");
+    }
+
+    #[test]
+    fn named_pub_fields_each_flagged() {
+        let diagnostics = run("struct Config { pub a: u32, b: u32, pub c: u32 }");
+
+        assert_eq!(diagnostics.len(), 2);
+        assert_diagnostic(&diagnostics[0]).message_contains("field `a` is public");
+        assert_diagnostic(&diagnostics[1]).message_contains("field `c` is public");
+    }
+
+    #[test]
+    fn nested_struct_in_function_flagged() {
+        let diagnostics = run("fn main() { struct Inner { pub a: u32 } }");
+
+        assert_eq!(diagnostics.len(), 1);
+        assert_diagnostic(&diagnostics[0]).message_contains("field `a` is public");
+    }
+
+    #[test]
+    fn newtype_diagnostic_spans_the_visibility_modifier() {
+        let diagnostics = run("pub struct ProviderName(pub &'static str);");
+
+        assert_eq!(diagnostics.len(), 1);
+        assert_diagnostic(&diagnostics[0]).has_span("<test>", 24, 27);
+    }
+
+    #[test]
+    fn newtype_pub_field_flagged() {
+        let diagnostics = run("pub struct ProviderName(pub &'static str);");
+
+        assert_eq!(diagnostics.len(), 1);
+        assert_diagnostic(&diagnostics[0])
+            .has_rule_id("lint.pub-field")
+            .has_severity(Severity::Warn)
+            .message_contains("field 0 is public")
+            .message_contains("accessor method");
+    }
+
+    #[test]
+    fn private_named_field_not_flagged() {
+        let diagnostics = run("pub struct Config { verbose: u32 }");
+
+        assert_no_diagnostics(&diagnostics);
+    }
+
+    #[test]
+    fn private_tuple_field_not_flagged() {
+        let diagnostics = run("pub struct RuleId(&'static str);");
+
+        assert_no_diagnostics(&diagnostics);
+    }
+
+    #[test]
+    fn pub_crate_named_field_not_flagged() {
+        let diagnostics = run("struct Config { pub(crate) verbose: u32 }");
+
+        assert_no_diagnostics(&diagnostics);
+    }
+
+    #[test]
+    fn pub_crate_tuple_field_not_flagged() {
+        let diagnostics = run("struct RuleId(pub(crate) &'static str);");
+
+        assert_no_diagnostics(&diagnostics);
+    }
+
+    #[test]
+    fn pub_function_not_flagged() {
+        let diagnostics = run("pub fn foo(x: u32) -> u32 { x }");
+
+        assert_no_diagnostics(&diagnostics);
+    }
+
+    #[test]
+    fn pub_in_path_tuple_field_not_flagged() {
+        let diagnostics = run("struct RuleId(pub(in crate::rules) u32);");
+
+        assert_no_diagnostics(&diagnostics);
+    }
+
+    #[test]
+    fn pub_super_named_field_not_flagged() {
+        let diagnostics = run("struct Config { pub(super) verbose: u32 }");
+
+        assert_no_diagnostics(&diagnostics);
+    }
+
+    #[test]
+    fn spaced_pub_crate_tuple_field_not_flagged() {
+        let diagnostics = run("struct RuleId(pub (crate) u32);");
+
+        assert_no_diagnostics(&diagnostics);
+    }
+
+    #[test]
+    fn trait_send() {
+        fn assert_send<T: Send>() {}
+        assert_send::<PubField>();
+    }
+
+    #[test]
+    fn trait_sync() {
+        fn assert_sync<T: Sync>() {}
+        assert_sync::<PubField>();
+    }
+
+    #[test]
+    fn trait_unpin() {
+        fn assert_unpin<T: Unpin>() {}
+        assert_unpin::<PubField>();
+    }
+
+    #[test]
+    fn tuple_field_after_attribute_flagged() {
+        let diagnostics = run("struct D(#[serde(default)] pub Vec<u32>,);");
+
+        assert_eq!(diagnostics.len(), 1);
+        assert_diagnostic(&diagnostics[0]).message_contains("field 0 is public");
+    }
+
+    #[test]
+    fn tuple_field_after_comment_flagged() {
+        let diagnostics = run("struct A(\n    /// the count\n    pub u32,\n    u8,\n);");
+
+        assert_eq!(diagnostics.len(), 1);
+        assert_diagnostic(&diagnostics[0]).message_contains("field 0 is public");
+    }
+
+    #[test]
+    fn tuple_field_with_comma_inside_type_indexed_correctly() {
+        let diagnostics = run("struct A(u32, pub Vec<(u8, u8)>, pub fn(u8, u8));");
+
+        assert_eq!(diagnostics.len(), 2);
+        assert_diagnostic(&diagnostics[0]).message_contains("field 1 is public");
+        assert_diagnostic(&diagnostics[1]).message_contains("field 2 is public");
+    }
+
+    #[test]
+    fn tuple_field_with_where_clause_flagged() {
+        let diagnostics = run("pub struct Wrap<T>(pub T) where T: Copy;");
+
+        assert_eq!(diagnostics.len(), 1);
+        assert_diagnostic(&diagnostics[0]).message_contains("field 0 is public");
+    }
+
+    #[test]
+    fn tuple_pub_field_before_restricted_field_flagged_once() {
+        let diagnostics = run("struct B(pub u32, String, pub(crate) i8);");
+
+        assert_eq!(diagnostics.len(), 1);
+        assert_diagnostic(&diagnostics[0]).message_contains("field 0 is public");
+    }
+
+    #[test]
+    fn tuple_pub_fields_report_their_own_index() {
+        let diagnostics = run("struct B(u32, pub String, pub u8);");
+
+        assert_eq!(diagnostics.len(), 2);
+        assert_diagnostic(&diagnostics[0]).message_contains("field 1 is public");
+        assert_diagnostic(&diagnostics[1]).message_contains("field 2 is public");
+    }
+
+    #[test]
+    fn tuple_struct_with_private_fields_not_flagged() {
+        let diagnostics = run("pub struct Span(usize, usize);");
+
+        assert_no_diagnostics(&diagnostics);
+    }
+
+    #[test]
+    fn union_pub_field_not_flagged() {
+        let diagnostics = run("pub union Raw { pub bits: u32 }");
+
+        assert_no_diagnostics(&diagnostics);
+    }
+
+    #[test]
+    fn unit_struct_not_flagged() {
+        let diagnostics = run("pub struct Marker;");
+
+        assert_no_diagnostics(&diagnostics);
+    }
+}


### PR DESCRIPTION
Closes #232.

Flags bare `pub` fields on structs, in both shapes. Named fields get one diagnostic each pointing at `getset`; tuple fields are named by index and point at a plain accessor, since `getset` cannot derive on unnamed fields. The span is the `visibility_modifier` itself — the token to delete.

## The tuple-struct matcher

`bool_param`'s shape does not transfer, as the issue noted. A tuple body has no per-field node; `visibility_modifier` and the type are flat siblings.

The first draft had a bug and was thrown away: it treated "any named child that is not an attribute or visibility modifier" as a type, so a doc comment above `pub u32` counted as field 0 and misreported the real field as field 1.

The shipped version **counts commas among the body's direct children**. Commas are anonymous tokens reachable through `child()`, and a comma inside `Vec<(u8, u8)>` or `fn(u8, u8)` is a descendant of that node rather than a sibling. No kind whitelist needed, and comments and attributes become irrelevant by construction.

Bare `pub` is detected structurally as a `visibility_modifier` with no named children, since every restricted form carries its scope as one. Text comparison would have missed `pub (crate)` with a space.

## The two scope questions from the issue

**Enum variant fields — out of scope.** Rust rejects a visibility qualifier there (E0449), callers reach `CoverageGap::OutsideRoot { root }` by pattern matching where a getter cannot help, and `getset` does not derive on enums. The rule implements `check_struct_item` only, so enum bodies are never routed to it.

The judge caught that the test pinning this was **vacuous** — it used legal source containing no `pub` at all, so it passed regardless. It now uses source rustc rejects but tree-sitter parses cleanly, verified free of ERROR nodes. Move the logic to `check_field_declaration` and it fails.

**`RuleId` and `ProviderName` — flagged, and I think the const-position objection in the issue is wrong.** `const fn new` works fine in const position: `const RULE_ID: RuleId = RuleId::new("lint.bool-param")`. Both types already have `as_str`, so the fix is a private field plus a `const fn new` and a mechanical call-site rename, once. I did not make that change.

`pub(crate)` and friends do not fire — a deliberate narrowing that CLAUDE.md asks for at module boundaries. Moot for now; the repo has none.

## Dogfood: two hits, both the motivating case

`ProviderName` and `RuleId`, both tuple structs in `whisker-types`. Named-field structs: zero. `lints/`: zero. Cross-checked by grep, and I confirmed the walker reaches `lints/` with a throwaway probe rather than trusting empty output.

Ready by default and enabled. 27 tests.