### PR TITLE
Let a lint crate export its passes as a plugin

### DIFF
--- a/crates/whisker-codegen/src/visitor.rs
+++ b/crates/whisker-codegen/src/visitor.rs
@@ -43,7 +43,7 @@ struct SubtypeRef {
 /// ```
 /// let json = r#"[{"type": "source_file", "named": true}]"#;
 /// let code = whisker_codegen::generate_visitor(json, "Rust").unwrap();
-/// assert!(code.contains("trait RustLintPass"));
+/// assert!(code.contains("trait RustLintPass: Send + Sync"));
 /// assert!(code.contains("fn check_source_file"));
 /// ```
 pub fn generate_visitor(
@@ -73,7 +73,11 @@ pub fn generate_visitor(
          /// Generated from the {language} tree-sitter grammar's `node-types.json`.\n\
          /// Each method corresponds to a named node type in the grammar and\n\
          /// defaults to returning no diagnostics.\n\
-         pub trait {trait_name} {{\n"
+         ///\n\
+         /// `Send + Sync` comes from `LintPass`, which every pass reaches the\n\
+         /// pipeline as. Requiring it here reports a pass that cannot cross\n\
+         /// threads at the pass, rather than where it is wrapped.\n\
+         pub trait {trait_name}: Send + Sync {{\n"
     ));
 
     for node in &concrete_nodes {
@@ -223,7 +227,7 @@ mod tests {
     fn generate_visitor_with_minimal_json_produces_trait() {
         let code = generate_visitor(MINIMAL_JSON, "Rust").expect("should parse");
 
-        assert!(code.contains("pub trait RustLintPass {"));
+        assert!(code.contains("pub trait RustLintPass: Send + Sync {"));
         assert!(code.contains("fn check_source_file("));
         assert!(code.contains("fn check_function_item("));
     }
@@ -324,7 +328,7 @@ mod tests {
     fn generate_visitor_with_different_language_changes_name() {
         let code = generate_visitor(MINIMAL_JSON, "Python").expect("should parse");
 
-        assert!(code.contains("pub trait PythonLintPass {"));
+        assert!(code.contains("pub trait PythonLintPass: Send + Sync {"));
         assert!(!code.contains("RustLintPass"));
     }
 

--- a/crates/whisker-rust/build.rs
+++ b/crates/whisker-rust/build.rs
@@ -2,6 +2,15 @@ use std::env;
 use std::fs;
 use std::path::Path;
 
+use whisker_codegen::Fingerprint;
+
+/// Generates the lint pass trait and fingerprints the crate for plugins
+///
+/// The fingerprint covers the sources and the generated code, and joins
+/// the custom lint plugin handshake as the language fingerprint. Hashing
+/// the generated trait matters: a plugin whose dispatch was generated from
+/// a different grammar would not crash, its checks would just quietly
+/// never fire, and the handshake turns that into a visible refusal.
 fn main() {
     let node_types_json = include_str!(concat!(env!("CARGO_MANIFEST_DIR"), "/src/node-types.json"));
 
@@ -10,7 +19,15 @@ fn main() {
 
     let out_dir = env::var("OUT_DIR").expect("OUT_DIR not set");
     let dest = Path::new(&out_dir).join("rust_lint_pass.rs");
-    fs::write(&dest, code).expect("failed to write generated visitor");
+    fs::write(&dest, &code).expect("failed to write generated visitor");
 
-    println!("cargo::rerun-if-changed=src/node-types.json");
+    println!("cargo::rerun-if-changed=src");
+
+    let manifest_dir = env::var("CARGO_MANIFEST_DIR").expect("cargo should set CARGO_MANIFEST_DIR");
+    let mut fingerprint = Fingerprint::new();
+    fingerprint
+        .add_directory(&Path::new(&manifest_dir).join("src"))
+        .expect("failed to read the crate sources");
+    fingerprint.add_bytes(code.as_bytes());
+    println!("cargo::rustc-env=WHISKER_RUST_FINGERPRINT={fingerprint}");
 }

--- a/crates/whisker-rust/src/adapter.rs
+++ b/crates/whisker-rust/src/adapter.rs
@@ -34,7 +34,7 @@ impl<P: RustLintPass> RustLintPassAdapter<P> {
     }
 }
 
-impl<P: RustLintPass + Send + Sync> LintPass for RustLintPassAdapter<P> {
+impl<P: RustLintPass> LintPass for RustLintPassAdapter<P> {
     fn check_node(&mut self, node: &DecoratedNode<'_>) -> Vec<Diagnostic> {
         dispatch(&mut self.inner, node)
     }

--- a/crates/whisker-rust/src/export_lints.rs
+++ b/crates/whisker-rust/src/export_lints.rs
@@ -1,0 +1,126 @@
+/// Exports Rust lint passes as a custom lint plugin
+///
+/// Invoke this once, at the crate root of a `cdylib` lint crate, with one
+/// expression per lint. Each expression must construct a type implementing
+/// [`RustLintPass`]:
+///
+/// ```ignore
+/// whisker_rust::export_lints![NoTodo, PreferExpect];
+/// ```
+///
+/// The macro writes the `whisker_plugin_declaration` static that whisker's
+/// loader looks up, filling in the handshake constants of the whisker
+/// crates this plugin was compiled against. Each lint is registered as a
+/// factory, because passes are stateful and the check command constructs a
+/// fresh set for every file. The factories are plain function pointers, so
+/// each expression must construct its lint from nothing; an expression
+/// that captures its surroundings does not compile.
+///
+/// [`RustLintPass`]: crate::RustLintPass
+#[macro_export]
+macro_rules! export_lints {
+    ($($lint:expr),+ $(,)?) => {
+        #[unsafe(no_mangle)]
+        #[allow(non_upper_case_globals)]
+        pub static whisker_plugin_declaration: $crate::plugin::PluginDeclaration =
+            $crate::plugin::PluginDeclaration {
+                abi_version: $crate::plugin::ABI_VERSION,
+                rustc_version: $crate::plugin::RUSTC_VERSION.as_ptr(),
+                types_fingerprint: $crate::plugin::TYPES_FINGERPRINT.as_ptr(),
+                language_fingerprint: $crate::plugin::LANGUAGE_FINGERPRINT.as_ptr(),
+                register: __whisker_register,
+            };
+
+        #[doc(hidden)]
+        fn __whisker_register(registrar: &mut dyn $crate::plugin::LintRegistrar) {
+            $(
+                registrar.register(|| {
+                    ::std::boxed::Box::new($crate::RustLintPassAdapter::new($lint))
+                });
+            )+
+        }
+    };
+}
+
+#[cfg(test)]
+mod tests {
+    use std::ffi::CStr;
+    use std::path::PathBuf;
+
+    use whisker_types::plugin::LintRegistrar;
+    use whisker_types::{DecoratedNode, DecoratedTree, Diagnostic, LintPass, RuleId, Severity};
+
+    use crate::RustLintPass;
+    use crate::plugin;
+
+    struct FlagEveryFunction;
+
+    impl RustLintPass for FlagEveryFunction {
+        fn check_function_item(&mut self, node: &DecoratedNode<'_>) -> Vec<Diagnostic> {
+            vec![Diagnostic::new(
+                RuleId("test.flag-every-function"),
+                Severity::Warn,
+                "found a function".into(),
+                node.span(),
+            )]
+        }
+    }
+
+    struct QuietLint;
+
+    impl RustLintPass for QuietLint {}
+
+    export_lints![FlagEveryFunction, QuietLint];
+
+    struct Collecting {
+        factories: Vec<fn() -> Box<dyn LintPass>>,
+    }
+
+    impl LintRegistrar for Collecting {
+        fn register(&mut self, factory: fn() -> Box<dyn LintPass>) {
+            self.factories.push(factory);
+        }
+    }
+
+    fn collected() -> Vec<fn() -> Box<dyn LintPass>> {
+        let mut registrar = Collecting {
+            factories: Vec::new(),
+        };
+        (whisker_plugin_declaration.register)(&mut registrar);
+        registrar.factories
+    }
+
+    #[test]
+    fn declaration_carries_the_handshake_constants() {
+        assert_eq!(whisker_plugin_declaration.abi_version, plugin::ABI_VERSION);
+
+        let rustc_version = unsafe { CStr::from_ptr(whisker_plugin_declaration.rustc_version) };
+        assert_eq!(rustc_version, plugin::RUSTC_VERSION);
+
+        let types = unsafe { CStr::from_ptr(whisker_plugin_declaration.types_fingerprint) };
+        assert_eq!(types, plugin::TYPES_FINGERPRINT);
+
+        let language = unsafe { CStr::from_ptr(whisker_plugin_declaration.language_fingerprint) };
+        assert_eq!(language, plugin::LANGUAGE_FINGERPRINT);
+    }
+
+    #[test]
+    fn register_yields_one_factory_per_lint() {
+        assert_eq!(collected().len(), 2);
+    }
+
+    #[test]
+    fn registered_factories_build_working_passes() {
+        let mut parser = tree_sitter::Parser::new();
+        parser.set_language(&crate::language()).unwrap();
+        let tree = parser.parse("fn main() {}", None).unwrap();
+        let tree = DecoratedTree::new(tree, "fn main() {}".into(), PathBuf::from("test.rs"));
+        let function = tree.root_node().named_child(0).expect("should parse a fn");
+
+        let mut pass = collected()[0]();
+        let diagnostics = pass.check_node(&function);
+
+        assert_eq!(diagnostics.len(), 1);
+        assert_eq!(diagnostics[0].rule_id(), RuleId("test.flag-every-function"));
+    }
+}

--- a/crates/whisker-rust/src/lib.rs
+++ b/crates/whisker-rust/src/lib.rs
@@ -1,5 +1,7 @@
 mod adapter;
 pub mod decorations;
+mod export_lints;
+pub mod plugin;
 #[cfg(feature = "provider")]
 mod provider;
 

--- a/crates/whisker-rust/src/plugin.rs
+++ b/crates/whisker-rust/src/plugin.rs
@@ -1,0 +1,48 @@
+//! What a Rust custom lint plugin needs to declare itself
+//!
+//! This module re-exports the plugin vocabulary from whisker-types and adds
+//! the one value only this crate can supply: the fingerprint of the Rust
+//! language support a plugin was built against. A plugin crate depends on
+//! whisker-rust, implements [`RustLintPass`] for its rules, and hands them
+//! to [`export_lints!`], which writes the exported declaration; nothing
+//! here needs to be touched by hand.
+//!
+//! [`RustLintPass`]: crate::RustLintPass
+//! [`export_lints!`]: crate::export_lints
+
+use std::ffi::CStr;
+
+pub use whisker_types::plugin::{
+    ABI_VERSION, LintRegistrar, PluginDeclaration, RUSTC_VERSION, TYPES_FINGERPRINT, c_str,
+};
+
+/// A fingerprint of the whisker-rust source this crate was compiled from
+///
+/// The hash covers the crate's sources, the grammar's node types, and the
+/// generated lint pass trait, so a plugin built against different Rust
+/// language support is refused at load rather than dispatched into
+/// methods that no longer line up with the tree.
+///
+/// # Examples
+///
+/// ```
+/// use whisker_rust::plugin::LANGUAGE_FINGERPRINT;
+///
+/// let fingerprint = LANGUAGE_FINGERPRINT.to_str().expect("should be UTF-8");
+///
+/// assert_eq!(fingerprint.len(), 16);
+/// ```
+pub const LANGUAGE_FINGERPRINT: &CStr = c_str(concat!(env!("WHISKER_RUST_FINGERPRINT"), "\0"));
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn language_fingerprint_is_a_64_bit_hex_string() {
+        let fingerprint = LANGUAGE_FINGERPRINT.to_str().expect("should be UTF-8");
+
+        assert_eq!(fingerprint.len(), 16);
+        assert!(fingerprint.chars().all(|c| c.is_ascii_hexdigit()));
+    }
+}

--- a/crates/whisker-types/src/plugin.rs
+++ b/crates/whisker-types/src/plugin.rs
@@ -94,13 +94,25 @@ pub const TYPES_FINGERPRINT: &CStr = c_str(concat!(env!("WHISKER_TYPES_FINGERPRI
 
 /// Converts a NUL-terminated string literal into a [`&CStr`] at compile time
 ///
+/// Language crates use this for their own handshake constants, the way
+/// [`LANGUAGE_FINGERPRINT`] in whisker-rust does.
+///
 /// # Panics
 ///
 /// Panics at compile time if `text` contains an interior NUL byte or does
 /// not end with one.
 ///
+/// # Examples
+///
+/// ```
+/// use whisker_types::plugin::c_str;
+///
+/// const GREETING: &std::ffi::CStr = c_str("hello\0");
+/// ```
+///
 /// [`&CStr`]: std::ffi::CStr
-const fn c_str(text: &'static str) -> &'static CStr {
+/// [`LANGUAGE_FINGERPRINT`]: PluginDeclaration::language_fingerprint
+pub const fn c_str(text: &'static str) -> &'static CStr {
     match CStr::from_bytes_with_nul(text.as_bytes()) {
         Ok(text) => text,
         Err(_) => panic!("the string must end with exactly one NUL byte"),


### PR DESCRIPTION
A custom lint crate implements `RustLintPass` exactly the way a built-in lint does. What it cannot do is appear in the CLI's hardcoded pass list. This gives it the other route: `export_lints!` writes the `whisker_plugin_declaration` static that whisker's loader looks up, filled with the handshake constants of the whisker crates the plugin was compiled against.

whisker-rust contributes the language fingerprint to that handshake. Its build script hashes the crate's sources together with the lint pass trait generated from the grammar's node types, because a plugin whose dispatch was generated from a different grammar would not crash — its checks would just quietly never fire. The fingerprinting logic moved into whisker-codegen, which both build scripts already reach.

Lints register as plain function pointer factories rather than as passes. Passes are stateful and the check command constructs a fresh set for every file, so a plugin hands over per-file construction. An expression that captures its surroundings does not coerce to a function pointer and fails to compile, which is the failure worth having.

The generated lint pass trait now requires `Send + Sync`, which `LintPass` has always required of anything the pipeline runs. The adapter used to carry that bound instead, so a lint holding an `Rc` compiled until a factory tried to box it and the error landed inside the macro rather than on the lint.

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>

