### PR TITLE
Load custom lints from a path in whisker check

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -886,6 +886,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b5b646652bf6661599e1da8901b3b9522896f01e736bad5f723fe7a3a27f899d"
 
 [[package]]
+name = "libloading"
+version = "0.8.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7c4b02199fee7c5d21a5ae7d8cfa79a6ef5bb2fc834d6e9058e89c825efdc55"
+dependencies = [
+ "cfg-if",
+ "windows-link",
+]
+
+[[package]]
 name = "line-index"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2830,9 +2840,11 @@ dependencies = [
  "derive_order",
  "if_let_with_else",
  "ignore",
+ "libloading",
  "no_matches_macro",
  "predicates",
  "serde",
+ "serde_json",
  "tempfile",
  "toml",
  "trycmd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,6 +36,10 @@ codespan-reporting = "0.13"
 # so that `.gitignore` and friends are honored: a linter that reports on
 # generated output such as `target/` is worse than no linter at all.
 ignore = "0.4"
+# Loads custom lint plugins. The loader trusts a library only after the
+# handshake in whisker-types::plugin proves it was built by the same rustc
+# from the same whisker source.
+libloading = "0.8"
 proptest = "1"
 ra_ap_hir = "0.0.348"
 ra_ap_ide_db = "0.0.348"

--- a/crates/whisker-rust/src/plugin.rs
+++ b/crates/whisker-rust/src/plugin.rs
@@ -13,7 +13,8 @@
 use std::ffi::CStr;
 
 pub use whisker_types::plugin::{
-    ABI_VERSION, LintRegistrar, PluginDeclaration, RUSTC_VERSION, TYPES_FINGERPRINT, c_str,
+    ABI_VERSION, LintPassFactory, LintRegistrar, PluginDeclaration, RUSTC_VERSION,
+    TYPES_FINGERPRINT, c_str,
 };
 
 /// A fingerprint of the whisker-rust source this crate was compiled from

--- a/crates/whisker-types/src/plugin.rs
+++ b/crates/whisker-types/src/plugin.rs
@@ -38,7 +38,7 @@ mod declaration;
 mod registrar;
 
 pub use declaration::PluginDeclaration;
-pub use registrar::LintRegistrar;
+pub use registrar::{LintPassFactory, LintRegistrar};
 
 /// The version of the plugin declaration protocol itself
 ///

--- a/crates/whisker-types/src/plugin/registrar.rs
+++ b/crates/whisker-types/src/plugin/registrar.rs
@@ -15,8 +15,14 @@ use crate::LintPass;
 /// [`register`]: LintRegistrar::register
 pub trait LintRegistrar {
     /// Registers one lint pass factory
-    fn register(&mut self, factory: fn() -> Box<dyn LintPass>);
+    fn register(&mut self, factory: LintPassFactory);
 }
+
+/// Constructs one fresh lint pass
+///
+/// See [`LintRegistrar`] for why plugins hand over construction rather
+/// than passes.
+pub type LintPassFactory = fn() -> Box<dyn LintPass>;
 
 #[cfg(test)]
 mod tests {

--- a/crates/whisker/Cargo.toml
+++ b/crates/whisker/Cargo.toml
@@ -21,8 +21,10 @@ clawless = "0.5.0"
 derive_order = { path = "../../lints/derive_order" }
 if_let_with_else = { path = "../../lints/if_let_with_else" }
 ignore.workspace = true
+libloading.workspace = true
 no_matches_macro = { path = "../../lints/no_matches_macro" }
 serde.workspace = true
+serde_json.workspace = true
 toml.workspace = true
 whisker-core = { path = "../whisker-core" }
 whisker-reporting = { path = "../whisker-reporting" }

--- a/crates/whisker/src/commands/check.rs
+++ b/crates/whisker/src/commands/check.rs
@@ -16,6 +16,7 @@ use self::check_outcome::CheckOutcome;
 use self::error_recovery::{ErrorRecovery, Walk};
 use self::failure_threshold::FailureThreshold;
 use crate::config::WhiskerConfig;
+use crate::custom_lints::CustomLints;
 use crate::discovery::{Discovery, WalkErrorPolicy};
 
 /// Run whisker lints against a project
@@ -40,10 +41,12 @@ pub struct CheckArgs {
 
 /// Builds the lint passes the CLI runs
 ///
-/// Every rule ships as its own crate and is linked in here. A rule that is
-/// not in this list does not run, however complete its own tests are.
-fn create_lint_passes() -> Vec<Box<dyn LintPass>> {
-    vec![
+/// Every built-in rule ships as its own crate, and this list links them
+/// in. A rule the list leaves out does not run, no matter how complete its
+/// own tests are. The project's custom lints join through the factories
+/// they registered when the run began.
+fn create_lint_passes(custom_lints: &CustomLints) -> Vec<Box<dyn LintPass>> {
+    let mut passes: Vec<Box<dyn LintPass>> = vec![
         Box::new(RustLintPassAdapter::new(
             anyhow_missing_context::AnyhowMissingContext,
         )),
@@ -54,7 +57,9 @@ fn create_lint_passes() -> Vec<Box<dyn LintPass>> {
         Box::new(RustLintPassAdapter::new(
             wildcard_match_arm::WildcardMatchArm,
         )),
-    ]
+    ];
+    passes.extend(custom_lints.instantiate());
+    passes
 }
 
 /// The distinct remedies for the files this run could not analyze
@@ -119,6 +124,9 @@ pub async fn check(args: CheckArgs, _context: Context) -> CommandResult {
 
     let config = WhiskerConfig::load(&path).context("failed to load the whisker configuration")?;
 
+    let custom_lints =
+        CustomLints::load(&config).context("failed to load the project's custom lints")?;
+
     let on_error = match keep_going {
         true => WalkErrorPolicy::ReportAndContinue,
         false => WalkErrorPolicy::Fail,
@@ -164,7 +172,7 @@ pub async fn check(args: CheckArgs, _context: Context) -> CommandResult {
             },
         };
 
-        let mut passes = create_lint_passes();
+        let mut passes = create_lint_passes(&custom_lints);
 
         match pipeline.run_on_source(&source, file, &providers, &mut passes) {
             Ok(diagnostics) => {

--- a/crates/whisker/src/config.rs
+++ b/crates/whisker/src/config.rs
@@ -4,19 +4,22 @@ use anyhow::Context as _;
 use serde::Deserialize;
 
 mod ignore_pattern;
+mod lint_path;
 
 pub use ignore_pattern::IgnorePattern;
+pub use lint_path::LintPath;
 
 /// Whisker's configuration for a single target project
 ///
 /// Whisker reads a TOML file that any project can write, whatever language
 /// it is in. The file holds the [`IgnorePattern`]s that exclude files from
-/// discovery. Those patterns anchor at the project directory, which
-/// [`WhiskerConfig::root`] returns.
+/// discovery and the [`LintPath`]s of the project's custom lints. Both
+/// anchor at the project directory, which [`WhiskerConfig::root`] returns.
 #[derive(Clone, Eq, PartialEq, Debug)]
 pub struct WhiskerConfig {
     root: PathBuf,
     ignore: Vec<IgnorePattern>,
+    lints: Vec<LintPath>,
 }
 
 impl WhiskerConfig {
@@ -28,10 +31,15 @@ impl WhiskerConfig {
     /// let config = WhiskerConfig::new(
     ///     PathBuf::from("/src/project"),
     ///     vec![IgnorePattern::new("examples/")],
+    ///     Vec::new(),
     /// );
     /// ```
-    pub fn new(root: PathBuf, ignore: Vec<IgnorePattern>) -> Self {
-        Self { root, ignore }
+    pub fn new(root: PathBuf, ignore: Vec<IgnorePattern>, lints: Vec<LintPath>) -> Self {
+        Self {
+            root,
+            ignore,
+            lints,
+        }
     }
 
     /// Loads the configuration that governs `path`
@@ -60,18 +68,22 @@ impl WhiskerConfig {
         let start = search_directory(path)?;
 
         let Some(FoundConfig { root, file }) = find_config(&start)? else {
-            return Ok(Self::new(start, Vec::new()));
+            return Ok(Self::new(start, Vec::new(), Vec::new()));
         };
 
         let text = std::fs::read_to_string(&file)
             .with_context(|| format!("failed to read {}", file.display()))?;
 
-        let ConfigTable { ignore } =
+        let ConfigTable { ignore, lints } =
             toml::from_str(&text).with_context(|| format!("failed to read {}", file.display()))?;
 
         let ignore = ignore.into_iter().map(IgnorePattern::new).collect();
+        let lints = lints
+            .into_iter()
+            .map(|LintEntry { path }| LintPath::new(path))
+            .collect();
 
-        Ok(Self::new(root, ignore))
+        Ok(Self::new(root, ignore, lints))
     }
 
     /// Returns the project directory that anchors the ignore patterns
@@ -103,18 +115,47 @@ impl WhiskerConfig {
     pub fn ignore(&self) -> &[IgnorePattern] {
         &self.ignore
     }
+
+    /// Returns the paths of the project's custom lint crates
+    ///
+    /// Relative paths anchor at [`WhiskerConfig::root`]; resolve them with
+    /// [`LintPath::resolve`].
+    ///
+    /// # Examples
+    ///
+    /// ```ignore
+    /// let config = WhiskerConfig::load(Path::new("."))?;
+    ///
+    /// assert!(config.lints().is_empty());
+    /// ```
+    pub fn lints(&self) -> &[LintPath] {
+        &self.lints
+    }
 }
 
 /// The configuration file as written on disk
 ///
-/// [`WhiskerConfig::load`] turns the strings here into [`IgnorePattern`]s.
-/// Whisker rejects a key it does not recognize, because a key it silently
-/// drops looks exactly like one that works.
+/// [`WhiskerConfig::load`] turns the strings here into [`IgnorePattern`]s
+/// and [`LintPath`]s. Whisker rejects a key it does not recognize, because
+/// a key it silently drops looks exactly like one that works.
 #[derive(Debug, Default, Deserialize)]
 #[serde(deny_unknown_fields)]
 struct ConfigTable {
     #[serde(default)]
     ignore: Vec<String>,
+
+    #[serde(default)]
+    lints: Vec<LintEntry>,
+}
+
+/// One `[[lints]]` entry as written on disk
+///
+/// An entry is a table rather than a bare string, so options like a build
+/// profile can join `path` later without another shape change.
+#[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct LintEntry {
+    path: String,
 }
 
 /// A configuration file whisker found, and the directory it anchors to
@@ -335,6 +376,54 @@ mod tests {
     }
 
     #[test]
+    fn load_with_lint_entries_returns_them_in_order() {
+        let directory = repository();
+        write_dotfile(
+            directory.path(),
+            "[[lints]]\npath = \"lints/no_todo\"\n\n[[lints]]\npath = \"lints/prefer_expect\"\n",
+        );
+
+        let config = WhiskerConfig::load(directory.path()).expect("configuration should load");
+
+        assert_eq!(
+            config.lints(),
+            vec![
+                LintPath::new("lints/no_todo"),
+                LintPath::new("lints/prefer_expect")
+            ]
+        );
+    }
+
+    #[test]
+    fn load_with_lint_entry_missing_path_returns_error() {
+        let directory = repository();
+        write_dotfile(directory.path(), "[[lints]]\nname = \"no_todo\"\n");
+
+        let error = WhiskerConfig::load(directory.path()).expect_err("configuration should fail");
+
+        assert!(
+            format!("{error:#}").contains(".whisker.toml"),
+            "error should name the offending file: {error:#}"
+        );
+    }
+
+    #[test]
+    fn load_with_lint_entry_unknown_key_returns_error() {
+        let directory = repository();
+        write_dotfile(
+            directory.path(),
+            "[[lints]]\npath = \"lints/no_todo\"\nprofile = \"release\"\n",
+        );
+
+        let error = WhiskerConfig::load(directory.path()).expect_err("configuration should fail");
+
+        assert!(
+            format!("{error:#}").contains("profile"),
+            "error should name the key whisker does not recognize: {error:#}"
+        );
+    }
+
+    #[test]
     fn load_with_malformed_ignore_value_returns_error() {
         let directory = repository();
         write_dotfile(directory.path(), "ignore = \"examples/\"\n");
@@ -374,6 +463,17 @@ mod tests {
 
         assert_eq!(config.root(), resolved(&directory));
         assert!(config.ignore().is_empty());
+        assert!(config.lints().is_empty());
+    }
+
+    #[test]
+    fn load_without_lint_entries_returns_no_lints() {
+        let directory = repository();
+        write_dotfile(directory.path(), "ignore = []\n");
+
+        let config = WhiskerConfig::load(directory.path()).expect("configuration should load");
+
+        assert!(config.lints().is_empty());
     }
 
     #[test]

--- a/crates/whisker/src/config/lint_path.rs
+++ b/crates/whisker/src/config/lint_path.rs
@@ -1,0 +1,102 @@
+use std::path::{Path, PathBuf};
+
+/// The path of a custom lint crate configured in the whisker configuration
+///
+/// The path names a directory holding a Cargo package that exports lint
+/// passes with `export_lints!`. The constructor does not validate it; the
+/// plugin loader resolves and checks the path when the run starts, so the
+/// error can say which configured entry is broken.
+///
+/// # Examples
+///
+/// ```ignore
+/// let path = LintPath::new("lints/no_todo");
+///
+/// assert_eq!(path.resolve(Path::new("/project")), Path::new("/project/lints/no_todo"));
+/// ```
+#[derive(Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug)]
+pub struct LintPath(PathBuf);
+
+impl LintPath {
+    /// Creates a lint path from its configured source
+    ///
+    /// # Examples
+    ///
+    /// ```ignore
+    /// let path = LintPath::new("lints/no_todo");
+    /// ```
+    pub fn new(path: impl Into<PathBuf>) -> Self {
+        Self(path.into())
+    }
+
+    /// Returns the path this entry points at, anchored at `root`
+    ///
+    /// A relative path anchors at the project directory that holds the
+    /// configuration file, the same directory the ignore patterns anchor
+    /// at. An absolute path stands on its own.
+    ///
+    /// # Examples
+    ///
+    /// ```ignore
+    /// let path = LintPath::new("lints/no_todo");
+    ///
+    /// assert_eq!(path.resolve(Path::new("/project")), Path::new("/project/lints/no_todo"));
+    /// ```
+    pub fn resolve(&self, root: &Path) -> PathBuf {
+        root.join(&self.0)
+    }
+}
+
+impl std::fmt::Display for LintPath {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        self.0.display().fmt(f)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn display_matches_source() {
+        let path = LintPath::new("lints/no_todo");
+
+        assert_eq!(path.to_string(), "lints/no_todo");
+    }
+
+    #[test]
+    fn resolve_anchors_a_relative_path_at_the_root() {
+        let path = LintPath::new("lints/no_todo");
+
+        let resolved = path.resolve(Path::new("/project"));
+
+        assert_eq!(resolved, Path::new("/project/lints/no_todo"));
+    }
+
+    #[test]
+    fn resolve_keeps_an_absolute_path() {
+        let path = LintPath::new("/elsewhere/no_todo");
+
+        let resolved = path.resolve(Path::new("/project"));
+
+        assert_eq!(resolved, Path::new("/elsewhere/no_todo"));
+    }
+
+    #[test]
+    fn trait_send() {
+        fn assert_send<T: Send>() {}
+        assert_send::<LintPath>();
+    }
+
+    #[test]
+    fn trait_sync() {
+        fn assert_sync<T: Sync>() {}
+        assert_sync::<LintPath>();
+    }
+
+    #[test]
+    fn trait_unpin() {
+        fn assert_unpin<T: Unpin>() {}
+        assert_unpin::<LintPath>();
+    }
+}

--- a/crates/whisker/src/custom_lints.rs
+++ b/crates/whisker/src/custom_lints.rs
@@ -1,0 +1,397 @@
+use std::collections::HashSet;
+use std::ffi::{CStr, OsString, c_char};
+use std::path::{Path, PathBuf};
+use std::process::{Command, Stdio};
+
+use anyhow::Context as _;
+use libloading::Library;
+use whisker_types::LintPass;
+use whisker_types::plugin::{LintPassFactory, LintRegistrar, PluginDeclaration};
+
+use self::handshake::AbiIdentity;
+use crate::config::WhiskerConfig;
+
+mod artifact;
+mod handshake;
+
+/// The lint passes loaded from the project's configured custom lint crates
+///
+/// Loading happens once per run, before the file walk: whisker compiles
+/// each configured path with the user's cargo, opens the dynamic library
+/// that build produced, and checks its declaration against this binary's
+/// own ABI identity before anything in it runs. What survives is a set of
+/// factories, because passes are stateful and the check command constructs
+/// a fresh set for every file.
+///
+/// A load failure is fatal rather than recoverable: configuration that
+/// silently does nothing looks exactly like configuration that works, and
+/// `--keep-going` governs per-file walk errors, not a broken setup.
+pub struct CustomLints {
+    factories: Vec<LintPassFactory>,
+}
+
+impl CustomLints {
+    /// Compiles, loads, and validates every configured custom lint crate
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if a configured path does not name a cargo
+    /// package, is configured twice, fails to build, does not export a
+    /// plugin declaration, fails the ABI handshake, or registers no
+    /// lints.
+    pub fn load(config: &WhiskerConfig) -> anyhow::Result<Self> {
+        let host = AbiIdentity::host();
+        let mut factories = Vec::new();
+
+        for directory in configured_directories(config)? {
+            let loaded = load_directory(&directory, &host).with_context(|| {
+                format!("failed to load the custom lints at {}", directory.display())
+            })?;
+            factories.extend(loaded);
+        }
+
+        Ok(Self { factories })
+    }
+
+    /// Constructs one fresh pass per loaded custom lint
+    pub fn instantiate(&self) -> Vec<Box<dyn LintPass>> {
+        self.factories.iter().map(|factory| factory()).collect()
+    }
+}
+
+/// Resolves and validates the configured lint paths before any build runs
+///
+/// All paths are checked up front, so a typo in the second entry surfaces
+/// before the first entry's potentially long compilation, and a path
+/// configured twice is caught however it was spelled.
+///
+/// # Errors
+///
+/// Returns an error if an entry does not exist, is not a directory, holds
+/// no `Cargo.toml`, or resolves to the same package as an earlier entry.
+fn configured_directories(config: &WhiskerConfig) -> anyhow::Result<Vec<PathBuf>> {
+    let mut directories = Vec::new();
+    let mut seen = HashSet::new();
+
+    for entry in config.lints() {
+        let directory = entry.resolve(config.root());
+
+        anyhow::ensure!(
+            directory.exists(),
+            "the configured lint path {entry} resolves to {}, which does not exist",
+            directory.display()
+        );
+        anyhow::ensure!(
+            directory.is_dir(),
+            "the configured lint path {entry} resolves to {}, which is not a directory",
+            directory.display()
+        );
+
+        let directory = std::fs::canonicalize(&directory)
+            .with_context(|| format!("failed to resolve the configured lint path {entry}"))?;
+
+        anyhow::ensure!(
+            directory.join("Cargo.toml").is_file(),
+            "the configured lint path {entry} holds no Cargo.toml; custom lints are cargo \
+             packages"
+        );
+        anyhow::ensure!(
+            seen.insert(directory.clone()),
+            "the configured lint path {entry} names a package that is already configured"
+        );
+
+        directories.push(directory);
+    }
+
+    Ok(directories)
+}
+
+/// Builds the package at `directory` and loads the lints it exports
+fn load_directory(directory: &Path, host: &AbiIdentity) -> anyhow::Result<Vec<LintPassFactory>> {
+    let library = build(directory)?;
+    load_library(&library, host)
+}
+
+/// Compiles the plugin with the user's cargo and returns the built library
+///
+/// The build inherits stderr, so compiler errors and progress render to
+/// the terminal exactly as they would for a direct `cargo build`; stdout
+/// carries the JSON messages the artifact search reads. Release profile,
+/// because the plugin then runs over every file of every check.
+///
+/// # Errors
+///
+/// Returns an error if cargo cannot be run, exits unsuccessfully, or
+/// produces no dynamic library for the package.
+fn build(directory: &Path) -> anyhow::Result<PathBuf> {
+    let cargo = std::env::var_os("CARGO").unwrap_or_else(|| OsString::from("cargo"));
+
+    let output = Command::new(cargo)
+        .args([
+            "build",
+            "--release",
+            "--message-format=json-render-diagnostics",
+        ])
+        .current_dir(directory)
+        .stdout(Stdio::piped())
+        .stderr(Stdio::inherit())
+        .output()
+        .context("failed to run cargo build")?;
+
+    anyhow::ensure!(output.status.success(), "cargo build failed");
+
+    let stdout = String::from_utf8(output.stdout).context("cargo build wrote invalid UTF-8")?;
+
+    artifact::cdylib_artifact(&stdout, &directory.join("Cargo.toml"))
+}
+
+/// Opens the built library, performs the handshake, and collects factories
+///
+/// The loader reads the declaration's leading protocol version through a
+/// raw pointer, and only a matching version licenses a reference to the
+/// whole struct: a plugin of another protocol may export a shorter or
+/// differently shaped declaration, and a reference to that is already
+/// undefined behavior.
+///
+/// The loaded library is deliberately leaked. The registered factories and
+/// every `RuleId(&'static str)` a plugin lint mints point into the
+/// library's image, so unloading it would leave dangling references
+/// behind values that outlive this function. The leak is bounded by the
+/// number of configured plugins in a short-lived process.
+///
+/// # Errors
+///
+/// Returns an error if the library cannot be opened, exports no plugin
+/// declaration, fails the ABI handshake, or registers no lints.
+fn load_library(library: &Path, host: &AbiIdentity) -> anyhow::Result<Vec<LintPassFactory>> {
+    let library = unsafe { Library::new(library) }
+        .with_context(|| format!("failed to open {}", library.display()))?;
+
+    let declaration =
+        unsafe { library.get::<*const PluginDeclaration>(b"whisker_plugin_declaration\0") }
+            .context(
+                "the library is not a whisker lint plugin; export its lints with \
+             whisker_rust::export_lints!",
+            )?;
+    let declaration: *const PluginDeclaration = *declaration;
+
+    let plugin_abi_version = unsafe { abi_version(declaration) };
+    if plugin_abi_version != host.abi_version {
+        return Err(handshake::HandshakeMismatch::AbiVersion {
+            host: host.abi_version,
+            plugin: plugin_abi_version,
+        }
+        .into());
+    }
+
+    let declaration = unsafe { &*declaration };
+
+    let plugin = AbiIdentity {
+        abi_version: plugin_abi_version,
+        rustc_version: read_declaration_string(declaration.rustc_version)?,
+        types_fingerprint: read_declaration_string(declaration.types_fingerprint)?,
+        language_fingerprint: read_declaration_string(declaration.language_fingerprint)?,
+    };
+    handshake::validate(host, &plugin)?;
+
+    let mut registrar = Collecting {
+        factories: Vec::new(),
+    };
+    (declaration.register)(&mut registrar);
+
+    anyhow::ensure!(
+        !registrar.factories.is_empty(),
+        "the plugin registered no lints; a plugin that does nothing looks exactly like one that \
+         works, so this is treated as a mistake"
+    );
+
+    std::mem::forget(library);
+
+    Ok(registrar.factories)
+}
+
+/// Reads the protocol version at the head of a plugin declaration
+///
+/// This is the one field a plugin of any vintage can be trusted to hold,
+/// because it sits at offset zero of a `#[repr(C)]` struct. Everything
+/// past it, the struct's own size included, is what a matching version
+/// establishes, so the read goes through a raw pointer rather than a
+/// reference to the whole declaration.
+///
+/// # Safety
+///
+/// `declaration` must be the address of a loaded library's
+/// `whisker_plugin_declaration` static.
+unsafe fn abi_version(declaration: *const PluginDeclaration) -> u32 {
+    unsafe { declaration.cast::<u32>().read_unaligned() }
+}
+
+/// Reads one C string field of a plugin declaration
+///
+/// # Errors
+///
+/// Returns an error if the pointer is null or the string is not UTF-8,
+/// both of which mean the declaration was not written by `export_lints!`.
+fn read_declaration_string(field: *const c_char) -> anyhow::Result<String> {
+    anyhow::ensure!(
+        !field.is_null(),
+        "the plugin declaration is malformed; export lints with whisker_rust::export_lints!"
+    );
+
+    let text = unsafe { CStr::from_ptr(field) };
+    let text = text
+        .to_str()
+        .context("the plugin declaration is malformed; export lints with export_lints!")?;
+
+    Ok(text.to_owned())
+}
+
+/// Gathers the factories a plugin registers
+struct Collecting {
+    factories: Vec<LintPassFactory>,
+}
+
+impl LintRegistrar for Collecting {
+    fn register(&mut self, factory: LintPassFactory) {
+        self.factories.push(factory);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::path::PathBuf;
+
+    use super::*;
+    use crate::config::LintPath;
+
+    fn config_with(root: &Path, lints: Vec<LintPath>) -> WhiskerConfig {
+        WhiskerConfig::new(root.to_path_buf(), Vec::new(), lints)
+    }
+
+    fn package(root: &Path, name: &str) -> PathBuf {
+        let directory = root.join(name);
+        std::fs::create_dir_all(&directory).expect("package directory should be created");
+        std::fs::write(directory.join("Cargo.toml"), "[package]\n").expect("manifest");
+        directory
+    }
+
+    #[test]
+    fn abi_version_reads_a_declaration_that_ends_after_the_version() {
+        #[repr(C)]
+        struct Truncated {
+            abi_version: u32,
+        }
+        let truncated = Truncated { abi_version: 7 };
+
+        let version = unsafe { abi_version((&raw const truncated).cast::<PluginDeclaration>()) };
+
+        assert_eq!(version, 7);
+    }
+
+    #[test]
+    fn configured_directories_rejects_a_duplicate_entry() {
+        let root = tempfile::tempdir().expect("temporary directory should be created");
+        package(root.path(), "no_todo");
+        let config = config_with(
+            root.path(),
+            vec![LintPath::new("no_todo"), LintPath::new("./no_todo")],
+        );
+
+        let error = configured_directories(&config).expect_err("should fail");
+
+        assert!(
+            error.to_string().contains("already configured"),
+            "unexpected: {error:#}"
+        );
+    }
+
+    #[test]
+    fn configured_directories_rejects_a_file_entry() {
+        let root = tempfile::tempdir().expect("temporary directory should be created");
+        std::fs::write(root.path().join("lint.rs"), "").expect("file should be written");
+        let config = config_with(root.path(), vec![LintPath::new("lint.rs")]);
+
+        let error = configured_directories(&config).expect_err("should fail");
+
+        assert!(
+            error.to_string().contains("not a directory"),
+            "unexpected: {error:#}"
+        );
+    }
+
+    #[test]
+    fn configured_directories_rejects_a_missing_entry() {
+        let root = tempfile::tempdir().expect("temporary directory should be created");
+        let config = config_with(root.path(), vec![LintPath::new("absent")]);
+
+        let error = configured_directories(&config).expect_err("should fail");
+
+        assert!(
+            error.to_string().contains("does not exist"),
+            "unexpected: {error:#}"
+        );
+    }
+
+    #[test]
+    fn configured_directories_rejects_an_entry_without_manifest() {
+        let root = tempfile::tempdir().expect("temporary directory should be created");
+        std::fs::create_dir(root.path().join("empty")).expect("directory should be created");
+        let config = config_with(root.path(), vec![LintPath::new("empty")]);
+
+        let error = configured_directories(&config).expect_err("should fail");
+
+        assert!(
+            error.to_string().contains("no Cargo.toml"),
+            "unexpected: {error:#}"
+        );
+    }
+
+    #[test]
+    fn configured_directories_resolves_entries_in_order() {
+        let root = tempfile::tempdir().expect("temporary directory should be created");
+        let first = package(root.path(), "first");
+        let second = package(root.path(), "second");
+        let config = config_with(
+            root.path(),
+            vec![LintPath::new("first"), LintPath::new("second")],
+        );
+
+        let directories = configured_directories(&config).expect("should resolve");
+
+        assert_eq!(
+            directories,
+            vec![
+                std::fs::canonicalize(first).expect("should resolve"),
+                std::fs::canonicalize(second).expect("should resolve"),
+            ]
+        );
+    }
+
+    #[test]
+    fn load_with_no_configured_lints_yields_no_passes() {
+        let root = tempfile::tempdir().expect("temporary directory should be created");
+        let config = config_with(root.path(), Vec::new());
+
+        let lints = CustomLints::load(&config).expect("should load");
+
+        assert!(lints.instantiate().is_empty());
+    }
+
+    #[test]
+    fn trait_send() {
+        fn assert_send<T: Send>() {}
+        assert_send::<CustomLints>();
+    }
+
+    #[test]
+    fn trait_sync() {
+        fn assert_sync<T: Sync>() {}
+        assert_sync::<CustomLints>();
+    }
+
+    #[test]
+    fn trait_unpin() {
+        fn assert_unpin<T: Unpin>() {}
+        assert_unpin::<CustomLints>();
+    }
+}

--- a/crates/whisker/src/custom_lints/artifact.rs
+++ b/crates/whisker/src/custom_lints/artifact.rs
@@ -1,0 +1,215 @@
+use std::path::{Path, PathBuf};
+
+use anyhow::Context as _;
+use serde::Deserialize;
+
+/// One line of `cargo build --message-format=json-render-diagnostics`
+///
+/// Only the fields the artifact search reads are declared, and only
+/// `reason` is required, because cargo adds message kinds and fields over
+/// time and an unknown one is not an error.
+#[derive(Debug, Deserialize)]
+struct BuildMessage {
+    reason: String,
+    #[serde(default)]
+    manifest_path: Option<PathBuf>,
+    #[serde(default)]
+    target: Option<Target>,
+    #[serde(default)]
+    filenames: Vec<PathBuf>,
+}
+
+/// The target a compiler artifact was built from
+#[derive(Debug, Deserialize)]
+struct Target {
+    #[serde(default)]
+    crate_types: Vec<String>,
+}
+
+/// Finds the dynamic library that cargo built for the package at `manifest`
+///
+/// `stdout` is the JSON message stream of a successful `cargo build`. The
+/// search matches artifacts by manifest path rather than by package name,
+/// so a dependency that happens to share the plugin's name cannot be
+/// loaded in its place.
+///
+/// # Errors
+///
+/// Returns an error if a message line is not valid JSON, if the build
+/// produced no artifact for `manifest`, or if the package does not build a
+/// `cdylib`. The last error quotes the manifest section to add, because a
+/// missing crate type is the most likely authoring mistake.
+pub fn cdylib_artifact(stdout: &str, manifest: &Path) -> anyhow::Result<PathBuf> {
+    let manifest = canonical(manifest);
+    let mut package_artifacts = Vec::new();
+
+    for line in stdout.lines().filter(|line| !line.trim().is_empty()) {
+        let message: BuildMessage = serde_json::from_str(line)
+            .with_context(|| format!("failed to read a cargo build message: {line}"))?;
+
+        if message.reason != "compiler-artifact" {
+            continue;
+        }
+
+        let Some(path) = &message.manifest_path else {
+            continue;
+        };
+
+        if canonical(path) == manifest {
+            package_artifacts.push(message);
+        }
+    }
+
+    anyhow::ensure!(
+        !package_artifacts.is_empty(),
+        "cargo built no artifact for {}; the configured path must name a single cargo package, \
+         not a workspace",
+        manifest.display()
+    );
+
+    let cdylib = package_artifacts
+        .into_iter()
+        .rev()
+        .find(|artifact| {
+            artifact
+                .target
+                .as_ref()
+                .is_some_and(|target| target.crate_types.iter().any(|kind| kind == "cdylib"))
+        })
+        .with_context(|| {
+            format!(
+                "the package at {} does not build a dynamic library; add\n\n[lib]\ncrate-type = \
+                 [\"cdylib\"]\n\nto its Cargo.toml",
+                manifest.display()
+            )
+        })?;
+
+    cdylib
+        .filenames
+        .iter()
+        .find(|file| {
+            file.extension()
+                .is_some_and(|extension| extension == std::env::consts::DLL_EXTENSION)
+        })
+        .cloned()
+        .with_context(|| {
+            format!(
+                "cargo reported no dynamic library file for {}",
+                manifest.display()
+            )
+        })
+}
+
+/// Resolves a path for comparison, or leaves it as written
+///
+/// Cargo prints absolute manifest paths, but whether symlinks are resolved
+/// is its business; resolving both sides makes the comparison meet in the
+/// middle. The fallback keeps the function total, so it stays testable on
+/// paths that do not exist.
+fn canonical(path: &Path) -> PathBuf {
+    std::fs::canonicalize(path).unwrap_or_else(|_| path.to_path_buf())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const MANIFEST: &str = "/plugin/Cargo.toml";
+
+    fn artifact_line(manifest: &str, crate_types: &str, filenames: &str) -> String {
+        format!(
+            r#"{{"reason":"compiler-artifact","manifest_path":"{manifest}","target":{{"crate_types":[{crate_types}],"name":"plugin"}},"filenames":[{filenames}]}}"#
+        )
+    }
+
+    fn dylib_name(stem: &str) -> String {
+        format!(
+            "\"/plugin/target/release/{stem}.{}\"",
+            std::env::consts::DLL_EXTENSION
+        )
+    }
+
+    #[test]
+    fn cdylib_artifact_finds_the_dynamic_library() {
+        let stdout = [
+            r#"{"reason":"compiler-artifact","manifest_path":"/deps/other/Cargo.toml","target":{"crate_types":["lib"],"name":"other"},"filenames":["/deps/libother.rlib"]}"#.to_string(),
+            artifact_line(MANIFEST, r#""cdylib""#, &dylib_name("libplugin")),
+            r#"{"reason":"build-finished","success":true}"#.to_string(),
+        ]
+        .join("\n");
+
+        let artifact = cdylib_artifact(&stdout, Path::new(MANIFEST)).expect("should find");
+
+        assert!(artifact.to_string_lossy().contains("libplugin"));
+    }
+
+    #[test]
+    fn cdylib_artifact_ignores_unknown_message_reasons() {
+        let stdout = [
+            r#"{"reason":"a-future-cargo-message","novel_field":42}"#.to_string(),
+            artifact_line(MANIFEST, r#""cdylib""#, &dylib_name("libplugin")),
+        ]
+        .join("\n");
+
+        let artifact = cdylib_artifact(&stdout, Path::new(MANIFEST));
+
+        assert!(artifact.is_ok());
+    }
+
+    #[test]
+    fn cdylib_artifact_picks_the_platform_library_among_filenames() {
+        let filenames = format!(
+            "\"/plugin/target/release/libplugin.rlib\", {}",
+            dylib_name("libplugin")
+        );
+        let stdout = artifact_line(MANIFEST, r#""cdylib", "rlib""#, &filenames);
+
+        let artifact = cdylib_artifact(&stdout, Path::new(MANIFEST)).expect("should find");
+
+        assert!(
+            artifact
+                .extension()
+                .is_some_and(|extension| extension == std::env::consts::DLL_EXTENSION)
+        );
+    }
+
+    #[test]
+    fn cdylib_artifact_with_malformed_line_returns_error() {
+        let stdout = "this is not json\n";
+
+        let error = cdylib_artifact(stdout, Path::new(MANIFEST)).expect_err("should fail");
+
+        assert!(
+            error.to_string().contains("cargo build message"),
+            "unexpected: {error:#}"
+        );
+    }
+
+    #[test]
+    fn cdylib_artifact_without_cdylib_crate_type_names_the_remedy() {
+        let stdout = artifact_line(
+            MANIFEST,
+            r#""lib""#,
+            "\"/plugin/target/release/libplugin.rlib\"",
+        );
+
+        let error = cdylib_artifact(&stdout, Path::new(MANIFEST)).expect_err("should fail");
+
+        assert!(
+            format!("{error:#}").contains("crate-type = [\"cdylib\"]"),
+            "the error should quote the manifest fix: {error:#}"
+        );
+    }
+
+    #[test]
+    fn cdylib_artifact_without_package_artifact_returns_error() {
+        let stdout = r#"{"reason":"compiler-artifact","manifest_path":"/deps/other/Cargo.toml","target":{"crate_types":["cdylib"],"name":"other"},"filenames":["/deps/libother.so"]}"#;
+
+        let error = cdylib_artifact(stdout, Path::new(MANIFEST)).expect_err("should fail");
+
+        assert!(
+            error.to_string().contains("no artifact"),
+            "unexpected: {error:#}"
+        );
+    }
+}

--- a/crates/whisker/src/custom_lints/handshake.rs
+++ b/crates/whisker/src/custom_lints/handshake.rs
@@ -1,0 +1,205 @@
+use std::fmt;
+
+use whisker_rust::plugin;
+
+/// The ABI-relevant identity of one side of the plugin boundary
+///
+/// Rust has no stable ABI, so a plugin and the whisker binary only agree on
+/// the layout of the types that cross between them when the same rustc
+/// compiled both from the same whisker source. This type captures exactly
+/// those facts for one side. [`validate`] compares the two sides.
+#[derive(Clone, Eq, PartialEq, Hash, Debug)]
+pub struct AbiIdentity {
+    pub abi_version: u32,
+    pub rustc_version: String,
+    pub types_fingerprint: String,
+    pub language_fingerprint: String,
+}
+
+impl AbiIdentity {
+    /// Returns the identity baked into this whisker binary
+    pub fn host() -> Self {
+        Self {
+            abi_version: plugin::ABI_VERSION,
+            rustc_version: plugin::RUSTC_VERSION.to_string_lossy().into_owned(),
+            types_fingerprint: plugin::TYPES_FINGERPRINT.to_string_lossy().into_owned(),
+            language_fingerprint: plugin::LANGUAGE_FINGERPRINT.to_string_lossy().into_owned(),
+        }
+    }
+}
+
+/// Accepts a plugin only when its identity matches the host's exactly
+///
+/// The checks run in the order the declaration's fields become
+/// trustworthy, and the first mismatch wins, so the reported error is the
+/// one whose remedy applies.
+///
+/// # Errors
+///
+/// Returns the first [`HandshakeMismatch`] between the two identities.
+pub fn validate(host: &AbiIdentity, plugin: &AbiIdentity) -> Result<(), HandshakeMismatch> {
+    if host.abi_version != plugin.abi_version {
+        return Err(HandshakeMismatch::AbiVersion {
+            host: host.abi_version,
+            plugin: plugin.abi_version,
+        });
+    }
+
+    if host.rustc_version != plugin.rustc_version {
+        return Err(HandshakeMismatch::RustcVersion {
+            host: host.rustc_version.clone(),
+            plugin: plugin.rustc_version.clone(),
+        });
+    }
+
+    if host.types_fingerprint != plugin.types_fingerprint {
+        return Err(HandshakeMismatch::TypesFingerprint);
+    }
+
+    if host.language_fingerprint != plugin.language_fingerprint {
+        return Err(HandshakeMismatch::LanguageFingerprint);
+    }
+
+    Ok(())
+}
+
+/// A difference between the plugin's ABI identity and the host's
+///
+/// Every variant is a refusal to load, because each one means the two
+/// images cannot be assumed to agree on type layout, and a wrong
+/// assumption is undefined behavior rather than a wrong answer. The
+/// fingerprint variants carry no values: the hashes mean nothing to a
+/// reader, while the version strings in the other variants tell the user
+/// what to install.
+#[derive(Clone, Eq, PartialEq, Hash, Debug)]
+pub enum HandshakeMismatch {
+    AbiVersion { host: u32, plugin: u32 },
+    RustcVersion { host: String, plugin: String },
+    TypesFingerprint,
+    LanguageFingerprint,
+}
+
+impl fmt::Display for HandshakeMismatch {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            HandshakeMismatch::AbiVersion { host, plugin } => write!(
+                f,
+                "the plugin speaks declaration protocol version {plugin}, but this whisker \
+                 speaks version {host}; rebuild the plugin against the whisker revision this \
+                 binary was built from"
+            ),
+            HandshakeMismatch::RustcVersion { host, plugin } => write!(
+                f,
+                "the plugin was built by `{plugin}`, but whisker was built by `{host}`; build \
+                 the plugin with the same toolchain"
+            ),
+            HandshakeMismatch::TypesFingerprint => write!(
+                f,
+                "the plugin was built against a different revision of whisker-types; update the \
+                 plugin's whisker dependencies to the revision whisker was built from"
+            ),
+            HandshakeMismatch::LanguageFingerprint => write!(
+                f,
+                "the plugin was built against a different revision of whisker-rust; update the \
+                 plugin's whisker dependencies to the revision whisker was built from"
+            ),
+        }
+    }
+}
+
+impl std::error::Error for HandshakeMismatch {}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn identity() -> AbiIdentity {
+        AbiIdentity {
+            abi_version: 1,
+            rustc_version: "rustc 1.92.0-nightly (0000000 2026-08-11)".into(),
+            types_fingerprint: "00000000000000aa".into(),
+            language_fingerprint: "00000000000000bb".into(),
+        }
+    }
+
+    #[test]
+    fn host_reports_the_baked_in_constants() {
+        let host = AbiIdentity::host();
+
+        assert_eq!(host.abi_version, plugin::ABI_VERSION);
+        assert!(host.rustc_version.starts_with("rustc"));
+    }
+
+    #[test]
+    fn trait_send() {
+        fn assert_send<T: Send>() {}
+        assert_send::<AbiIdentity>();
+        assert_send::<HandshakeMismatch>();
+    }
+
+    #[test]
+    fn trait_sync() {
+        fn assert_sync<T: Sync>() {}
+        assert_sync::<AbiIdentity>();
+        assert_sync::<HandshakeMismatch>();
+    }
+
+    #[test]
+    fn trait_unpin() {
+        fn assert_unpin<T: Unpin>() {}
+        assert_unpin::<AbiIdentity>();
+        assert_unpin::<HandshakeMismatch>();
+    }
+
+    #[test]
+    fn validate_matching_identities_succeeds() {
+        validate(&identity(), &identity()).expect("should match");
+    }
+
+    #[test]
+    fn validate_reports_a_differing_abi_version_first() {
+        let mut plugin = identity();
+        plugin.abi_version = 2;
+        plugin.rustc_version = "rustc 2.0.0".into();
+
+        let error = validate(&identity(), &plugin).expect_err("should mismatch");
+
+        assert_eq!(error, HandshakeMismatch::AbiVersion { host: 1, plugin: 2 });
+        assert!(error.to_string().contains("rebuild the plugin"));
+    }
+
+    #[test]
+    fn validate_reports_a_differing_language_fingerprint() {
+        let mut plugin = identity();
+        plugin.language_fingerprint = "00000000000000cc".into();
+
+        let error = validate(&identity(), &plugin).expect_err("should mismatch");
+
+        assert_eq!(error, HandshakeMismatch::LanguageFingerprint);
+        assert!(error.to_string().contains("whisker-rust"));
+    }
+
+    #[test]
+    fn validate_reports_a_differing_rustc_version() {
+        let mut plugin = identity();
+        plugin.rustc_version = "rustc 1.93.0-nightly (1111111 2026-09-01)".into();
+
+        let error = validate(&identity(), &plugin).expect_err("should mismatch");
+
+        let message = error.to_string();
+        assert!(message.contains("1.92.0"), "should name both: {message}");
+        assert!(message.contains("1.93.0"), "should name both: {message}");
+        assert!(message.contains("same toolchain"), "unexpected: {message}");
+    }
+
+    #[test]
+    fn validate_reports_a_differing_types_fingerprint() {
+        let mut plugin = identity();
+        plugin.types_fingerprint = "00000000000000cc".into();
+
+        let error = validate(&identity(), &plugin).expect_err("should mismatch");
+
+        assert_eq!(error, HandshakeMismatch::TypesFingerprint);
+        assert!(error.to_string().contains("whisker-types"));
+    }
+}

--- a/crates/whisker/src/discovery.rs
+++ b/crates/whisker/src/discovery.rs
@@ -311,7 +311,7 @@ mod tests {
             .map(|pattern| IgnorePattern::new(*pattern))
             .collect();
 
-        WhiskerConfig::new(root, patterns)
+        WhiskerConfig::new(root, patterns, Vec::new())
     }
 
     /// Returns the discovered files as slash-separated paths relative to `root`

--- a/crates/whisker/src/main.rs
+++ b/crates/whisker/src/main.rs
@@ -1,5 +1,6 @@
 mod commands;
 mod config;
+mod custom_lints;
 mod discovery;
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {


### PR DESCRIPTION
A project can now bring its own rules. The configuration file accepts lint entries naming directories that hold custom lint crates, and `whisker check` compiles each one with the user's cargo, opens the built dynamic library, and runs the exported lints alongside the built-ins.

Loading is guarded by the handshake the earlier PRs in this stack prepared. The loader reads the declaration's fields in order of decreasing layout stability and refuses the plugin at the first mismatch, so an incompatible library produces an actionable error instead of undefined behavior. That order starts before the first field: the protocol version is read through a raw pointer, because a plugin of another protocol may have exported a declaration of another size, and merely referencing that would already be undefined behavior. The loaded library is deliberately leaked, because rule ids and pass factories point into its image and outlive the loading scope.

Path validation runs for every entry before the first build starts, so a typo in the second entry surfaces before the first entry's long compilation, and a path configured twice is caught however it was spelled. A plugin that registers no lints is an error for the same reason an unknown configuration key is: configuration that silently does nothing looks exactly like configuration that works. Load failures stay fatal under `--keep-going`, which governs per-file walk errors rather than a broken setup.

The cargo message parsing and the handshake comparison are pure functions with their own tests, so every failure mode is covered without needing a real dynamic library. The end-to-end coverage arrives in the next PR alongside the example plugin.

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>

