### PR TITLE
Flag doc sentences over twenty-five words

### DIFF
--- a/.config/whisker.toml
+++ b/.config/whisker.toml
@@ -23,6 +23,9 @@ path = "lints/explicit_destructuring"
 path = "lints/if_let_with_else"
 
 [[lints]]
+path = "lints/long_doc_sentence"
+
+[[lints]]
 path = "lints/missing_examples_doc"
 
 [[lints]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [workspace]
 members = ["crates/*"]
-exclude = ["examples/*", "lints/anyhow_missing_context", "lints/bool_param", "lints/derive_order", "lints/explicit_destructuring", "lints/if_let_with_else", "lints/missing_examples_doc", "lints/missing_trait_tests", "lints/no_commented_out_code", "lints/no_inline_comments", "lints/no_matches_macro", "lints/no_todo_comments", "lints/pub_field", "lints/reference_style_links", "lints/repeated_primitive_params", "lints/shadow_transformations", "lints/wildcard_match_arm"]
+exclude = ["examples/*", "lints/anyhow_missing_context", "lints/bool_param", "lints/derive_order", "lints/explicit_destructuring", "lints/if_let_with_else", "lints/long_doc_sentence", "lints/missing_examples_doc", "lints/missing_trait_tests", "lints/no_commented_out_code", "lints/no_inline_comments", "lints/no_matches_macro", "lints/no_todo_comments", "lints/pub_field", "lints/reference_style_links", "lints/repeated_primitive_params", "lints/shadow_transformations", "lints/wildcard_match_arm"]
 
 # Opt-in to the new feature resolver introduced in Rust 1.85 and Edition 2024.
 # https://doc.rust-lang.org/cargo/reference/resolver.html#resolver-versions

--- a/lints/long_doc_sentence/Cargo.toml
+++ b/lints/long_doc_sentence/Cargo.toml
@@ -1,0 +1,40 @@
+# A lint is its own cargo package, built as a cdylib and loaded by whisker at
+# check time. It is not a workspace member: the handshake compares the whisker
+# it was compiled against with the whisker loading it, and a package outside
+# the workspace resolves its own dependencies, which is what a lint written
+# outside this repository does too. The lockfile beside this manifest pins
+# that resolution.
+[package]
+name = "long_doc_sentence"
+version = "0.1.0"
+edition = "2024"
+license = "Apache-2.0 OR MIT"
+publish = false
+
+[lib]
+crate-type = ["cdylib", "rlib"]
+
+# The provider feature stays off: a lint needs the generated trait and the
+# decoration types, not the rust-analyzer stack that produces decorations.
+# The exported declaration is a `no_mangle` static, so two rules linked into
+# one binary would collide. The cdylib whisker loads keeps it; a rule used as
+# an ordinary rlib dependency, as whisker-rust's provider tests do, turns it
+# off.
+[features]
+default = ["plugin"]
+plugin = []
+
+[dependencies]
+# `DecoratedNode::raw()` returns a `tree_sitter::Node`, which the rule names
+# directly. The version matches the workspace so the plugin and the host agree
+# on the type that crosses the boundary.
+tree-sitter = "0.26"
+whisker-rust = { path = "../../crates/whisker-rust", default-features = false }
+whisker-types = { path = "../../crates/whisker-types" }
+
+[dev-dependencies]
+whisker-testing = { path = "../../crates/whisker-testing" }
+
+[lints.clippy]
+missing_errors_doc = "warn"
+missing_panics_doc = "warn"

--- a/lints/long_doc_sentence/src/doc_line.rs
+++ b/lints/long_doc_sentence/src/doc_line.rs
@@ -1,0 +1,58 @@
+/// One line of doc comment text, with the marker gone
+///
+/// A sentence often runs across several lines, so the reassembled prose has
+/// offsets of its own. The file offset of each line lets a diagnostic point
+/// at the sentence rather than at the whole comment.
+#[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug)]
+pub(crate) struct DocLine<'a> {
+    text: &'a str,
+    offset: usize,
+}
+
+impl<'a> DocLine<'a> {
+    /// Creates a line holding `text`, which starts at `offset` in the file
+    pub(crate) fn new(text: &'a str, offset: usize) -> Self {
+        Self { text, offset }
+    }
+
+    /// Returns the text of the line
+    pub(crate) fn text(&self) -> &'a str {
+        self.text
+    }
+
+    /// Returns the byte offset of the line in the file
+    pub(crate) fn offset(&self) -> usize {
+        self.offset
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn accessors_return_constructor_arguments() {
+        let line = DocLine::new(" Returns the length", 7);
+
+        assert_eq!(line.text(), " Returns the length");
+        assert_eq!(line.offset(), 7);
+    }
+
+    #[test]
+    fn trait_send() {
+        fn assert_send<T: Send>() {}
+        assert_send::<DocLine<'_>>();
+    }
+
+    #[test]
+    fn trait_sync() {
+        fn assert_sync<T: Sync>() {}
+        assert_sync::<DocLine<'_>>();
+    }
+
+    #[test]
+    fn trait_unpin() {
+        fn assert_unpin<T: Unpin>() {}
+        assert_unpin::<DocLine<'_>>();
+    }
+}

--- a/lints/long_doc_sentence/src/lib.rs
+++ b/lints/long_doc_sentence/src/lib.rs
@@ -1,0 +1,391 @@
+mod doc_line;
+mod sentence;
+
+use std::sync::Arc;
+
+use whisker_rust::RustLintPass;
+use whisker_types::{DecoratedNode, Diagnostic, RuleId, Severity, Span};
+
+use crate::doc_line::DocLine;
+use crate::sentence::sentences;
+
+/// The most words one doc comment sentence may have
+const MAX_WORDS: usize = 25;
+
+/// Flags a doc comment sentence longer than 25 words
+///
+/// ASD-STE100 caps a descriptive sentence at 25 words, past which a reader
+/// has to hold too much at once.
+///
+/// The rule reads the comment text, never the item it documents. It skips
+/// what rustdoc does not render as prose: fenced code blocks, section
+/// headings, link definitions, and table rows.
+pub struct LongDocSentence;
+
+impl RustLintPass for LongDocSentence {
+    fn check_block_comment(&mut self, node: &DecoratedNode<'_>) -> Vec<Diagnostic> {
+        if doc_marker(node.raw()).is_none() {
+            return Vec::new();
+        }
+
+        let mut lines = Vec::new();
+        collect(&mut lines, node);
+        report(&lines, node)
+    }
+
+    fn check_line_comment(&mut self, node: &DecoratedNode<'_>) -> Vec<Diagnostic> {
+        let Some(marker) = doc_marker(node.raw()) else {
+            return Vec::new();
+        };
+        if continues_block(node.raw(), marker) {
+            return Vec::new();
+        }
+        let Some(parent) = node.parent() else {
+            return Vec::new();
+        };
+
+        let siblings = parent.named_children();
+        let Some(index) = siblings
+            .iter()
+            .position(|sibling| sibling.id() == node.id())
+        else {
+            return Vec::new();
+        };
+
+        let mut lines = Vec::new();
+        let rows = node.raw().start_position().row..;
+        for (row, sibling) in rows.zip(&siblings[index..]) {
+            if sibling.kind() != "line_comment" || doc_marker(sibling.raw()) != Some(marker) {
+                break;
+            }
+            if sibling.raw().start_position().row != row {
+                break;
+            }
+            collect(&mut lines, sibling);
+        }
+
+        report(&lines, node)
+    }
+}
+
+/// The marker that opens a doc comment
+///
+/// A `///` run and a `//!` run document different items, so the rule reads
+/// them as separate comments even when they touch.
+#[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug)]
+enum Marker {
+    Inner,
+    Outer,
+}
+
+/// Returns the marker of a comment, or [`None`] when it carries no doc text
+///
+/// [`None`]: std::option::Option::None
+fn doc_marker(node: tree_sitter::Node<'_>) -> Option<Marker> {
+    node.child_by_field_name("doc")?;
+
+    match node.child_by_field_name("inner") {
+        Some(_) => Some(Marker::Inner),
+        None => node.child_by_field_name("outer").map(|_| Marker::Outer),
+    }
+}
+
+/// Returns whether the line continues a doc comment that started above it
+///
+/// Rustdoc joins a run of `///` lines into one comment. A sentence may cross
+/// the line breaks, so only the first line of the run reports.
+fn continues_block(node: tree_sitter::Node<'_>, marker: Marker) -> bool {
+    let Some(previous) = node.prev_named_sibling() else {
+        return false;
+    };
+    if previous.kind() != "line_comment" {
+        return false;
+    }
+    if previous.start_position().row + 1 != node.start_position().row {
+        return false;
+    }
+
+    doc_marker(previous) == Some(marker)
+}
+
+/// Appends every line of one comment to `lines`
+///
+/// The `doc` field holds the text after the marker, so its offsets already
+/// skip the marker. A block comment keeps its newlines in that one field, so
+/// this function splits the text rather than treating the node as one line.
+fn collect<'a>(lines: &mut Vec<DocLine<'a>>, node: &DecoratedNode<'a>) {
+    let Some(doc) = node.child_by_field_name("doc") else {
+        return;
+    };
+
+    let offset = doc.raw().start_byte();
+    let text = doc.text();
+    let text = text.strip_suffix('\n').unwrap_or(text);
+
+    let mut cursor = 0;
+    for line in text.split('\n') {
+        lines.push(DocLine::new(
+            line.strip_suffix('\r').unwrap_or(line),
+            offset + cursor,
+        ));
+        cursor += line.len() + 1;
+    }
+}
+
+/// Reports every sentence in `lines` that goes over the word cap
+fn report(lines: &[DocLine<'_>], node: &DecoratedNode<'_>) -> Vec<Diagnostic> {
+    let file = node.span();
+
+    sentences(lines)
+        .into_iter()
+        .filter(|sentence| sentence.words() > MAX_WORDS)
+        .map(|sentence| {
+            Diagnostic::new(
+                RuleId::new("lint.long-doc-sentence"),
+                Severity::Warn,
+                format!(
+                    "doc sentence is {} words, over the {MAX_WORDS}-word limit",
+                    sentence.words()
+                ),
+                Span::new(
+                    Arc::clone(file.file_arc()),
+                    sentence.start(),
+                    sentence.end(),
+                ),
+            )
+        })
+        .collect()
+}
+
+#[cfg(feature = "plugin")]
+whisker_rust::export_lints![LongDocSentence];
+
+#[cfg(test)]
+mod tests {
+    use whisker_rust::RustLintPassAdapter;
+    use whisker_testing::{assert_diagnostic, assert_no_diagnostics, execute, parse};
+    use whisker_types::{Language, LintPass, Severity};
+
+    use super::*;
+
+    fn passes() -> Vec<Box<dyn LintPass>> {
+        vec![Box::new(RustLintPassAdapter::new(LongDocSentence))]
+    }
+
+    fn check(source: &str) -> Vec<Diagnostic> {
+        let tree = parse(source, Language::Rust);
+
+        execute(&tree, &mut passes())
+    }
+
+    fn words(count: usize) -> String {
+        let words: Vec<String> = (0..count).map(|index| format!("word{index}")).collect();
+
+        words.join(" ")
+    }
+
+    fn doc_of(count: usize) -> String {
+        format!("/// {}.\npub struct Foo;\n", words(count))
+    }
+
+    #[test]
+    fn block_doc_comment_over_the_limit_is_flagged() {
+        let source = format!("/** {}. */\npub struct Foo;\n", words(30));
+
+        let diagnostics = check(&source);
+
+        assert_eq!(diagnostics.len(), 1);
+    }
+
+    #[test]
+    fn block_inner_doc_comment_over_the_limit_is_flagged() {
+        let source = format!("/*! {}. */\npub struct Foo;\n", words(30));
+
+        let diagnostics = check(&source);
+
+        assert_eq!(diagnostics.len(), 1);
+    }
+
+    #[test]
+    fn code_span_counts_as_one_word() {
+        let source = "/// Reads `a b c d e f`, `g h i j k l`, `m n o p q r`, and `s t u v w x` now.\npub struct Foo;\n";
+
+        let diagnostics = check(source);
+
+        assert_no_diagnostics(&diagnostics);
+    }
+
+    #[test]
+    fn doc_comment_inside_an_impl_is_flagged() {
+        let source = format!(
+            "impl Foo {{\n    /// {}.\n    fn f(&self) {{}}\n}}\n",
+            words(30)
+        );
+
+        let diagnostics = check(&source);
+
+        assert_eq!(diagnostics.len(), 1);
+    }
+
+    #[test]
+    fn fenced_code_block_is_not_flagged() {
+        let source = format!(
+            "/// Summary\n///\n/// ```text\n/// {}.\n/// ```\npub struct Foo;\n",
+            words(30)
+        );
+
+        let diagnostics = check(&source);
+
+        assert_no_diagnostics(&diagnostics);
+    }
+
+    #[test]
+    fn inner_and_outer_markers_are_not_joined() {
+        let half = words(15);
+        let source = format!("//! {half}\n/// {half}\npub struct Foo;\n");
+
+        let diagnostics = check(&source);
+
+        assert_no_diagnostics(&diagnostics);
+    }
+
+    #[test]
+    fn inner_doc_comment_over_the_limit_is_flagged() {
+        let source = format!("//! {}.\n", words(30));
+
+        let diagnostics = check(&source);
+
+        assert_eq!(diagnostics.len(), 1);
+    }
+
+    #[test]
+    fn long_sentence_across_lines_is_flagged() {
+        let source = "/// Returns the coverage verdict for this file, which is empty when no decoration\n/// providers were configured, since a provider that declines still counts as\n/// having looked and the walk needs to distinguish that from never having run.\npub struct Foo;\n";
+
+        let diagnostics = check(source);
+
+        assert_eq!(diagnostics.len(), 1);
+        assert_diagnostic(&diagnostics[0])
+            .has_rule_id("lint.long-doc-sentence")
+            .has_severity(Severity::Warn)
+            .message_contains("37 words");
+        let span = diagnostics[0].span();
+        assert!(source[span.start()..span.end()].starts_with("Returns the coverage"));
+        assert!(source[span.start()..span.end()].ends_with("having run."));
+    }
+
+    #[test]
+    fn multibyte_prose_reports_a_span_on_a_character_boundary() {
+        let source = format!("/// 日本語 {}.\npub struct Foo;\n", words(30));
+
+        let diagnostics = check(&source);
+
+        assert_eq!(diagnostics.len(), 1);
+        let span = diagnostics[0].span();
+        assert!(source[span.start()..span.end()].starts_with("日本語"));
+    }
+
+    #[test]
+    fn multibyte_text_is_not_flagged() {
+        let source = "/// Résumé — 日本語 `多バイト` ünïcödé here.\n/// ``unbalanced ` span\npub struct Foo;\n";
+
+        let diagnostics = check(source);
+
+        assert_no_diagnostics(&diagnostics);
+    }
+
+    #[test]
+    fn non_doc_comment_is_not_flagged() {
+        let source = format!("// {}.\npub struct Foo;\n", words(40));
+
+        let diagnostics = check(&source);
+
+        assert_no_diagnostics(&diagnostics);
+    }
+
+    #[test]
+    fn section_heading_is_not_flagged() {
+        let source = format!("/// Summary\n///\n/// # {}\npub struct Foo;\n", words(30));
+
+        let diagnostics = check(&source);
+
+        assert_no_diagnostics(&diagnostics);
+    }
+
+    #[test]
+    fn sentence_at_the_limit_is_not_flagged() {
+        let diagnostics = check(&doc_of(MAX_WORDS));
+
+        assert_no_diagnostics(&diagnostics);
+    }
+
+    #[test]
+    fn sentence_over_the_limit_is_flagged() {
+        let diagnostics = check(&doc_of(MAX_WORDS + 1));
+
+        assert_eq!(diagnostics.len(), 1);
+        assert_diagnostic(&diagnostics[0]).message_contains("26 words");
+    }
+
+    #[test]
+    fn separate_doc_blocks_are_not_joined() {
+        let half = words(15);
+        let source = format!("/// {half}\npub struct Foo;\n/// {half}\npub struct Bar;\n");
+
+        let diagnostics = check(&source);
+
+        assert_no_diagnostics(&diagnostics);
+    }
+
+    #[test]
+    fn short_sentences_are_not_flagged() {
+        let source = "/// Returns the coverage verdict for this file\n///\n/// The map is empty when no providers were configured. A provider that\n/// declines still counts as having looked.\npub struct Foo;\n";
+
+        let diagnostics = check(source);
+
+        assert_no_diagnostics(&diagnostics);
+    }
+
+    #[test]
+    fn span_covers_one_sentence_only() {
+        let source = doc_of(MAX_WORDS + 1);
+
+        let diagnostics = check(&source);
+
+        assert_eq!(diagnostics.len(), 1);
+        let span = diagnostics[0].span();
+        let sentence = source[4..].lines().next().expect("the doc line");
+        assert_eq!(&source[span.start()..span.end()], sentence);
+    }
+
+    #[test]
+    fn trait_send() {
+        fn assert_send<T: Send>() {}
+        assert_send::<LongDocSentence>();
+        assert_send::<Marker>();
+    }
+
+    #[test]
+    fn trait_sync() {
+        fn assert_sync<T: Sync>() {}
+        assert_sync::<LongDocSentence>();
+        assert_sync::<Marker>();
+    }
+
+    #[test]
+    fn trait_unpin() {
+        fn assert_unpin<T: Unpin>() {}
+        assert_unpin::<LongDocSentence>();
+        assert_unpin::<Marker>();
+    }
+
+    #[test]
+    fn two_long_sentences_are_flagged_once_each() {
+        let sentence = words(30);
+        let source = format!("/// {sentence}. And {sentence}.\npub struct Foo;\n");
+
+        let diagnostics = check(&source);
+
+        assert_eq!(diagnostics.len(), 2);
+    }
+}

--- a/lints/long_doc_sentence/src/sentence.rs
+++ b/lints/long_doc_sentence/src/sentence.rs
@@ -1,0 +1,696 @@
+use crate::doc_line::DocLine;
+
+/// Abbreviations that end in a period but never end a sentence
+///
+/// `is_abbreviation` covers forms with an inner period, such as `e.g.` and
+/// `i.e.`, so this list omits them. It also omits `etc.`, which ends a
+/// sentence as often as not.
+const ABBREVIATIONS: [&str; 6] = ["approx.", "cf.", "fig.", "resp.", "viz.", "vs."];
+
+/// Characters that may sit between a sentence terminator and the whitespace
+const CLOSERS: [u8; 9] = *b".!?)]\"'*_";
+
+/// Markers that open a Markdown list item or a block quote
+const LIST_MARKERS: [&str; 4] = ["- ", "* ", "+ ", "> "];
+
+/// Characters that can end a sentence
+const TERMINATORS: [u8; 3] = *b".!?";
+
+/// One sentence of doc comment prose
+///
+/// The range is in file bytes, so it covers the `///` markers of the lines
+/// the sentence continues onto. A [`Span`] is one contiguous range, so the
+/// markers cannot be cut out.
+///
+/// [`Span`]: whisker_types::Span
+#[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug)]
+pub(crate) struct Sentence {
+    words: usize,
+    start: usize,
+    end: usize,
+}
+
+impl Sentence {
+    /// Returns how many words the sentence has
+    pub(crate) fn words(&self) -> usize {
+        self.words
+    }
+
+    /// Returns the byte offset where the sentence starts in the file
+    pub(crate) fn start(&self) -> usize {
+        self.start
+    }
+
+    /// Returns the byte offset one past the end of the sentence
+    pub(crate) fn end(&self) -> usize {
+        self.end
+    }
+}
+
+/// Splits the prose of one doc comment into sentences
+///
+/// Fenced code blocks, section headings, link definitions, and table rows
+/// are not prose, so no sentence contains them. A blank line or a new list
+/// item ends the current sentence, because Markdown reads them as a break
+/// even without a period.
+pub(crate) fn sentences(lines: &[DocLine<'_>]) -> Vec<Sentence> {
+    let mut found = Vec::new();
+    let mut prose = Prose::default();
+    let mut fence = None;
+
+    for line in lines {
+        let text = line.text();
+        let trimmed = text.trim_start();
+
+        match (fence, Fence::of(trimmed)) {
+            (None, None) => {}
+            (None, Some(opened)) => {
+                fence = Some(opened);
+                prose.flush(&mut found);
+                continue;
+            }
+            (Some(_), None) => continue,
+            (Some(opened), Some(candidate)) => {
+                fence = match candidate.closes(opened) {
+                    true => None,
+                    false => Some(opened),
+                };
+                continue;
+            }
+        }
+
+        if trimmed.is_empty()
+            || is_heading(trimmed)
+            || is_link_definition(trimmed)
+            || trimmed.starts_with('|')
+        {
+            prose.flush(&mut found);
+            continue;
+        }
+
+        let indent = text.len() - trimmed.len();
+        let marker = list_marker(trimmed);
+        if marker > 0 {
+            prose.flush(&mut found);
+        }
+        let start = indent + marker;
+        prose.push(&text[start..], line.offset() + start);
+    }
+
+    prose.flush(&mut found);
+    found
+}
+
+/// The prose of one paragraph, reassembled from the lines it spans
+///
+/// Each line keeps the file offset it came from, so a sentence can point
+/// back into the file. The segments stay sorted by their position in `text`,
+/// which the offset lookup relies on.
+#[derive(Clone, Eq, PartialEq, Debug, Default)]
+struct Prose {
+    text: String,
+    segments: Vec<(usize, usize)>,
+}
+
+impl Prose {
+    /// Appends one line of prose that starts at `offset` in the file
+    fn push(&mut self, text: &str, offset: usize) {
+        let indent = text.len() - text.trim_start().len();
+        let text = text.trim();
+        if text.is_empty() {
+            return;
+        }
+
+        if !self.text.is_empty() {
+            self.text.push(' ');
+        }
+        self.segments.push((self.text.len(), offset + indent));
+        self.text.push_str(text);
+    }
+
+    /// Appends the sentences of the paragraph to `found` and empties it
+    fn flush(&mut self, found: &mut Vec<Sentence>) {
+        let masked = mask_code_spans(&self.text);
+        for (start, end) in split(&masked) {
+            found.push(Sentence {
+                words: count_words(&masked[start..end]),
+                start: self.offset(start),
+                end: self.offset(end),
+            });
+        }
+
+        self.text.clear();
+        self.segments.clear();
+    }
+
+    /// Maps an offset in `text` to the file offset it came from
+    ///
+    /// # Panics
+    ///
+    /// Panics if the paragraph holds no segments. Only [`Prose::flush`] calls
+    /// this, and a paragraph without segments has no text to split, so it asks
+    /// for no offsets.
+    fn offset(&self, offset: usize) -> usize {
+        let index = self
+            .segments
+            .partition_point(|(position, _)| *position <= offset);
+        let (position, file) = self.segments[index - 1];
+        file + (offset - position)
+    }
+}
+
+/// The run of backticks or tildes that opens or closes a code block
+///
+/// Treating every fence line as a toggle ends a block at the first fence line
+/// inside it. Markdown closes a block only with the character that opened it,
+/// repeated at least as many times, and with no language label.
+#[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug)]
+struct Fence {
+    character: u8,
+    length: usize,
+    labeled: bool,
+}
+
+impl Fence {
+    /// Returns the fence the line carries, or nothing when it is prose
+    fn of(text: &str) -> Option<Self> {
+        let character = *text.as_bytes().first()?;
+        if character != b'`' && character != b'~' {
+            return None;
+        }
+
+        let length = text.bytes().take_while(|byte| *byte == character).count();
+        if length < 3 {
+            return None;
+        }
+
+        Some(Self {
+            character,
+            length,
+            labeled: !text[length..].trim().is_empty(),
+        })
+    }
+
+    /// Returns whether this fence closes the block that `opened` started
+    fn closes(&self, opened: Self) -> bool {
+        self.character == opened.character && self.length >= opened.length && !self.labeled
+    }
+}
+
+/// Returns whether the line is a rustdoc section heading such as `# Errors`
+fn is_heading(text: &str) -> bool {
+    let rest = text.trim_start_matches('#');
+    rest.len() < text.len() && (rest.is_empty() || rest.starts_with(' '))
+}
+
+/// Returns whether the line defines a reference-style Markdown link
+fn is_link_definition(text: &str) -> bool {
+    text.starts_with('[') && text.contains("]:")
+}
+
+/// Returns the length of the list or quote marker that opens the line
+///
+/// A line that opens neither yields zero.
+fn list_marker(text: &str) -> usize {
+    for marker in LIST_MARKERS {
+        if text.starts_with(marker) {
+            return marker.len();
+        }
+    }
+
+    let digits = text.bytes().take_while(u8::is_ascii_digit).count();
+    if digits == 0 {
+        return 0;
+    }
+    let rest = &text[digits..];
+    match rest.starts_with(". ") || rest.starts_with(") ") {
+        true => digits + 2,
+        false => 0,
+    }
+}
+
+/// Replaces the inside of every inline code span with `x`, byte for byte
+///
+/// A code span may hold anything, including periods and spaces, so the
+/// splitter must not read it. The replacement keeps every offset intact and
+/// leaves the span as a single word.
+fn mask_code_spans(text: &str) -> String {
+    let bytes = text.as_bytes();
+    let mut masked = String::with_capacity(text.len());
+    let mut index = 0;
+
+    while index < bytes.len() {
+        if bytes[index] != b'`' {
+            let next = text[index..]
+                .find('`')
+                .map_or(bytes.len(), |offset| index + offset);
+            masked.push_str(&text[index..next]);
+            index = next;
+            continue;
+        }
+
+        let fence = backtick_run(bytes, index);
+        masked.push_str(&text[index..index + fence]);
+        index += fence;
+
+        let Some(close) = closing_backticks(bytes, index, fence) else {
+            continue;
+        };
+        for _ in index..close {
+            masked.push('x');
+        }
+        masked.push_str(&text[close..close + fence]);
+        index = close + fence;
+    }
+
+    masked
+}
+
+/// Returns how many backticks start at `index`
+fn backtick_run(bytes: &[u8], index: usize) -> usize {
+    bytes[index..].iter().take_while(|&&b| b == b'`').count()
+}
+
+/// Finds the run of exactly `fence` backticks that closes a code span
+///
+/// A span that never closes yields nothing, and the text stays unmasked.
+fn closing_backticks(bytes: &[u8], from: usize, fence: usize) -> Option<usize> {
+    let mut index = from;
+    while index < bytes.len() {
+        if bytes[index] != b'`' {
+            index += 1;
+            continue;
+        }
+        let run = backtick_run(bytes, index);
+        if run == fence {
+            return Some(index);
+        }
+        index += run;
+    }
+    None
+}
+
+/// Splits masked prose into sentence ranges
+fn split(text: &str) -> Vec<(usize, usize)> {
+    let bytes = text.as_bytes();
+    let mut ranges = Vec::new();
+    let mut start = 0;
+    let mut index = 0;
+
+    while index < bytes.len() {
+        if !TERMINATORS.contains(&bytes[index]) {
+            index += 1;
+            continue;
+        }
+
+        let mut end = index + 1;
+        while end < bytes.len() && CLOSERS.contains(&bytes[end]) {
+            end += 1;
+        }
+        if end < bytes.len() && !bytes[end].is_ascii_whitespace() {
+            index = end;
+            continue;
+        }
+        if !ends_sentence(text, start, index, end) {
+            index = end;
+            continue;
+        }
+
+        ranges.push((start, end));
+        let rest = &text[end..];
+        start = end + (rest.len() - rest.trim_start().len());
+        index = start;
+    }
+
+    if start < bytes.len() {
+        ranges.push((start, bytes.len()));
+    }
+    ranges
+}
+
+/// Decides whether the terminator at `at` ends a sentence
+///
+/// An abbreviation and a sentence end look the same. For a period, the word
+/// before it decides. A `!` or a `?` also needs the word after it, because a
+/// macro name ends in `!` and prose writes a bare `?`.
+///
+/// The word after a period decides nothing. Rust prose starts sentences with
+/// names such as `rust-analyzer`, so lower case is no sign that the sentence
+/// goes on.
+fn ends_sentence(text: &str, start: usize, at: usize, end: usize) -> bool {
+    let word = text[start..at]
+        .rfind(char::is_whitespace)
+        .map_or(start, |offset| start + offset + 1);
+    let word = &text[word..=at];
+    if ABBREVIATIONS
+        .iter()
+        .any(|abbreviation| abbreviation.eq_ignore_ascii_case(word))
+    {
+        return false;
+    }
+    if is_abbreviation(word) {
+        return false;
+    }
+    if text.as_bytes()[at] == b'.' {
+        return true;
+    }
+
+    match text[end..].trim_start().chars().next() {
+        None => true,
+        Some(next) => !next.is_lowercase(),
+    }
+}
+
+/// Returns whether the word is an abbreviation such as `e.g.` or `a.k.a.`
+///
+/// Only letters and periods qualify, so a version number such as `1.97.0.`
+/// still ends a sentence.
+fn is_abbreviation(word: &str) -> bool {
+    let Some(stem) = word.strip_suffix('.') else {
+        return false;
+    };
+    stem.contains('.') && stem.bytes().all(|b| b.is_ascii_alphabetic() || b == b'.')
+}
+
+/// Counts the words of one sentence
+///
+/// An inline code span counts as one word, because a reader takes
+/// `Option<T>` or `crates/whisker-rust` as a single name. Punctuation on its
+/// own is not a word.
+fn count_words(text: &str) -> usize {
+    text.split_whitespace()
+        .filter(|word| word.chars().any(char::is_alphanumeric))
+        .count()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn lines(text: &str) -> Vec<DocLine<'_>> {
+        let mut offset = 0;
+        let mut lines = Vec::new();
+        for line in text.split('\n') {
+            lines.push(DocLine::new(line, offset));
+            offset += line.len() + 1;
+        }
+        lines
+    }
+
+    fn words(text: &str) -> Vec<usize> {
+        sentences(&lines(text))
+            .iter()
+            .map(Sentence::words)
+            .collect()
+    }
+
+    #[test]
+    fn count_words_ignores_bare_punctuation() {
+        assert_eq!(count_words("a -- b"), 2);
+    }
+
+    #[test]
+    fn count_words_treats_a_masked_code_span_as_one_word() {
+        assert_eq!(count_words(&mask_code_spans("takes `Vec<String>` now")), 3);
+    }
+
+    #[test]
+    fn fence_closes_accepts_a_longer_run() {
+        let opened = Fence::of("```").expect("a fence");
+        let candidate = Fence::of("`````").expect("a fence");
+
+        let closes = candidate.closes(opened);
+
+        assert!(closes);
+    }
+
+    #[test]
+    fn fence_closes_rejects_a_different_character() {
+        let opened = Fence::of("```").expect("a fence");
+        let candidate = Fence::of("~~~").expect("a fence");
+
+        let closes = candidate.closes(opened);
+
+        assert!(!closes);
+    }
+
+    #[test]
+    fn fence_closes_rejects_a_labeled_run() {
+        let opened = Fence::of("```").expect("a fence");
+        let candidate = Fence::of("```rust").expect("a fence");
+
+        let closes = candidate.closes(opened);
+
+        assert!(!closes);
+    }
+
+    #[test]
+    fn fence_closes_rejects_a_shorter_run() {
+        let opened = Fence::of("````").expect("a fence");
+        let candidate = Fence::of("```").expect("a fence");
+
+        let closes = candidate.closes(opened);
+
+        assert!(!closes);
+    }
+
+    #[test]
+    fn fence_of_rejects_a_short_run() {
+        assert!(Fence::of("`` code").is_none());
+    }
+
+    #[test]
+    fn fence_of_rejects_prose() {
+        assert!(Fence::of("Returns the length").is_none());
+    }
+
+    #[test]
+    fn is_abbreviation_accepts_inner_periods() {
+        assert!(is_abbreviation("e.g."));
+        assert!(is_abbreviation("a.k.a."));
+    }
+
+    #[test]
+    fn is_abbreviation_rejects_a_plain_word() {
+        assert!(!is_abbreviation("word."));
+    }
+
+    #[test]
+    fn is_abbreviation_rejects_a_version_number() {
+        assert!(!is_abbreviation("1.97.0."));
+    }
+
+    #[test]
+    fn is_heading_accepts_a_section_heading() {
+        assert!(is_heading("# Errors"));
+        assert!(is_heading("## Panics"));
+    }
+
+    #[test]
+    fn is_heading_rejects_an_issue_reference() {
+        assert!(!is_heading("#239 changed this"));
+    }
+
+    #[test]
+    fn is_link_definition_accepts_a_reference_target() {
+        assert!(is_link_definition("[`io::Error`]: std::io::Error"));
+    }
+
+    #[test]
+    fn is_link_definition_rejects_a_reference_use() {
+        assert!(!is_link_definition("[the walker][ignore] honors gitignore"));
+    }
+
+    #[test]
+    fn list_marker_measures_an_ordered_item() {
+        assert_eq!(list_marker("12. first"), 4);
+    }
+
+    #[test]
+    fn list_marker_measures_an_unordered_item() {
+        assert_eq!(list_marker("- first"), 2);
+    }
+
+    #[test]
+    fn list_marker_rejects_a_decimal() {
+        assert_eq!(list_marker("1.5 seconds"), 0);
+    }
+
+    #[test]
+    fn mask_code_spans_hides_a_period_inside_a_span() {
+        assert_eq!(mask_code_spans("see `a. b` now"), "see `xxxx` now");
+    }
+
+    #[test]
+    fn mask_code_spans_leaves_an_unclosed_span_alone() {
+        assert_eq!(mask_code_spans("a ` b c"), "a ` b c");
+    }
+
+    #[test]
+    fn mask_code_spans_respects_a_double_backtick_span() {
+        assert_eq!(mask_code_spans("``a ` b`` c"), "``xxxxx`` c");
+    }
+
+    #[test]
+    fn sentences_counts_a_sentence_that_spans_lines() {
+        assert_eq!(words("one two three\nfour five six."), vec![6]);
+    }
+
+    #[test]
+    fn sentences_ignores_a_fenced_code_block() {
+        let text = "Text here.\n\n```\nlet a = 1. let b = 2;\n```\n\nMore text.";
+
+        assert_eq!(words(text), vec![2, 2]);
+    }
+
+    #[test]
+    fn sentences_ignores_a_link_definition() {
+        assert_eq!(
+            words("Uses [`Span`] here.\n\n[`Span`]: whisker_types::Span"),
+            vec![3]
+        );
+    }
+
+    #[test]
+    fn sentences_ignores_a_section_heading() {
+        assert_eq!(words("# Errors\n\nReturns an error."), vec![3]);
+    }
+
+    #[test]
+    fn sentences_ignores_a_shorter_fence_inside_a_longer_one() {
+        let text = "Text here.\n\n````\n``` a. b\n````\n\nMore text.";
+
+        assert_eq!(words(text), vec![2, 2]);
+    }
+
+    #[test]
+    fn sentences_ignores_a_table_row() {
+        assert_eq!(words("Text.\n\n| a | b |\n| - | - |"), vec![1]);
+    }
+
+    #[test]
+    fn sentences_ignores_a_tilde_line_inside_a_backtick_fence() {
+        let text = "Text here.\n\n```\n~~~\nlet a = 1. let b = 2;\n~~~\n```\n\nMore text.";
+
+        assert_eq!(words(text), vec![2, 2]);
+    }
+
+    #[test]
+    fn sentences_keeps_a_version_number_whole() {
+        assert_eq!(words("Needs 1.97.0 or later"), vec![4]);
+    }
+
+    #[test]
+    fn sentences_maps_offsets_back_to_the_file() {
+        let found = sentences(&lines("Abc def.\nGhi."));
+
+        assert_eq!(found.len(), 2);
+        assert_eq!((found[0].start(), found[0].end()), (0, 8));
+        assert_eq!((found[1].start(), found[1].end()), (9, 13));
+    }
+
+    #[test]
+    fn sentences_reports_nothing_for_empty_prose() {
+        assert!(sentences(&lines("\n\n")).is_empty());
+    }
+
+    #[test]
+    fn sentences_splits_at_a_list_item() {
+        assert_eq!(
+            words("The rules are\n- one thing\n- two things"),
+            vec![3, 2, 2]
+        );
+    }
+
+    #[test]
+    fn sentences_splits_at_a_paragraph_break() {
+        assert_eq!(words("One two\n\nthree four five"), vec![2, 3]);
+    }
+
+    #[test]
+    fn sentences_splits_before_a_code_span() {
+        assert_eq!(words("It runs. `Foo` stops."), vec![2, 2]);
+    }
+
+    #[test]
+    fn sentences_splits_on_a_period() {
+        assert_eq!(words("One two three. Four five."), vec![3, 2]);
+    }
+
+    #[test]
+    fn sentences_treats_an_unnamed_abbreviation_as_one_sentence() {
+        assert_eq!(words("Prefers a.k.a. Names over others."), vec![5]);
+    }
+
+    #[test]
+    fn split_keeps_a_bare_macro_name_whole() {
+        assert_eq!(words("The matches! macro hides the arms."), vec![6]);
+    }
+
+    #[test]
+    fn split_keeps_a_capitalized_listed_abbreviation_whole() {
+        assert_eq!(words("Compare Cf. Rust and this."), vec![5]);
+    }
+
+    #[test]
+    fn split_keeps_a_listed_abbreviation_whole() {
+        assert_eq!(words("Compare cf. Rust and this."), vec![5]);
+    }
+
+    #[test]
+    fn split_keeps_a_path_whole() {
+        assert_eq!(words("Reads std::io::Error from disk."), vec![4]);
+    }
+
+    #[test]
+    fn split_keeps_a_url_whole() {
+        assert_eq!(words("See https://flox.dev for more."), vec![4]);
+    }
+
+    #[test]
+    fn split_keeps_e_g_whole() {
+        assert_eq!(
+            words("The kind, e.g. `function_item`, is a string."),
+            vec![7]
+        );
+    }
+
+    #[test]
+    fn split_keeps_i_e_whole() {
+        assert_eq!(words("One thing, i.e. the only thing."), vec![6]);
+    }
+
+    #[test]
+    fn split_stops_at_a_lowercase_name() {
+        assert_eq!(words("Interns it. rust-analyzer panics."), vec![2, 2]);
+    }
+
+    #[test]
+    fn split_stops_at_a_question_mark() {
+        assert_eq!(words("Did it run? It did."), vec![3, 2]);
+    }
+
+    #[test]
+    fn trait_send() {
+        fn assert_send<T: Send>() {}
+        assert_send::<Fence>();
+        assert_send::<Prose>();
+        assert_send::<Sentence>();
+    }
+
+    #[test]
+    fn trait_sync() {
+        fn assert_sync<T: Sync>() {}
+        assert_sync::<Fence>();
+        assert_sync::<Prose>();
+        assert_sync::<Sentence>();
+    }
+
+    #[test]
+    fn trait_unpin() {
+        fn assert_unpin<T: Unpin>() {}
+        assert_unpin::<Fence>();
+        assert_unpin::<Prose>();
+        assert_unpin::<Sentence>();
+    }
+}


### PR DESCRIPTION
Closes #239.

Flags any sentence in a `///`, `//!`, `/**`, or `/*!` comment over 25 words, spanning the offending sentence. Silent on fenced code blocks, ATX headings, reference-style link definitions, table rows, and plain `//` comments. A blank line, list item, blockquote, or table row ends a sentence unit, so a bulleted list of fragments is never joined into one giant sentence. A fenced block ends only at a run of the same character that opened it, at least as long and carrying no language label, so a tilde line inside a backtick block, a three-backtick line inside a four-backtick block, and a labeled fence line all stay code.

## The two judgement calls

**An inline code span counts as one word.** Spans are masked byte-for-byte before splitting, which does double duty: the splitter cannot trip on punctuation inside a span, and `Option<T>`, `std::io::Error`, or a long path each read as one name. Counting span contents would punish precise naming and give unstable answers — is `std::io::Error` one word or three? Multi-word Markdown link text does count word by word, since those are real words being read.

**Sentence boundaries** require a terminator followed by whitespace or end-of-chunk, so `1.97.0`, `std::io`, and `flox.dev` never split. The preceding word is then rejected if it is in a six-entry abbreviation list or has the *shape* of an inner-period abbreviation — letters and dots only, which covers `e.g.` and `a.k.a.` generically while letting `1.97.0.` end a sentence. `etc.` and `al.` are deliberately absent: they end sentences as often as not.

A "next word starts lowercase means not a boundary" rule was **removed because dogfooding killed it** — it merged two real sentences at `…for it. rust-analyzer panics…`, producing two false 29-word reports. Rust prose starts sentences with lowercase crate names constantly.

## 73 hits across the repo

| file | words |
|---|---|
| `whisker-rust/src/provider.rs:213` | **51** |
| `whisker-rust/src/provider.rs:224` | **50** |
| `whisker-codegen/src/fingerprint.rs:75` | **50** |
| `whisker-types/src/decoration_map.rs:11` | 48 |
| `whisker/src/custom_lints.rs:150` | 46 |
| 68 more between 26 and 42 | |

The shape is informative: most are one to six words over, so the cap is being nearly hit rather than ignored, with five outliers above 45 words that are qualitatively different. No source edited.

Evidence the splitter is not too lenient: it caught a 27-word sentence I introduced in this crate's own doc comment while rewriting after review.

**On 20 versus 25 words**, which DOC_RULES distinguishes for procedural text: not reliably detectable without a part-of-speech lexicon. The one usable signal is imperative mood, and it cannot be separated from a noun-initial descriptive sentence when the word is both noun and verb — which is most of them here (`check`, `report`, `walk`, `parse`, `run`). Only the 25 cap is implemented, as the issue asked.

73 tests. Known limits, both erring toward under-counting: 4-space indented code blocks count as prose, and each ` * ` line of a block comment reads as a list item.
