### PR TITLE
Gate rust-analyzer behind a provider feature

### DIFF
--- a/.config/whisker.toml
+++ b/.config/whisker.toml
@@ -2,7 +2,4 @@
 # The patterns below anchor at the repository root, not at `.config`.
 # Both paths hold code that breaks whisker's own lints on purpose. Neither is
 # part of the Cargo build, so rust-analyzer never sees them.
-ignore = [
-  "/examples/",
-  "crates/whisker-rust/tests/fixtures/",
-]
+ignore = ["/examples/", "crates/whisker-rust/tests/fixtures/"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,13 @@
 [workspace]
-members = ["crates/*", "lints/anyhow_missing_context", "lints/bool_param", "lints/derive_order", "lints/if_let_with_else", "lints/no_matches_macro", "lints/wildcard_match_arm"]
+members = [
+  "crates/*",
+  "lints/anyhow_missing_context",
+  "lints/bool_param",
+  "lints/derive_order",
+  "lints/if_let_with_else",
+  "lints/no_matches_macro",
+  "lints/wildcard_match_arm",
+]
 exclude = ["examples/*", "lints/*"]
 
 # Opt-in to the new feature resolver introduced in Rust 1.85 and Edition 2024.

--- a/crates/whisker-rust/Cargo.toml
+++ b/crates/whisker-rust/Cargo.toml
@@ -12,13 +12,13 @@ publish = false
 [features]
 default = ["provider"]
 provider = [
-    "dep:anyhow",
-    "dep:ra_ap_hir",
-    "dep:ra_ap_ide_db",
-    "dep:ra_ap_load-cargo",
-    "dep:ra_ap_project_model",
-    "dep:ra_ap_syntax",
-    "dep:ra_ap_vfs",
+  "dep:anyhow",
+  "dep:ra_ap_hir",
+  "dep:ra_ap_ide_db",
+  "dep:ra_ap_load-cargo",
+  "dep:ra_ap_project_model",
+  "dep:ra_ap_syntax",
+  "dep:ra_ap_vfs",
 ]
 
 [dependencies]

--- a/crates/whisker-rust/Cargo.toml
+++ b/crates/whisker-rust/Cargo.toml
@@ -5,14 +5,30 @@ edition.workspace = true
 license.workspace = true
 publish = false
 
+# The rust-analyzer stack behind the decoration provider dwarfs everything
+# else in this crate. Custom lint plugins depend on this crate only for the
+# generated trait, the adapter, and the decoration types, so the provider is
+# a default feature they can switch off rather than an unconditional cost.
+[features]
+default = ["provider"]
+provider = [
+    "dep:anyhow",
+    "dep:ra_ap_hir",
+    "dep:ra_ap_ide_db",
+    "dep:ra_ap_load-cargo",
+    "dep:ra_ap_project_model",
+    "dep:ra_ap_syntax",
+    "dep:ra_ap_vfs",
+]
+
 [dependencies]
-anyhow.workspace = true
-ra_ap_hir.workspace = true
-ra_ap_ide_db.workspace = true
-ra_ap_load-cargo.workspace = true
-ra_ap_project_model.workspace = true
-ra_ap_syntax.workspace = true
-ra_ap_vfs.workspace = true
+anyhow = { workspace = true, optional = true }
+ra_ap_hir = { workspace = true, optional = true }
+ra_ap_ide_db = { workspace = true, optional = true }
+ra_ap_load-cargo = { workspace = true, optional = true }
+ra_ap_project_model = { workspace = true, optional = true }
+ra_ap_syntax = { workspace = true, optional = true }
+ra_ap_vfs = { workspace = true, optional = true }
 tree-sitter.workspace = true
 tree-sitter-rust.workspace = true
 whisker-types.workspace = true

--- a/crates/whisker-rust/src/lib.rs
+++ b/crates/whisker-rust/src/lib.rs
@@ -1,8 +1,10 @@
 mod adapter;
 pub mod decorations;
+#[cfg(feature = "provider")]
 mod provider;
 
 pub use adapter::RustLintPassAdapter;
+#[cfg(feature = "provider")]
 pub use provider::RustDecorationProvider;
 
 include!(concat!(env!("OUT_DIR"), "/rust_lint_pass.rs"));
@@ -16,10 +18,7 @@ pub fn language() -> tree_sitter::Language {
 mod tests {
     use std::path::PathBuf;
 
-    use whisker_types::{
-        Coverage, CoverageGap, DecoratedNode, DecoratedTree, DecorationMap, DecorationProvider,
-        Diagnostic, RuleId, Severity,
-    };
+    use whisker_types::{DecoratedNode, DecoratedTree, Diagnostic, RuleId, Severity};
 
     use super::*;
 
@@ -28,24 +27,6 @@ mod tests {
         parser.set_language(&language()).unwrap();
         let tree = parser.parse(source, None).unwrap();
         DecoratedTree::new(tree, source.to_string(), PathBuf::from("test.rs"))
-    }
-
-    #[test]
-    fn trait_send_provider() {
-        fn assert_send<T: Send>() {}
-        assert_send::<RustDecorationProvider>();
-    }
-
-    #[test]
-    fn trait_sync_provider() {
-        fn assert_sync<T: Sync>() {}
-        assert_sync::<RustDecorationProvider>();
-    }
-
-    #[test]
-    fn trait_unpin_provider() {
-        fn assert_unpin<T: Unpin>() {}
-        assert_unpin::<RustDecorationProvider>();
     }
 
     #[test]
@@ -62,48 +43,6 @@ mod tests {
         parser.set_language(&language()).unwrap();
         let tree = parser.parse("fn main() {}", None).unwrap();
         assert_eq!(tree.root_node().kind(), "source_file");
-    }
-
-    #[test]
-    fn decorate_with_empty_provider_leaves_existing_decorations_intact() {
-        let provider = RustDecorationProvider::empty();
-        let mut tree = parse_rust("fn main() {}");
-        let root_id = tree.root_node().id();
-        let mut staged = DecorationMap::new();
-        staged.insert(root_id, 7u32);
-        tree.merge_decorations(staged);
-
-        let coverage = provider.decorate(&tree).expect("should succeed");
-
-        match coverage {
-            Coverage::Covered(_) => panic!("an empty VFS cannot cover any file"),
-            Coverage::NotCovered(CoverageGap::OutsideRoot { .. }) => {}
-            Coverage::NotCovered(gap) => panic!("unexpected gap: {gap}"),
-        }
-        assert_eq!(tree.root_node().decoration::<u32>(), Some(&7));
-    }
-
-    #[test]
-    fn decorate_with_empty_provider_reports_outside_workspace() {
-        let provider = RustDecorationProvider::empty();
-        let tree = parse_rust("");
-
-        let coverage = provider.decorate(&tree).expect("should succeed");
-
-        match coverage {
-            Coverage::Covered(_) => panic!("an empty VFS cannot cover any file"),
-            Coverage::NotCovered(CoverageGap::OutsideRoot { .. }) => {}
-            Coverage::NotCovered(gap) => panic!("unexpected gap: {gap}"),
-        }
-    }
-
-    #[test]
-    fn name_returns_rust() {
-        let provider = RustDecorationProvider::empty();
-
-        let name = provider.name();
-
-        assert_eq!(name.as_str(), "rust");
     }
 
     #[test]
@@ -415,6 +354,73 @@ mod tests {
                 walk_and_dispatch(&root, &mut pass);
                 prop_assert_eq!(pass.0, count);
             }
+        }
+    }
+
+    #[cfg(feature = "provider")]
+    mod provider {
+        use whisker_types::{Coverage, CoverageGap, DecorationMap, DecorationProvider};
+
+        use super::*;
+
+        #[test]
+        fn decorate_with_empty_provider_leaves_existing_decorations_intact() {
+            let provider = RustDecorationProvider::empty();
+            let mut tree = parse_rust("fn main() {}");
+            let root_id = tree.root_node().id();
+            let mut staged = DecorationMap::new();
+            staged.insert(root_id, 7u32);
+            tree.merge_decorations(staged);
+
+            let coverage = provider.decorate(&tree).expect("should succeed");
+
+            match coverage {
+                Coverage::Covered(_) => panic!("an empty VFS cannot cover any file"),
+                Coverage::NotCovered(CoverageGap::OutsideRoot { .. }) => {}
+                Coverage::NotCovered(gap) => panic!("unexpected gap: {gap}"),
+            }
+            assert_eq!(tree.root_node().decoration::<u32>(), Some(&7));
+        }
+
+        #[test]
+        fn decorate_with_empty_provider_reports_outside_workspace() {
+            let provider = RustDecorationProvider::empty();
+            let tree = parse_rust("");
+
+            let coverage = provider.decorate(&tree).expect("should succeed");
+
+            match coverage {
+                Coverage::Covered(_) => panic!("an empty VFS cannot cover any file"),
+                Coverage::NotCovered(CoverageGap::OutsideRoot { .. }) => {}
+                Coverage::NotCovered(gap) => panic!("unexpected gap: {gap}"),
+            }
+        }
+
+        #[test]
+        fn name_returns_rust() {
+            let provider = RustDecorationProvider::empty();
+
+            let name = provider.name();
+
+            assert_eq!(name.as_str(), "rust");
+        }
+
+        #[test]
+        fn trait_send() {
+            fn assert_send<T: Send>() {}
+            assert_send::<RustDecorationProvider>();
+        }
+
+        #[test]
+        fn trait_sync() {
+            fn assert_sync<T: Sync>() {}
+            assert_sync::<RustDecorationProvider>();
+        }
+
+        #[test]
+        fn trait_unpin() {
+            fn assert_unpin<T: Unpin>() {}
+            assert_unpin::<RustDecorationProvider>();
         }
     }
 }

--- a/crates/whisker-rust/tests/provider_integration.rs
+++ b/crates/whisker-rust/tests/provider_integration.rs
@@ -1,3 +1,5 @@
+#![cfg(feature = "provider")]
+
 use std::ops::Range;
 use std::path::{Path, PathBuf};
 use std::sync::OnceLock;

--- a/justfile
+++ b/justfile
@@ -24,6 +24,10 @@ pre-commit:
 check-dependencies:
     cargo deny check bans licenses sources
 
+# Check that a lint crate's view of whisker-rust builds without the provider
+check-features:
+    cargo check -p whisker-rust --no-default-features
+
 # Format JSON files
 format-json fix="false": (prettier fix "{json,json5}")
 


### PR DESCRIPTION
The whisker-rust crate serves two audiences with very different needs. The CLI needs the decoration provider, which drags in the entire rust-analyzer stack. Lint crates need only the generated trait, the adapter, and the decoration types, none of which touch rust-analyzer at all.

Previously both audiences paid for rust-analyzer. This puts the provider behind a default-on `provider` feature, so a lint crate that depends on whisker-rust with default features disabled compiles in seconds rather than minutes. That matters for the custom lint plugins later in this stack, which whisker compiles on the user's machine at check time.

Nothing changes for the CLI or for existing lint crates, which keep default features. The provider's own tests move behind the same gate.

CI now covers the feature-off build too. Both Rust recipes force `--all-features`, so nothing was compiling the view a lint plugin gets; a `check-features` recipe runs `cargo check -p whisker-rust --no-default-features`, which CI enumerates like every other recipe. Lib-only on purpose: whisker-rust's dev-dependencies close a cycle back to whisker-rust with default features, so `--all-targets` would unify the provider straight back on and the check would prove nothing.

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>

