### PR TITLE
Give RuleId a private field and a const constructor

### DIFF
--- a/crates/whisker-core/src/pipeline.rs
+++ b/crates/whisker-core/src/pipeline.rs
@@ -197,7 +197,7 @@ mod tests {
                 return Vec::new();
             };
             vec![Diagnostic::new(
-                RuleId("test.marker"),
+                RuleId::new("test.marker"),
                 Severity::Warn,
                 marker.0.into(),
                 node.span(),
@@ -310,7 +310,7 @@ mod tests {
             fn check_node(&mut self, node: &DecoratedNode<'_>) -> Vec<Diagnostic> {
                 if node.kind() == "function_item" {
                     vec![Diagnostic::new(
-                        RuleId("test.always"),
+                        RuleId::new("test.always"),
                         Severity::Warn,
                         "found function".into(),
                         node.span(),

--- a/crates/whisker-core/src/tree_walker.rs
+++ b/crates/whisker-core/src/tree_walker.rs
@@ -181,7 +181,7 @@ mod tests {
             fn check_node(&mut self, node: &DecoratedNode<'_>) -> Vec<Diagnostic> {
                 if node.kind() == "function_item" {
                     vec![Diagnostic::new(
-                        RuleId(self.0),
+                        RuleId::new(self.0),
                         Severity::Warn,
                         format!("{} found fn", self.0),
                         node.span(),
@@ -198,8 +198,8 @@ mod tests {
         let diagnostics = walk(&tree, &mut passes);
 
         assert_eq!(diagnostics.len(), 2);
-        assert_eq!(diagnostics[0].rule_id(), RuleId("pass.a"));
-        assert_eq!(diagnostics[1].rule_id(), RuleId("pass.b"));
+        assert_eq!(diagnostics[0].rule_id(), RuleId::new("pass.a"));
+        assert_eq!(diagnostics[1].rule_id(), RuleId::new("pass.b"));
     }
 
     #[test]
@@ -210,7 +210,7 @@ mod tests {
         impl LintPass for SpanChecker {
             fn check_node(&mut self, node: &DecoratedNode<'_>) -> Vec<Diagnostic> {
                 vec![Diagnostic::new(
-                    RuleId("test"),
+                    RuleId::new("test"),
                     Severity::Info,
                     "span check".into(),
                     node.span(),
@@ -256,7 +256,7 @@ mod tests {
                         node: &DecoratedNode<'_>,
                     ) -> Vec<Diagnostic> {
                         vec![Diagnostic::new(
-                            whisker_types::RuleId("test"),
+                            whisker_types::RuleId::new("test"),
                             whisker_types::Severity::Warn,
                             "hit".into(),
                             node.span(),

--- a/crates/whisker-reporting/src/renderer.rs
+++ b/crates/whisker-reporting/src/renderer.rs
@@ -181,7 +181,7 @@ mod tests {
 
     fn test_diagnostic() -> Diagnostic {
         Diagnostic::new(
-            RuleId("lint.test"),
+            RuleId::new("lint.test"),
             Severity::Warn,
             "test warning".into(),
             Span::new(PathBuf::from("test.rs"), 0, 12),
@@ -224,7 +224,7 @@ mod tests {
     #[test]
     fn render_to_string_shows_error_severity() {
         let diag = Diagnostic::new(
-            RuleId("lint.err"),
+            RuleId::new("lint.err"),
             Severity::Error,
             "test error".into(),
             Span::new(PathBuf::from("test.rs"), 0, 12),
@@ -283,13 +283,13 @@ mod tests {
     #[test]
     fn render_to_string_renders_multiple_diagnostics() {
         let d1 = Diagnostic::new(
-            RuleId("lint.a"),
+            RuleId::new("lint.a"),
             Severity::Warn,
             "first".into(),
             Span::new(PathBuf::from("test.rs"), 0, 2),
         );
         let d2 = Diagnostic::new(
-            RuleId("lint.b"),
+            RuleId::new("lint.b"),
             Severity::Error,
             "second".into(),
             Span::new(PathBuf::from("test.rs"), 3, 7),
@@ -335,7 +335,7 @@ mod tests {
                 severity in arb_severity(),
             ) {
                 let diag = Diagnostic::new(
-                    RuleId("lint.prop"),
+                    RuleId::new("lint.prop"),
                     severity,
                     message.clone(),
                     Span::new(PathBuf::from("test.rs"), 0, 5),
@@ -352,7 +352,7 @@ mod tests {
                 severity in arb_severity(),
             ) {
                 let diag = Diagnostic::new(
-                    RuleId("lint.propcheck"),
+                    RuleId::new("lint.propcheck"),
                     severity,
                     "msg".into(),
                     Span::new(PathBuf::from("test.rs"), 0, 5),
@@ -371,7 +371,7 @@ mod tests {
                 let diagnostics: Vec<Diagnostic> = (0..count)
                     .map(|i| {
                         Diagnostic::new(
-                            RuleId("lint.multi"),
+                            RuleId::new("lint.multi"),
                             Severity::Warn,
                             format!("diag_{i}"),
                             Span::new(PathBuf::from("test.rs"), 0, 5),

--- a/crates/whisker-rust/src/adapter.rs
+++ b/crates/whisker-rust/src/adapter.rs
@@ -88,7 +88,7 @@ mod tests {
             fn check_function_item(&mut self, node: &DecoratedNode<'_>) -> Vec<Diagnostic> {
                 self.found = true;
                 vec![Diagnostic::new(
-                    RuleId("test.fn"),
+                    RuleId::new("test.fn"),
                     Severity::Warn,
                     "found".into(),
                     node.span(),
@@ -103,7 +103,7 @@ mod tests {
         let diagnostics = adapter.check_node(&fn_node);
 
         assert_eq!(diagnostics.len(), 1);
-        assert_eq!(diagnostics[0].rule_id(), RuleId("test.fn"));
+        assert_eq!(diagnostics[0].rule_id(), RuleId::new("test.fn"));
     }
 
     #[test]
@@ -124,7 +124,7 @@ mod tests {
         impl RustLintPass for WarnOnFn {
             fn check_function_item(&mut self, node: &DecoratedNode<'_>) -> Vec<Diagnostic> {
                 vec![Diagnostic::new(
-                    RuleId("test.warn"),
+                    RuleId::new("test.warn"),
                     Severity::Warn,
                     "function found".into(),
                     node.span(),

--- a/crates/whisker-rust/src/export_lints.rs
+++ b/crates/whisker-rust/src/export_lints.rs
@@ -58,7 +58,7 @@ mod tests {
     impl RustLintPass for FlagEveryFunction {
         fn check_function_item(&mut self, node: &DecoratedNode<'_>) -> Vec<Diagnostic> {
             vec![Diagnostic::new(
-                RuleId("test.flag-every-function"),
+                RuleId::new("test.flag-every-function"),
                 Severity::Warn,
                 "found a function".into(),
                 node.span(),
@@ -121,6 +121,9 @@ mod tests {
         let diagnostics = pass.check_node(&function);
 
         assert_eq!(diagnostics.len(), 1);
-        assert_eq!(diagnostics[0].rule_id(), RuleId("test.flag-every-function"));
+        assert_eq!(
+            diagnostics[0].rule_id(),
+            RuleId::new("test.flag-every-function")
+        );
     }
 }

--- a/crates/whisker-rust/src/lib.rs
+++ b/crates/whisker-rust/src/lib.rs
@@ -150,7 +150,7 @@ mod tests {
         impl RustLintPass for AlwaysWarn {
             fn check_function_item(&mut self, node: &DecoratedNode<'_>) -> Vec<Diagnostic> {
                 vec![Diagnostic::new(
-                    RuleId("test.warn"),
+                    RuleId::new("test.warn"),
                     Severity::Warn,
                     "found function".into(),
                     node.span(),
@@ -166,7 +166,7 @@ mod tests {
         let diagnostics = dispatch(&mut pass, &fn_item);
 
         assert_eq!(diagnostics.len(), 1);
-        assert_eq!(diagnostics[0].rule_id(), RuleId("test.warn"));
+        assert_eq!(diagnostics[0].rule_id(), RuleId::new("test.warn"));
     }
 
     #[test]

--- a/crates/whisker-rust/tests/provider_integration.rs
+++ b/crates/whisker-rust/tests/provider_integration.rs
@@ -701,7 +701,7 @@ fn flagged_within_with_a_span_past_the_function_end_returns_nothing() {
     let func = find_function_by_name(&root, "match_on_enum").expect("should find match_on_enum");
     let Range { start, end } = func.raw().byte_range();
     let diagnostics = vec![Diagnostic::new(
-        RuleId("lint.test"),
+        RuleId::new("lint.test"),
         Severity::Warn,
         "a span that leaves the function".to_string(),
         Span::new(tree.file().to_path_buf(), start, end + 1),

--- a/crates/whisker-testing/src/lib.rs
+++ b/crates/whisker-testing/src/lib.rs
@@ -274,7 +274,7 @@ mod tests {
             fn check_node(&mut self, node: &DecoratedNode<'_>) -> Vec<Diagnostic> {
                 if node.kind() == "function_item" {
                     vec![Diagnostic::new(
-                        RuleId("test.fn"),
+                        RuleId::new("test.fn"),
                         Severity::Warn,
                         "found fn".into(),
                         node.span(),
@@ -305,7 +305,7 @@ mod tests {
     #[should_panic(expected = "expected no diagnostics")]
     fn assert_no_diagnostics_with_non_empty_slice_panics() {
         let diag = Diagnostic::new(
-            RuleId("test"),
+            RuleId::new("test"),
             Severity::Warn,
             "msg".into(),
             whisker_types::Span::new(std::path::PathBuf::from("f.rs"), 0, 1),

--- a/crates/whisker-testing/tests/integration.rs
+++ b/crates/whisker-testing/tests/integration.rs
@@ -13,7 +13,7 @@ impl RustLintPass for MatchArmWildcardFinder {
         let text = node.text();
         if text.starts_with('_') && !text.starts_with("__") {
             vec![Diagnostic::new(
-                RuleId("lint.wildcard-match-arm"),
+                RuleId::new("lint.wildcard-match-arm"),
                 Severity::Warn,
                 "wildcard match arm".into(),
                 node.span(),
@@ -53,7 +53,7 @@ impl RustLintPass for MacroInvocationFinder {
         let text = node.text();
         if text.starts_with("matches!") {
             vec![Diagnostic::new(
-                RuleId("lint.no-matches-macro"),
+                RuleId::new("lint.no-matches-macro"),
                 Severity::Warn,
                 "use of matches! macro".into(),
                 node.span(),
@@ -92,7 +92,7 @@ impl RustLintPass for BoolParamFinder {
         let text = node.text();
         if text.contains(": bool") {
             vec![Diagnostic::new(
-                RuleId("lint.bool-param"),
+                RuleId::new("lint.bool-param"),
                 Severity::Warn,
                 "bool parameter".into(),
                 node.span(),

--- a/crates/whisker-types/src/diagnostic.rs
+++ b/crates/whisker-types/src/diagnostic.rs
@@ -62,7 +62,7 @@ impl Diagnostic {
     /// use whisker_types::{Diagnostic, RuleId, Severity, Span};
     ///
     /// let diagnostic = Diagnostic::new(
-    ///     RuleId("lint.bool-param"),
+    ///     RuleId::new("lint.bool-param"),
     ///     Severity::Warn,
     ///     "parameter has type `bool`".into(),
     ///     Span::new(PathBuf::from("src/lib.rs"), 0, 10),
@@ -121,7 +121,7 @@ mod tests {
 
     fn test_diagnostic() -> Diagnostic {
         Diagnostic::new(
-            RuleId("lint.test"),
+            RuleId::new("lint.test"),
             Severity::Warn,
             "test message".into(),
             Span::new(PathBuf::from("test.rs"), 0, 10),
@@ -150,7 +150,7 @@ mod tests {
     fn accessors_return_correct_values() {
         let diag = test_diagnostic();
 
-        assert_eq!(diag.rule_id(), RuleId("lint.test"));
+        assert_eq!(diag.rule_id(), RuleId::new("lint.test"));
         assert_eq!(diag.severity(), Severity::Warn);
         assert_eq!(diag.message(), "test message");
         assert_eq!(diag.span().start(), 0);
@@ -201,7 +201,7 @@ mod tests {
             .with_origin(origin)
             .with_severity(Severity::Error);
 
-        assert_eq!(diag.rule_id(), RuleId("lint.test"));
+        assert_eq!(diag.rule_id(), RuleId::new("lint.test"));
         assert_eq!(diag.message(), "test message");
         assert_eq!(diag.span().start(), 0);
         assert_eq!(diag.origins().len(), 1);
@@ -255,13 +255,13 @@ mod tests {
                 span in arb_span(),
             ) {
                 let diag = Diagnostic::new(
-                    RuleId("lint.prop"),
+                    RuleId::new("lint.prop"),
                     severity,
                     message.clone(),
                     span.clone(),
                 );
 
-                prop_assert_eq!(diag.rule_id(), RuleId("lint.prop"));
+                prop_assert_eq!(diag.rule_id(), RuleId::new("lint.prop"));
                 prop_assert_eq!(diag.severity(), severity);
                 prop_assert_eq!(diag.message(), message);
                 prop_assert_eq!(diag.span(), &span);
@@ -272,7 +272,7 @@ mod tests {
                 severity in arb_severity(),
             ) {
                 let diag = Diagnostic::new(
-                    RuleId("lint.prop"),
+                    RuleId::new("lint.prop"),
                     severity,
                     "msg".into(),
                     Span::new(PathBuf::from("f.rs"), 0, 1),

--- a/crates/whisker-types/src/rule_id.rs
+++ b/crates/whisker-types/src/rule_id.rs
@@ -2,11 +2,49 @@
 ///
 /// Each rule has a unique static string identifier following the convention
 /// `category.rule-name` (e.g. `lint.wildcard-match-arm`).
+///
+/// The string is private so that the only way to mint an identifier is
+/// [`RuleId::new`], which takes a `&'static str` and is `const`. A rule
+/// therefore still declares its identifier as an associated constant, while
+/// nothing can build one out of a string assembled at runtime.
+///
+/// # Examples
+///
+/// ```
+/// use whisker_types::RuleId;
+///
+/// const RULE_ID: RuleId = RuleId::new("lint.wildcard-match-arm");
+///
+/// assert_eq!(RULE_ID.as_str(), "lint.wildcard-match-arm");
+/// ```
 #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug)]
-pub struct RuleId(pub &'static str);
+pub struct RuleId(&'static str);
 
 impl RuleId {
+    /// Returns the identifier for a static rule name
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use whisker_types::RuleId;
+    ///
+    /// let id = RuleId::new("lint.bool-param");
+    ///
+    /// assert_eq!(id.to_string(), "lint.bool-param");
+    /// ```
+    pub const fn new(id: &'static str) -> Self {
+        Self(id)
+    }
+
     /// Returns the string representation of this rule identifier
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use whisker_types::RuleId;
+    ///
+    /// assert_eq!(RuleId::new("lint.derive-order").as_str(), "lint.derive-order");
+    /// ```
     pub fn as_str(&self) -> &'static str {
         self.0
     }
@@ -21,6 +59,27 @@ impl std::fmt::Display for RuleId {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn as_str_returns_inner() {
+        let id = RuleId::new("lint.test");
+
+        assert_eq!(id.as_str(), "lint.test");
+    }
+
+    #[test]
+    fn display_matches_inner() {
+        let id = RuleId::new("lint.test");
+
+        assert_eq!(id.to_string(), "lint.test");
+    }
+
+    #[test]
+    fn new_in_const_context_returns_the_name() {
+        const RULE_ID: RuleId = RuleId::new("lint.const");
+
+        assert_eq!(RULE_ID.as_str(), "lint.const");
+    }
 
     #[test]
     fn trait_send() {
@@ -38,17 +97,5 @@ mod tests {
     fn trait_unpin() {
         fn assert_unpin<T: Unpin>() {}
         assert_unpin::<RuleId>();
-    }
-
-    #[test]
-    fn as_str_returns_inner() {
-        let id = RuleId("lint.test");
-        assert_eq!(id.as_str(), "lint.test");
-    }
-
-    #[test]
-    fn display_matches_inner() {
-        let id = RuleId("lint.test");
-        assert_eq!(id.to_string(), "lint.test");
     }
 }

--- a/crates/whisker/src/commands/check/check_outcome.rs
+++ b/crates/whisker/src/commands/check/check_outcome.rs
@@ -53,7 +53,7 @@ mod tests {
 
     fn test_diagnostic(severity: Severity) -> Diagnostic {
         Diagnostic::new(
-            RuleId("lint.test"),
+            RuleId::new("lint.test"),
             severity,
             "test message".into(),
             Span::new(PathBuf::from("test.rs"), 0, 10),

--- a/crates/whisker/src/commands/check/failure_threshold.rs
+++ b/crates/whisker/src/commands/check/failure_threshold.rs
@@ -55,7 +55,7 @@ mod tests {
 
     fn test_diagnostic(severity: Severity) -> Diagnostic {
         Diagnostic::new(
-            RuleId("lint.test"),
+            RuleId::new("lint.test"),
             severity,
             "test message".into(),
             Span::new(PathBuf::from("test.rs"), 0, 10),
@@ -163,7 +163,7 @@ mod tests {
 
         let promoted = FailureThreshold::Warnings.promote(diagnostic);
 
-        assert_eq!(promoted.rule_id(), RuleId("lint.test"));
+        assert_eq!(promoted.rule_id(), RuleId::new("lint.test"));
         assert_eq!(promoted.message(), "test message");
         assert_eq!(promoted.span().start(), 0);
         assert_eq!(promoted.span().end(), 10);

--- a/crates/whisker/src/custom_lints.rs
+++ b/crates/whisker/src/custom_lints.rs
@@ -153,9 +153,9 @@ fn build(directory: &Path) -> anyhow::Result<PathBuf> {
 /// differently shaped declaration, and a reference to that is already
 /// undefined behavior.
 ///
-/// The loaded library is deliberately leaked. The registered factories and
-/// every `RuleId(&'static str)` a plugin lint mints point into the
-/// library's image, so unloading it would leave dangling references
+/// The loader deliberately leaks the library. The registered factories and
+/// the `&'static str` inside every [`RuleId`] a plugin lint mints point into
+/// the library's image, so unloading it would leave dangling references
 /// behind values that outlive this function. The leak is bounded by the
 /// number of configured plugins in a short-lived process.
 ///
@@ -163,6 +163,8 @@ fn build(directory: &Path) -> anyhow::Result<PathBuf> {
 ///
 /// Returns an error if the library cannot be opened, exports no plugin
 /// declaration, fails the ABI handshake, or registers no lints.
+///
+/// [`RuleId`]: whisker_types::RuleId
 fn load_library(library: &Path, host: &AbiIdentity) -> anyhow::Result<Vec<LintPassFactory>> {
     let library = unsafe { Library::new(library) }
         .with_context(|| format!("failed to open {}", library.display()))?;

--- a/examples/custom_lint/src/lib.rs
+++ b/examples/custom_lint/src/lib.rs
@@ -30,7 +30,7 @@ impl RustLintPass for NoTodo {
         }
 
         vec![Diagnostic::new(
-            RuleId("custom.no-todo"),
+            RuleId::new("custom.no-todo"),
             Severity::Warn,
             "finish this before it ships".into(),
             node.span(),

--- a/lints/anyhow_missing_context/src/lib.rs
+++ b/lints/anyhow_missing_context/src/lib.rs
@@ -2,7 +2,7 @@ use whisker_rust::RustLintPass;
 use whisker_rust::decorations::{FnSignature, ResolvedType, TypePathRef};
 use whisker_types::{DecoratedNode, Diagnostic, LintPass, RuleId, Severity};
 
-const RULE_ID: RuleId = RuleId("lint.anyhow-missing-context");
+const RULE_ID: RuleId = RuleId::new("lint.anyhow-missing-context");
 
 /// The definition path of `anyhow::Error`
 ///

--- a/lints/bool_param/src/lib.rs
+++ b/lints/bool_param/src/lib.rs
@@ -1,7 +1,7 @@
 use whisker_rust::{RustLintPass, RustLintPassAdapter};
 use whisker_types::{DecoratedNode, Diagnostic, LintPass, RuleId, Severity};
 
-const RULE_ID: RuleId = RuleId("lint.bool-param");
+const RULE_ID: RuleId = RuleId::new("lint.bool-param");
 
 /// Flags `bool` parameters in function signatures and `bool` fields in
 /// struct definitions

--- a/lints/derive_order/src/lib.rs
+++ b/lints/derive_order/src/lib.rs
@@ -109,7 +109,7 @@ impl RustLintPass for DeriveOrder {
 
         let expected_str = expected.join(", ");
         vec![Diagnostic::new(
-            RuleId("lint.derive-order"),
+            RuleId::new("lint.derive-order"),
             Severity::Warn,
             format!("derive macros are not in canonical order; expected: {expected_str}"),
             node.span(),

--- a/lints/if_let_with_else/src/lib.rs
+++ b/lints/if_let_with_else/src/lib.rs
@@ -35,7 +35,7 @@ impl RustLintPass for IfLetWithElse {
         }
 
         vec![Diagnostic::new(
-            RuleId("lint.if-let-with-else"),
+            RuleId::new("lint.if-let-with-else"),
             Severity::Warn,
             "`if let` with `else` should be written as a `match` expression".into(),
             node.span(),

--- a/lints/no_matches_macro/src/lib.rs
+++ b/lints/no_matches_macro/src/lib.rs
@@ -21,7 +21,7 @@ impl RustLintPass for NoMatchesMacro {
         }
 
         vec![Diagnostic::new(
-            RuleId("lint.no-matches-macro"),
+            RuleId::new("lint.no-matches-macro"),
             Severity::Warn,
             "use a full `match` expression instead of `matches!`".into(),
             node.span(),

--- a/lints/wildcard_match_arm/src/lib.rs
+++ b/lints/wildcard_match_arm/src/lib.rs
@@ -44,7 +44,7 @@ impl RustLintPass for WildcardMatchArm {
             };
             if is_wildcard_pattern(&pattern) {
                 diagnostics.push(Diagnostic::new(
-                    RuleId("lint.wildcard-match-arm"),
+                    RuleId::new("lint.wildcard-match-arm"),
                     Severity::Warn,
                     "wildcard match arm hides unhandled variants".into(),
                     pattern.span(),


### PR DESCRIPTION
Whisker's own `pub_field` rule (#232, PR #252) flags `pub struct RuleId(pub &'static str)`, so that lint could not be turned on without the linter reporting the type it uses to report. This makes the field private and `RuleId::new` the only way to mint one.

The constructor is `const`, which is what keeps this a rename rather than a redesign: every rule declares its identifier as `const RULE_ID: RuleId = RuleId::new("lint.whatever")`, and that still compiles. A private field also closes the door on building an identifier from a string assembled at runtime, which matters more than it looks — the `&'static str` inside a plugin's `RuleId` points into the deliberately leaked library image, and nothing outside `new` can now put a shorter-lived string there.

All 43 construction sites move in this one commit, because the field goes private in the same commit and splitting the two would leave the workspace uncompilable in between. That includes `examples/custom_lint`, which resolves whisker through path dependencies and so tracks the change.

This unblocks #252, which currently scopes the fix out and would otherwise land a rule that fires on whisker itself.