### PR TITLE
Define the plugin declaration and handshake vocabulary

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2039,6 +2039,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustc_version"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cfcb3a22ef46e85b45de6ee7e79d063319ebb6594faafcf1c225ea92ab6e9b92"
+dependencies = [
+ "semver",
+]
+
+[[package]]
 name = "rustix"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2841,6 +2850,7 @@ dependencies = [
  "proptest",
  "serde",
  "serde_json",
+ "tempfile",
 ]
 
 [[package]]
@@ -2916,8 +2926,10 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "proptest",
+ "rustc_version",
  "tree-sitter",
  "tree-sitter-rust",
+ "whisker-codegen",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,6 +45,10 @@ ra_ap_syntax = "0.0.348"
 ra_ap_vfs = "0.0.348"
 proc-macro2 = "1"
 quote = "1"
+# Read by build scripts to bake the compiler's identity into the plugin
+# handshake: whisker refuses to load a custom lint plugin built by a
+# different rustc, because Rust's ABI is only coherent within one compiler.
+rustc_version = "0.4"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 syn = { version = "3", features = ["full", "extra-traits"] }

--- a/crates/whisker-codegen/Cargo.toml
+++ b/crates/whisker-codegen/Cargo.toml
@@ -11,6 +11,7 @@ serde_json.workspace = true
 
 [dev-dependencies]
 proptest.workspace = true
+tempfile.workspace = true
 
 [lints]
 workspace = true

--- a/crates/whisker-codegen/src/fingerprint.rs
+++ b/crates/whisker-codegen/src/fingerprint.rs
@@ -1,0 +1,257 @@
+use std::fmt;
+use std::fs;
+use std::io;
+use std::path::Path;
+
+const FNV_OFFSET_BASIS: u64 = 0xcbf2_9ce4_8422_2325;
+const FNV_PRIME: u64 = 0x0000_0100_0000_01b3;
+
+/// An order-sensitive hash of the inputs that shape a compiled crate
+///
+/// The build scripts of whisker-types and whisker-rust bake one of these
+/// into each crate, and the custom lint plugin loader compares the plugin's
+/// values against its own. The crate version cannot serve that comparison:
+/// whisker's crates are unpublished and keep one version number between
+/// releases, so two builds of the same version can compile different
+/// source. The fingerprint detects that drift; it is not a security
+/// measure, so an unkeyed 64-bit FNV-1a suffices and avoids pulling a
+/// cryptography dependency into every build script.
+///
+/// Files enter the hash in sorted path order, with paths relative to the
+/// added directory and `/` separators, so the fingerprint is identical
+/// wherever the crate is checked out and on every platform. Every name
+/// and every file's contents enter as their own run, carrying their
+/// length, so no two trees whose bytes merely fall differently across
+/// names and files can hash alike.
+///
+/// # Examples
+///
+/// ```
+/// use whisker_codegen::Fingerprint;
+///
+/// let mut fingerprint = Fingerprint::new();
+/// fingerprint.add_bytes(b"generated code");
+///
+/// assert_eq!(fingerprint.to_string().len(), 16);
+/// ```
+#[derive(Copy, Clone, Eq, PartialEq, Hash, Debug)]
+pub struct Fingerprint(u64);
+
+impl Fingerprint {
+    /// Creates a fingerprint of nothing
+    pub fn new() -> Self {
+        Self(FNV_OFFSET_BASIS)
+    }
+
+    /// Folds every file under `root` into the fingerprint
+    ///
+    /// Every file counts, whatever its extension: a file that turns out
+    /// not to influence the build only makes the comparison stricter, and
+    /// a stray mismatch is a refusal the user can see, while a missed one
+    /// is undefined behavior nobody can.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`io::Error`] if a directory or file under `root` cannot be
+    /// read.
+    pub fn add_directory(&mut self, root: &Path) -> io::Result<()> {
+        let mut files = Vec::new();
+        collect_files(root, root, &mut files)?;
+        files.sort();
+
+        for (name, contents) in files {
+            self.add_bytes(name.as_bytes());
+            self.add_bytes(&contents);
+        }
+
+        Ok(())
+    }
+
+    /// Folds one run of bytes into the fingerprint
+    ///
+    /// This is how generated code, which lives outside the source tree,
+    /// joins the hash.
+    ///
+    /// The run's length enters the hash ahead of its content, so a call
+    /// never folds to the state some other split of the same bytes would
+    /// reach: without that, a file named `a` holding `bc` and a file named
+    /// `ab` holding `c` would be one byte stream and one fingerprint.
+    pub fn add_bytes(&mut self, bytes: &[u8]) {
+        self.fold(&(bytes.len() as u64).to_le_bytes());
+        self.fold(bytes);
+    }
+
+    /// Folds bytes into the hash as they are
+    fn fold(&mut self, bytes: &[u8]) {
+        for byte in bytes {
+            self.0 ^= u64::from(*byte);
+            self.0 = self.0.wrapping_mul(FNV_PRIME);
+        }
+    }
+}
+
+impl Default for Fingerprint {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl fmt::Display for Fingerprint {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{:016x}", self.0)
+    }
+}
+
+/// Gathers `(relative path, contents)` pairs for the files under `dir`
+fn collect_files(root: &Path, dir: &Path, files: &mut Vec<(String, Vec<u8>)>) -> io::Result<()> {
+    for entry in fs::read_dir(dir)? {
+        let path = entry?.path();
+
+        if path.is_dir() {
+            collect_files(root, &path, files)?;
+            continue;
+        }
+
+        let relative = path
+            .strip_prefix(root)
+            .expect("collected paths should sit under the root")
+            .components()
+            .map(|component| component.as_os_str().to_string_lossy())
+            .collect::<Vec<_>>()
+            .join("/");
+
+        files.push((relative, fs::read(&path)?));
+    }
+
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use std::fs;
+
+    use super::*;
+
+    fn fingerprint_of(dir: &Path) -> String {
+        let mut fingerprint = Fingerprint::new();
+        fingerprint
+            .add_directory(dir)
+            .expect("should hash the directory");
+        fingerprint.to_string()
+    }
+
+    #[test]
+    fn add_bytes_changes_the_fingerprint() {
+        let empty = Fingerprint::new();
+        let mut fed = Fingerprint::new();
+
+        fed.add_bytes(b"generated code");
+
+        assert_ne!(empty, fed);
+    }
+
+    #[test]
+    fn add_bytes_frames_each_run() {
+        let mut split = Fingerprint::new();
+        let mut whole = Fingerprint::new();
+
+        split.add_bytes(b"ab");
+        split.add_bytes(b"c");
+        whole.add_bytes(b"abc");
+
+        assert_ne!(split, whole);
+    }
+
+    #[test]
+    fn add_directory_is_insensitive_to_creation_order() {
+        let first = tempfile::tempdir().expect("should create a directory");
+        fs::write(first.path().join("a.rs"), "a").expect("should write");
+        fs::write(first.path().join("b.rs"), "b").expect("should write");
+        let second = tempfile::tempdir().expect("should create a directory");
+        fs::write(second.path().join("b.rs"), "b").expect("should write");
+        fs::write(second.path().join("a.rs"), "a").expect("should write");
+
+        assert_eq!(fingerprint_of(first.path()), fingerprint_of(second.path()));
+    }
+
+    #[test]
+    fn add_directory_keeps_names_and_contents_apart() {
+        let first = tempfile::tempdir().expect("should create a directory");
+        fs::write(first.path().join("a"), "bc").expect("should write");
+        let second = tempfile::tempdir().expect("should create a directory");
+        fs::write(second.path().join("ab"), "c").expect("should write");
+
+        assert_ne!(fingerprint_of(first.path()), fingerprint_of(second.path()));
+    }
+
+    #[test]
+    fn add_directory_missing_root_returns_error() {
+        let dir = tempfile::tempdir().expect("should create a directory");
+        let missing = dir.path().join("absent");
+        let mut fingerprint = Fingerprint::new();
+
+        let error = fingerprint
+            .add_directory(&missing)
+            .expect_err("should fail");
+
+        assert_eq!(error.kind(), io::ErrorKind::NotFound);
+    }
+
+    #[test]
+    fn add_directory_sees_nested_files() {
+        let flat = tempfile::tempdir().expect("should create a directory");
+        fs::write(flat.path().join("a.rs"), "a").expect("should write");
+        let nested = tempfile::tempdir().expect("should create a directory");
+        fs::create_dir(nested.path().join("sub")).expect("should create");
+        fs::write(nested.path().join("a.rs"), "a").expect("should write");
+        fs::write(nested.path().join("sub").join("b.rs"), "b").expect("should write");
+
+        assert_ne!(fingerprint_of(flat.path()), fingerprint_of(nested.path()));
+    }
+
+    #[test]
+    fn different_contents_produce_different_fingerprints() {
+        let first = tempfile::tempdir().expect("should create a directory");
+        fs::write(first.path().join("a.rs"), "a").expect("should write");
+        let second = tempfile::tempdir().expect("should create a directory");
+        fs::write(second.path().join("a.rs"), "changed").expect("should write");
+
+        assert_ne!(fingerprint_of(first.path()), fingerprint_of(second.path()));
+    }
+
+    #[test]
+    fn display_renders_sixteen_hex_digits() {
+        let fingerprint = Fingerprint::new();
+
+        let rendered = fingerprint.to_string();
+
+        assert_eq!(rendered.len(), 16);
+        assert!(rendered.chars().all(|c| c.is_ascii_hexdigit()));
+    }
+
+    #[test]
+    fn same_directory_fingerprints_identically() {
+        let dir = tempfile::tempdir().expect("should create a directory");
+        fs::write(dir.path().join("a.rs"), "a").expect("should write");
+
+        assert_eq!(fingerprint_of(dir.path()), fingerprint_of(dir.path()));
+    }
+
+    #[test]
+    fn trait_send() {
+        fn assert_send<T: Send>() {}
+        assert_send::<Fingerprint>();
+    }
+
+    #[test]
+    fn trait_sync() {
+        fn assert_sync<T: Sync>() {}
+        assert_sync::<Fingerprint>();
+    }
+
+    #[test]
+    fn trait_unpin() {
+        fn assert_unpin<T: Unpin>() {}
+        assert_unpin::<Fingerprint>();
+    }
+}

--- a/crates/whisker-codegen/src/lib.rs
+++ b/crates/whisker-codegen/src/lib.rs
@@ -1,3 +1,5 @@
+mod fingerprint;
 mod visitor;
 
+pub use fingerprint::Fingerprint;
 pub use visitor::generate_visitor;

--- a/crates/whisker-types/Cargo.toml
+++ b/crates/whisker-types/Cargo.toml
@@ -13,5 +13,9 @@ tree-sitter.workspace = true
 proptest.workspace = true
 tree-sitter-rust.workspace = true
 
+[build-dependencies]
+rustc_version.workspace = true
+whisker-codegen.workspace = true
+
 [lints]
 workspace = true

--- a/crates/whisker-types/build.rs
+++ b/crates/whisker-types/build.rs
@@ -1,0 +1,29 @@
+use std::path::Path;
+
+use whisker_codegen::Fingerprint;
+
+/// Bakes the compiler's identity and a source fingerprint into the crate
+///
+/// Both values feed the custom lint plugin handshake. Rust has no stable
+/// ABI, so whisker only loads a plugin whose whisker-types was compiled by
+/// the same rustc from the same source as its own. The crate version cannot
+/// stand in for the source: every whisker crate is unpublished and stays at
+/// one version between releases, so two builds of "0.1.0" can differ. The
+/// fingerprint detects drift; it is not a security measure.
+fn main() {
+    println!("cargo::rerun-if-changed=src");
+
+    let version = rustc_version::version_meta().expect("failed to read the rustc version");
+    println!(
+        "cargo::rustc-env=WHISKER_RUSTC_VERSION={}",
+        version.short_version_string
+    );
+
+    let manifest_dir =
+        std::env::var("CARGO_MANIFEST_DIR").expect("cargo should set CARGO_MANIFEST_DIR");
+    let mut fingerprint = Fingerprint::new();
+    fingerprint
+        .add_directory(&Path::new(&manifest_dir).join("src"))
+        .expect("failed to read the crate sources");
+    println!("cargo::rustc-env=WHISKER_TYPES_FINGERPRINT={fingerprint}");
+}

--- a/crates/whisker-types/src/lib.rs
+++ b/crates/whisker-types/src/lib.rs
@@ -10,6 +10,7 @@ mod diagnostic;
 mod language;
 mod lint_pass;
 mod location;
+pub mod plugin;
 mod provider_name;
 mod rule_id;
 mod severity;

--- a/crates/whisker-types/src/plugin.rs
+++ b/crates/whisker-types/src/plugin.rs
@@ -1,0 +1,128 @@
+//! Vocabulary for custom lint plugins
+//!
+//! A custom lint plugin is a dynamic library that whisker compiles and
+//! loads at check time, given only a path. Rust has no stable ABI, so a
+//! loaded library is only coherent with the whisker binary when both were
+//! compiled by the same rustc from the same source for every type that
+//! crosses the boundary. This module defines the declaration a plugin
+//! exports and the constants whisker compares to establish exactly that
+//! before it trusts anything else in the library.
+//!
+//! The handshake proceeds in order of decreasing layout stability:
+//!
+//! 1. [`PluginDeclaration::abi_version`] sits first in a `#[repr(C)]`
+//!    struct, so it reads correctly whatever else changed.
+//! 2. The version and fingerprint fields are C strings, readable across
+//!    any pair of rustc versions.
+//! 3. Only when every one of them matches the host's own constants may
+//!    [`PluginDeclaration::register`] be called, because a plain Rust
+//!    function pointer is only meaningful once the two images are known to
+//!    agree on the language's ABI.
+//!
+//! A plugin must not set its own `#[global_allocator]`: the host frees the
+//! values a plugin allocated (diagnostics, boxed passes), which is sound
+//! because both images default to the system allocator.
+//!
+//! The handshake reaches the whisker source both sides compiled, not the
+//! dependency graph each side resolved. A plugin's lockfile picks its own
+//! `tree-sitter`, whose `Node` is a `#[repr(transparent)]` wrapper around
+//! a `#[repr(C)]` struct of the C library, so a patch-level difference
+//! moves no field. It does give each image its own copy of that C
+//! library, and a plugin reads a tree the host parsed through its copy.
+//! Whisker accepts that residual risk rather than pinning every resolved
+//! version a plugin may build against.
+
+use std::ffi::CStr;
+
+mod declaration;
+mod registrar;
+
+pub use declaration::PluginDeclaration;
+pub use registrar::LintRegistrar;
+
+/// The version of the plugin declaration protocol itself
+///
+/// This guards the shape of [`PluginDeclaration`] and the meaning of its
+/// fields, not the ABI of the lint passes; the version and fingerprint
+/// strings guard those. Bump it whenever the declaration struct or the
+/// registration contract changes.
+///
+/// # Examples
+///
+/// ```
+/// use whisker_types::plugin::ABI_VERSION;
+///
+/// assert_eq!(ABI_VERSION, 1);
+/// ```
+pub const ABI_VERSION: u32 = 1;
+
+/// The full identity of the rustc that compiled this crate
+///
+/// The plugin loader compares the plugin's copy against the host's. The
+/// string carries the commit hash and date, so two nightlies of the same
+/// semantic version do not pass for one another.
+///
+/// # Examples
+///
+/// ```
+/// use whisker_types::plugin::RUSTC_VERSION;
+///
+/// let version = RUSTC_VERSION.to_str().expect("should be UTF-8");
+///
+/// assert!(version.starts_with("rustc"));
+/// ```
+pub const RUSTC_VERSION: &CStr = c_str(concat!(env!("WHISKER_RUSTC_VERSION"), "\0"));
+
+/// A fingerprint of the whisker-types source this crate was compiled from
+///
+/// The crate version cannot detect drift, because whisker's crates are
+/// unpublished and hold one version between releases. The build script
+/// hashes every source file instead, so a plugin built against a different
+/// revision of whisker-types is refused rather than trusted to share
+/// layouts it may not share.
+///
+/// # Examples
+///
+/// ```
+/// use whisker_types::plugin::TYPES_FINGERPRINT;
+///
+/// let fingerprint = TYPES_FINGERPRINT.to_str().expect("should be UTF-8");
+///
+/// assert_eq!(fingerprint.len(), 16);
+/// ```
+pub const TYPES_FINGERPRINT: &CStr = c_str(concat!(env!("WHISKER_TYPES_FINGERPRINT"), "\0"));
+
+/// Converts a NUL-terminated string literal into a [`&CStr`] at compile time
+///
+/// # Panics
+///
+/// Panics at compile time if `text` contains an interior NUL byte or does
+/// not end with one.
+///
+/// [`&CStr`]: std::ffi::CStr
+const fn c_str(text: &'static str) -> &'static CStr {
+    match CStr::from_bytes_with_nul(text.as_bytes()) {
+        Ok(text) => text,
+        Err(_) => panic!("the string must end with exactly one NUL byte"),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn rustc_version_names_the_compiler() {
+        let version = RUSTC_VERSION.to_str().expect("should be UTF-8");
+
+        assert!(version.starts_with("rustc"), "unexpected: {version}");
+    }
+
+    #[test]
+    fn types_fingerprint_is_a_64_bit_hex_string() {
+        let fingerprint = TYPES_FINGERPRINT.to_str().expect("should be UTF-8");
+
+        assert_eq!(fingerprint.len(), 16);
+        assert!(fingerprint.chars().all(|c| c.is_ascii_hexdigit()));
+    }
+}

--- a/crates/whisker-types/src/plugin/declaration.rs
+++ b/crates/whisker-types/src/plugin/declaration.rs
@@ -1,0 +1,97 @@
+use std::ffi::c_char;
+
+use crate::plugin::LintRegistrar;
+
+/// The entry point a custom lint plugin exports
+///
+/// A plugin exports exactly one static of this type under the symbol name
+/// `whisker_plugin_declaration`; the `export_lints!` macro in whisker-rust
+/// writes it. The loader reads the fields in declaration order and stops at
+/// the first mismatch, because each field's readability rests on
+/// progressively stronger assumptions:
+///
+/// - [`abi_version`] is a bare integer at offset zero of a `#[repr(C)]`
+///   struct, readable whatever else changed.
+/// - The version and fingerprint fields are pointers to NUL-terminated
+///   strings in the plugin's immutable data, readable across rustc
+///   versions. They are raw pointers rather than `&CStr`, because a
+///   reference's layout is only promised within one compiler.
+/// - [`register`] is a plain Rust function pointer. Calling it hands
+///   `&mut dyn` trait objects across the boundary, which is only sound
+///   once every prior field proved that both images agree on the ABI.
+///
+/// The fields are public rather than accessed through getters, because
+/// this struct is a wire format: the exporting macro constructs it in a
+/// `const` context and the loader consumes it field by field.
+///
+/// `Send` and `Sync` are implemented by hand, because the string fields
+/// make the type `!Sync` by default; they are sound because every field
+/// points at immutable `'static` data in the plugin image.
+///
+/// [`abi_version`]: PluginDeclaration::abi_version
+/// [`register`]: PluginDeclaration::register
+#[repr(C)]
+pub struct PluginDeclaration {
+    /// The plugin's copy of [`ABI_VERSION`]
+    ///
+    /// [`ABI_VERSION`]: crate::plugin::ABI_VERSION
+    pub abi_version: u32,
+
+    /// The plugin's copy of [`RUSTC_VERSION`]
+    ///
+    /// [`RUSTC_VERSION`]: crate::plugin::RUSTC_VERSION
+    pub rustc_version: *const c_char,
+
+    /// The plugin's copy of [`TYPES_FINGERPRINT`]
+    ///
+    /// [`TYPES_FINGERPRINT`]: crate::plugin::TYPES_FINGERPRINT
+    pub types_fingerprint: *const c_char,
+
+    /// The plugin's fingerprint of the language crate it was built against
+    ///
+    /// For Rust lints this is whisker-rust's fingerprint, which also covers
+    /// the lint pass trait generated from the grammar's node types. A
+    /// plugin whose dispatch was generated from a different grammar would
+    /// not crash, but its checks would quietly never fire; the handshake
+    /// turns that into a refusal.
+    pub language_fingerprint: *const c_char,
+
+    /// Registers the plugin's lint passes with the host
+    ///
+    /// The host calls this once, after the handshake, with a registrar
+    /// that collects one factory per lint.
+    pub register: fn(&mut dyn LintRegistrar),
+}
+
+unsafe impl Send for PluginDeclaration {}
+unsafe impl Sync for PluginDeclaration {}
+
+#[cfg(test)]
+mod tests {
+    use std::mem::offset_of;
+
+    use super::*;
+
+    #[test]
+    fn abi_version_sits_at_offset_zero() {
+        assert_eq!(offset_of!(PluginDeclaration, abi_version), 0);
+    }
+
+    #[test]
+    fn trait_send() {
+        fn assert_send<T: Send>() {}
+        assert_send::<PluginDeclaration>();
+    }
+
+    #[test]
+    fn trait_sync() {
+        fn assert_sync<T: Sync>() {}
+        assert_sync::<PluginDeclaration>();
+    }
+
+    #[test]
+    fn trait_unpin() {
+        fn assert_unpin<T: Unpin>() {}
+        assert_unpin::<PluginDeclaration>();
+    }
+}

--- a/crates/whisker-types/src/plugin/registrar.rs
+++ b/crates/whisker-types/src/plugin/registrar.rs
@@ -1,0 +1,55 @@
+use crate::LintPass;
+
+/// Collects the lint passes a custom lint plugin exports
+///
+/// The host hands an implementation to [`PluginDeclaration::register`],
+/// and the plugin calls [`register`] once per lint. A plugin registers a
+/// factory rather than a pass, because passes are stateful and the check
+/// command constructs a fresh set for every file; the CLI's pass list
+/// gives the built-in lints that same per-file construction. A plain
+/// function pointer suffices, because a lint is a unit struct
+/// the factory constructs from nothing, and it keeps captured state out of
+/// the plugin boundary.
+///
+/// [`PluginDeclaration::register`]: crate::plugin::PluginDeclaration::register
+/// [`register`]: LintRegistrar::register
+pub trait LintRegistrar {
+    /// Registers one lint pass factory
+    fn register(&mut self, factory: fn() -> Box<dyn LintPass>);
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{DecoratedNode, Diagnostic};
+
+    struct Collecting {
+        factories: Vec<fn() -> Box<dyn LintPass>>,
+    }
+
+    impl LintRegistrar for Collecting {
+        fn register(&mut self, factory: fn() -> Box<dyn LintPass>) {
+            self.factories.push(factory);
+        }
+    }
+
+    struct Quiet;
+
+    impl LintPass for Quiet {
+        fn check_node(&mut self, _node: &DecoratedNode<'_>) -> Vec<Diagnostic> {
+            Vec::new()
+        }
+    }
+
+    #[test]
+    fn register_collects_working_factories() {
+        let mut registrar = Collecting {
+            factories: Vec::new(),
+        };
+
+        registrar.register(|| Box::new(Quiet));
+
+        assert_eq!(registrar.factories.len(), 1);
+        let _pass = registrar.factories[0]();
+    }
+}


### PR DESCRIPTION
Custom lint plugins are dynamic libraries, and Rust has no stable ABI: a loaded library is only coherent with the whisker binary when the same rustc compiled both from the same source. This gives whisker-types the vocabulary to establish exactly that, before anything in a plugin is trusted.

A plugin exports one `PluginDeclaration`, a `repr(C)` struct whose fields read in order of decreasing layout stability. An integer protocol version sits at offset zero, readable whatever else changed. Then come C strings naming the compiler and fingerprinting the source, readable across rustc versions. Only when all of them match the host's own constants may the Rust function pointer that registers the lints be called.

The fingerprints come from a new build script that hashes the crate's sources, because whisker's crates are unpublished and keep one version number between releases, so the version alone cannot detect drift. Every name and every file's contents enter the hash carrying their length, so no rearrangement of the same bytes across files can produce the same fingerprint. The same script records the full rustc version string, commit hash included, so two nightlies of one semantic version do not pass for one another.

Nothing loads plugins yet; this is the shared vocabulary the next two PRs build on.

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>

