### PR TITLE
Fingerprint the plugin boundary by layout, not by source

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -102,11 +102,11 @@ decorations, the same test harness — and enters through
 `export_lints!` instead of the CLI's pass list.
 
 Rust has no stable ABI, so a loaded library is only coherent with the
-whisker binary when the same rustc compiled both from the same whisker
-source. Whisker establishes that before trusting anything: the plugin's
-declaration carries the compiler's identity and build-time fingerprints
-of the whisker crates whose types cross the boundary, and the loader
-refuses the library at the first mismatch.
+whisker binary when the same rustc compiled both and both lay the
+boundary out the same way. Whisker establishes that before trusting
+anything: the plugin's declaration carries the compiler's identity and a
+fingerprint of each side of the boundary, and the loader refuses the
+library at the first mismatch.
 
 The failure mode this guards against is not a crash but silence — a
 plugin built against drifted source would mostly _seem_ to work, and
@@ -115,7 +115,19 @@ a visible refusal. For the same reason, decorations are recovered by a
 name-based key rather than `TypeId`, which is not stable across
 separately compiled crate graphs.
 
-The fingerprints reach whisker's own sources, not the graph a plugin's
+The fingerprints hash layout, not source text: the size, alignment, and
+field offsets of every type that crosses, plus the lint pass trait
+whisker-rust generates from the grammar. An earlier revision hashed the
+crates' source directories, which meant a doc comment refused every
+plugin in the tree until each was rebuilt — a cost that scales with the
+number of plugins and buys nothing, since text that moves no field
+threatens nothing. What layout cannot cover is the method order of
+`LintPass` and `LintRegistrar`, because a vtable is ordered by
+declaration and no const reads that back; those belong to the
+declaration's `ABI_VERSION`, and a test fails when either trait's method
+list moves so the bump is not left to memory.
+
+The fingerprints reach whisker's own layout, not the graph a plugin's
 lockfile resolves for itself. `tree_sitter::Node` crosses the boundary
 as a `#[repr(transparent)]` wrapper around a `#[repr(C)]` struct of the
 C library, so a version difference there moves no field, but it does

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2941,7 +2941,6 @@ dependencies = [
  "rustc_version",
  "tree-sitter",
  "tree-sitter-rust",
- "whisker-codegen",
 ]
 
 [[package]]

--- a/crates/whisker-rust/build.rs
+++ b/crates/whisker-rust/build.rs
@@ -4,13 +4,16 @@ use std::path::Path;
 
 use whisker_codegen::Fingerprint;
 
-/// Generates the lint pass trait and fingerprints the crate for plugins
+/// Generates the lint pass trait and fingerprints it for plugins
 ///
-/// The fingerprint covers the sources and the generated code, and joins
-/// the custom lint plugin handshake as the language fingerprint. Hashing
-/// the generated trait matters: a plugin whose dispatch was generated from
-/// a different grammar would not crash, its checks would just quietly
-/// never fire, and the handshake turns that into a visible refusal.
+/// The fingerprint covers the generated code alone, and joins the custom
+/// lint plugin handshake as half of the language fingerprint. Hashing the
+/// generated trait matters: a plugin whose dispatch was generated from a
+/// different grammar would not crash, its checks would just quietly never
+/// fire, and the handshake turns that into a visible refusal. It stops
+/// there because the rest of this crate's source does not shape the
+/// boundary, and hashing it would refuse every plugin in the tree over an
+/// edit that moved nothing.
 fn main() {
     let node_types_json = include_str!(concat!(env!("CARGO_MANIFEST_DIR"), "/src/node-types.json"));
 
@@ -21,13 +24,14 @@ fn main() {
     let dest = Path::new(&out_dir).join("rust_lint_pass.rs");
     fs::write(&dest, &code).expect("failed to write generated visitor");
 
-    println!("cargo::rerun-if-changed=src");
+    println!("cargo::rerun-if-changed=src/node-types.json");
 
-    let manifest_dir = env::var("CARGO_MANIFEST_DIR").expect("cargo should set CARGO_MANIFEST_DIR");
     let mut fingerprint = Fingerprint::new();
-    fingerprint
-        .add_directory(&Path::new(&manifest_dir).join("src"))
-        .expect("failed to read the crate sources");
     fingerprint.add_bytes(code.as_bytes());
-    println!("cargo::rustc-env=WHISKER_RUST_FINGERPRINT={fingerprint}");
+    let dest = Path::new(&out_dir).join("visitor_fingerprint.rs");
+    fs::write(
+        &dest,
+        format!("pub const VISITOR_FINGERPRINT: u64 = 0x{fingerprint};\n"),
+    )
+    .expect("failed to write the visitor fingerprint");
 }

--- a/crates/whisker-rust/src/export_lints.rs
+++ b/crates/whisker-rust/src/export_lints.rs
@@ -26,8 +26,8 @@ macro_rules! export_lints {
             $crate::plugin::PluginDeclaration {
                 abi_version: $crate::plugin::ABI_VERSION,
                 rustc_version: $crate::plugin::RUSTC_VERSION.as_ptr(),
-                types_fingerprint: $crate::plugin::TYPES_FINGERPRINT.as_ptr(),
-                language_fingerprint: $crate::plugin::LANGUAGE_FINGERPRINT.as_ptr(),
+                types_fingerprint: $crate::plugin::TYPES_FINGERPRINT,
+                language_fingerprint: $crate::plugin::LANGUAGE_FINGERPRINT,
                 register: __whisker_register,
             };
 
@@ -97,10 +97,10 @@ mod tests {
         let rustc_version = unsafe { CStr::from_ptr(whisker_plugin_declaration.rustc_version) };
         assert_eq!(rustc_version, plugin::RUSTC_VERSION);
 
-        let types = unsafe { CStr::from_ptr(whisker_plugin_declaration.types_fingerprint) };
+        let types = whisker_plugin_declaration.types_fingerprint;
         assert_eq!(types, plugin::TYPES_FINGERPRINT);
 
-        let language = unsafe { CStr::from_ptr(whisker_plugin_declaration.language_fingerprint) };
+        let language = whisker_plugin_declaration.language_fingerprint;
         assert_eq!(language, plugin::LANGUAGE_FINGERPRINT);
     }
 

--- a/crates/whisker-rust/src/plugin.rs
+++ b/crates/whisker-rust/src/plugin.rs
@@ -10,40 +10,70 @@
 //! [`RustLintPass`]: crate::RustLintPass
 //! [`export_lints!`]: crate::export_lints
 
-use std::ffi::CStr;
-
 pub use whisker_types::plugin::{
     ABI_VERSION, LintPassFactory, LintRegistrar, PluginDeclaration, RUSTC_VERSION,
     TYPES_FINGERPRINT, c_str,
 };
+use whisker_types::plugin::{Shape, seeded_fingerprint};
 
-/// A fingerprint of the whisker-rust source this crate was compiled from
+use crate::decorations::{
+    AdtFlags, ErrorType, FnSignature, ResolvedType, ReturnMode, TypePath, TypePathRef,
+};
+
+include!(concat!(env!("OUT_DIR"), "/visitor_fingerprint.rs"));
+
+/// A fingerprint of the Rust language support a plugin was built against
 ///
-/// The hash covers the crate's sources, the grammar's node types, and the
-/// generated lint pass trait, so a plugin built against different Rust
-/// language support is refused at load rather than dispatched into
-/// methods that no longer line up with the tree.
+/// Two things on this side shape the boundary. The generated lint pass
+/// trait is one: its methods are named after the grammar's node kinds and
+/// a plugin generated from a different grammar would not crash, its checks
+/// would quietly never fire, so [`VISITOR_FINGERPRINT`] hashes the
+/// generated source. The decoration types are the other, because a plugin
+/// reads them out of a node the host decorated, and reading them at a
+/// layout the host did not write is unsound rather than merely quiet.
+///
+/// Everything else in this crate is deliberately absent. Hashing it, as an
+/// earlier revision did, refused every plugin in the tree whenever any
+/// source file here changed at all.
 ///
 /// # Examples
 ///
 /// ```
 /// use whisker_rust::plugin::LANGUAGE_FINGERPRINT;
 ///
-/// let fingerprint = LANGUAGE_FINGERPRINT.to_str().expect("should be UTF-8");
-///
-/// assert_eq!(fingerprint.len(), 16);
+/// assert_ne!(LANGUAGE_FINGERPRINT, 0);
 /// ```
-pub const LANGUAGE_FINGERPRINT: &CStr = c_str(concat!(env!("WHISKER_RUST_FINGERPRINT"), "\0"));
+pub const LANGUAGE_FINGERPRINT: u64 = seeded_fingerprint(
+    VISITOR_FINGERPRINT,
+    &[
+        Shape::of::<AdtFlags>(),
+        Shape::of::<ErrorType>(),
+        Shape::of::<FnSignature>(),
+        Shape::of::<ResolvedType>(),
+        Shape::of::<ReturnMode>(),
+        Shape::of::<TypePath>(),
+        Shape::of::<TypePathRef>(),
+    ],
+);
 
 #[cfg(test)]
 mod tests {
     use super::*;
 
     #[test]
-    fn language_fingerprint_is_a_64_bit_hex_string() {
-        let fingerprint = LANGUAGE_FINGERPRINT.to_str().expect("should be UTF-8");
+    fn language_fingerprint_covers_more_than_the_visitor() {
+        let visitor_only = VISITOR_FINGERPRINT;
 
-        assert_eq!(fingerprint.len(), 16);
-        assert!(fingerprint.chars().all(|c| c.is_ascii_hexdigit()));
+        let combined = LANGUAGE_FINGERPRINT;
+
+        assert_ne!(combined, visitor_only);
+        assert_ne!(combined, 0);
+    }
+
+    #[test]
+    fn visitor_fingerprint_is_not_zero() {
+        let generated = VISITOR_FINGERPRINT;
+
+        assert_ne!(generated, 0);
     }
 }

--- a/crates/whisker-types/Cargo.toml
+++ b/crates/whisker-types/Cargo.toml
@@ -15,7 +15,6 @@ tree-sitter-rust.workspace = true
 
 [build-dependencies]
 rustc_version.workspace = true
-whisker-codegen.workspace = true
 
 [lints]
 workspace = true

--- a/crates/whisker-types/build.rs
+++ b/crates/whisker-types/build.rs
@@ -1,29 +1,13 @@
-use std::path::Path;
-
-use whisker_codegen::Fingerprint;
-
-/// Bakes the compiler's identity and a source fingerprint into the crate
+/// Bakes the compiler's identity into the crate
 ///
-/// Both values feed the custom lint plugin handshake. Rust has no stable
-/// ABI, so whisker only loads a plugin whose whisker-types was compiled by
-/// the same rustc from the same source as its own. The crate version cannot
-/// stand in for the source: every whisker crate is unpublished and stays at
-/// one version between releases, so two builds of "0.1.0" can differ. The
-/// fingerprint detects drift; it is not a security measure.
+/// Rust has no stable ABI, so whisker only loads a plugin its own rustc
+/// compiled. The layout of the boundary is fingerprinted in the crate
+/// itself rather than here, because a build script sees source text and
+/// the handshake cares about how that text lays out in memory.
 fn main() {
-    println!("cargo::rerun-if-changed=src");
-
     let version = rustc_version::version_meta().expect("failed to read the rustc version");
     println!(
         "cargo::rustc-env=WHISKER_RUSTC_VERSION={}",
         version.short_version_string
     );
-
-    let manifest_dir =
-        std::env::var("CARGO_MANIFEST_DIR").expect("cargo should set CARGO_MANIFEST_DIR");
-    let mut fingerprint = Fingerprint::new();
-    fingerprint
-        .add_directory(&Path::new(&manifest_dir).join("src"))
-        .expect("failed to read the crate sources");
-    println!("cargo::rustc-env=WHISKER_TYPES_FINGERPRINT={fingerprint}");
 }

--- a/crates/whisker-types/src/decorated_node.rs
+++ b/crates/whisker-types/src/decorated_node.rs
@@ -1,3 +1,4 @@
+use std::mem::offset_of;
 use std::path::Path;
 use std::sync::Arc;
 
@@ -152,6 +153,18 @@ impl std::fmt::Debug for DecoratedNode<'_> {
             .finish()
     }
 }
+
+/// The offsets of every field, in declaration order
+///
+/// The plugin handshake hashes these so a plugin that places a field
+/// somewhere else is refused rather than trusted. They live beside the
+/// struct, because a field added there has to be added here too.
+pub(crate) const FIELD_OFFSETS: &[usize] = &[
+    offset_of!(DecoratedNode<'static>, node),
+    offset_of!(DecoratedNode<'static>, source),
+    offset_of!(DecoratedNode<'static>, file),
+    offset_of!(DecoratedNode<'static>, decorations),
+];
 
 #[cfg(test)]
 mod tests {

--- a/crates/whisker-types/src/diagnostic.rs
+++ b/crates/whisker-types/src/diagnostic.rs
@@ -1,3 +1,5 @@
+use std::mem::offset_of;
+
 use crate::{Location, RuleId, Severity, Span, Suggestion};
 
 /// A diagnostic emitted by a lint rule
@@ -112,6 +114,21 @@ impl Diagnostic {
         &self.suggestions
     }
 }
+
+/// The offsets of every field, in declaration order
+///
+/// The plugin handshake hashes these so a plugin that places a field
+/// somewhere else is refused rather than trusted. They live beside the
+/// struct, because a field added there has to be added here too.
+pub(crate) const FIELD_OFFSETS: &[usize] = &[
+    offset_of!(Diagnostic, rule_id),
+    offset_of!(Diagnostic, severity),
+    offset_of!(Diagnostic, message),
+    offset_of!(Diagnostic, span),
+    offset_of!(Diagnostic, origins),
+    offset_of!(Diagnostic, related),
+    offset_of!(Diagnostic, suggestions),
+];
 
 #[cfg(test)]
 mod tests {

--- a/crates/whisker-types/src/location.rs
+++ b/crates/whisker-types/src/location.rs
@@ -1,3 +1,5 @@
+use std::mem::offset_of;
+
 use crate::Span;
 
 /// A source location with an associated message
@@ -27,6 +29,14 @@ impl Location {
         &self.message
     }
 }
+
+/// The offsets of every field, in declaration order
+///
+/// The plugin handshake hashes these so a plugin that places a field
+/// somewhere else is refused rather than trusted. They live beside the
+/// struct, because a field added there has to be added here too.
+pub(crate) const FIELD_OFFSETS: &[usize] =
+    &[offset_of!(Location, span), offset_of!(Location, message)];
 
 #[cfg(test)]
 mod tests {

--- a/crates/whisker-types/src/plugin.rs
+++ b/crates/whisker-types/src/plugin.rs
@@ -12,8 +12,8 @@
 //!
 //! 1. [`PluginDeclaration::abi_version`] sits first in a `#[repr(C)]`
 //!    struct, so it reads correctly whatever else changed.
-//! 2. The version and fingerprint fields are C strings, readable across
-//!    any pair of rustc versions.
+//! 2. The rustc version is a C string and the two fingerprints are plain
+//!    integers, all readable across any pair of rustc versions.
 //! 3. Only when every one of them matches the host's own constants may
 //!    [`PluginDeclaration::register`] be called, because a plain Rust
 //!    function pointer is only meaningful once the two images are known to
@@ -23,8 +23,12 @@
 //! values a plugin allocated (diagnostics, boxed passes), which is sound
 //! because both images default to the system allocator.
 //!
-//! The handshake reaches the whisker source both sides compiled, not the
-//! dependency graph each side resolved. A plugin's lockfile picks its own
+//! The handshake reaches how both sides lay out the boundary, not the
+//! source they compiled and not the dependency graph each side resolved.
+//! Layout is what unsoundness turns on, and it is far narrower than source
+//! text: a doc comment or a private helper moves nothing, so a plugin
+//! stays loadable across most of whisker's own churn. A plugin's lockfile
+//! picks its own
 //! `tree-sitter`, whose `Node` is a `#[repr(transparent)]` wrapper around
 //! a `#[repr(C)]` struct of the C library, so a patch-level difference
 //! moves no field. It does give each image its own copy of that C
@@ -34,27 +38,38 @@
 
 use std::ffi::CStr;
 
+use crate::{
+    Coverage, CoverageGap, DecoratedNode, DecoratedTree, DecorationKey, DecorationMap, Diagnostic,
+    Language, Location, ProviderName, RuleId, Severity, Span, Suggestion, UncoveredFile,
+};
+
 mod declaration;
+mod fingerprint;
 mod registrar;
 
 pub use declaration::PluginDeclaration;
+pub use fingerprint::{Shape, fingerprint, seeded_fingerprint};
 pub use registrar::{LintPassFactory, LintRegistrar};
 
 /// The version of the plugin declaration protocol itself
 ///
 /// This guards the shape of [`PluginDeclaration`] and the meaning of its
-/// fields, not the ABI of the lint passes; the version and fingerprint
-/// strings guard those. Bump it whenever the declaration struct or the
-/// registration contract changes.
+/// fields, and the method order of the two traits that cross the boundary,
+/// which no fingerprint can read back. The rustc version and the two
+/// fingerprints guard everything else. Bump it whenever the declaration
+/// struct, the registration contract, [`LintPass`], or [`LintRegistrar`]
+/// changes.
+///
+/// [`LintPass`]: crate::LintPass
 ///
 /// # Examples
 ///
 /// ```
 /// use whisker_types::plugin::ABI_VERSION;
 ///
-/// assert_eq!(ABI_VERSION, 1);
+/// assert_eq!(ABI_VERSION, 2);
 /// ```
-pub const ABI_VERSION: u32 = 1;
+pub const ABI_VERSION: u32 = 2;
 
 /// The full identity of the rustc that compiled this crate
 ///
@@ -73,24 +88,51 @@ pub const ABI_VERSION: u32 = 1;
 /// ```
 pub const RUSTC_VERSION: &CStr = c_str(concat!(env!("WHISKER_RUSTC_VERSION"), "\0"));
 
-/// A fingerprint of the whisker-types source this crate was compiled from
+/// A fingerprint of how this crate lays out the plugin boundary
 ///
 /// The crate version cannot detect drift, because whisker's crates are
-/// unpublished and hold one version between releases. The build script
-/// hashes every source file instead, so a plugin built against a different
-/// revision of whisker-types is refused rather than trusted to share
-/// layouts it may not share.
+/// unpublished and hold one version between releases. Hashing the source
+/// text detects far too much of it: a doc comment or a private helper
+/// would refuse every plugin in the tree until each was rebuilt, which is
+/// the whole cost of shipping rules as plugins. This hashes what the two
+/// images must actually agree on instead — the size, alignment, and field
+/// offsets of every type that crosses the boundary.
+///
+/// What it does not cover is the shape of [`LintPass`] and
+/// [`LintRegistrar`] themselves. A trait object's vtable orders its
+/// methods by declaration, and no const can read that back, so adding,
+/// removing, or reordering a method on either trait is a change to the
+/// protocol and belongs in [`ABI_VERSION`]. The `abi_version_covers_the
+/// _boundary_traits` test in this module fails when either trait's method
+/// list moves, so the bump is not left to memory.
+///
+/// [`LintPass`]: crate::LintPass
 ///
 /// # Examples
 ///
 /// ```
 /// use whisker_types::plugin::TYPES_FINGERPRINT;
 ///
-/// let fingerprint = TYPES_FINGERPRINT.to_str().expect("should be UTF-8");
-///
-/// assert_eq!(fingerprint.len(), 16);
+/// assert_ne!(TYPES_FINGERPRINT, 0);
 /// ```
-pub const TYPES_FINGERPRINT: &CStr = c_str(concat!(env!("WHISKER_TYPES_FINGERPRINT"), "\0"));
+pub const TYPES_FINGERPRINT: u64 = fingerprint(&[
+    Shape::of_fields::<Diagnostic>(crate::diagnostic::FIELD_OFFSETS),
+    Shape::of_fields::<Span>(crate::span::FIELD_OFFSETS),
+    Shape::of_fields::<Suggestion>(crate::suggestion::FIELD_OFFSETS),
+    Shape::of_fields::<Location>(crate::location::FIELD_OFFSETS),
+    Shape::of_fields::<DecoratedNode<'static>>(crate::decorated_node::FIELD_OFFSETS),
+    Shape::of::<DecoratedTree>(),
+    Shape::of::<DecorationKey>(),
+    Shape::of::<DecorationMap>(),
+    Shape::of::<RuleId>(),
+    Shape::of::<Severity>(),
+    Shape::of::<Language>(),
+    Shape::of::<ProviderName>(),
+    Shape::of::<Coverage>(),
+    Shape::of::<CoverageGap>(),
+    Shape::of::<UncoveredFile>(),
+    Shape::of::<LintPassFactory>(),
+]);
 
 /// Converts a NUL-terminated string literal into a [`&CStr`] at compile time
 ///
@@ -130,11 +172,61 @@ mod tests {
         assert!(version.starts_with("rustc"), "unexpected: {version}");
     }
 
-    #[test]
-    fn types_fingerprint_is_a_64_bit_hex_string() {
-        let fingerprint = TYPES_FINGERPRINT.to_str().expect("should be UTF-8");
+    /// Returns each method signature a trait declares, in declaration order
+    ///
+    /// The scan takes the lines inside the trait's block that open a
+    /// method and squeezes their whitespace, so a doc comment or a
+    /// reflowed line changes nothing while an added, removed, reordered,
+    /// or re-signed method does.
+    fn method_signatures(source: &str, declaration: &str) -> Vec<String> {
+        let body = source
+            .split_once(declaration)
+            .expect("the trait should be declared in this source")
+            .1;
+        let body = body
+            .split_once("\n}")
+            .expect("the trait block should be closed")
+            .0;
 
-        assert_eq!(fingerprint.len(), 16);
-        assert!(fingerprint.chars().all(|c| c.is_ascii_hexdigit()));
+        body.lines()
+            .map(str::trim)
+            .filter(|line| line.starts_with("fn "))
+            .map(|line| line.split_whitespace().collect::<Vec<_>>().join(" "))
+            .collect()
+    }
+
+    #[test]
+    fn abi_version_covers_the_boundary_traits() {
+        let lint_pass = method_signatures(
+            include_str!("lint_pass.rs"),
+            "pub trait LintPass: Send + Sync {",
+        );
+        let registrar = method_signatures(
+            include_str!("plugin/registrar.rs"),
+            "pub trait LintRegistrar {",
+        );
+
+        assert_eq!(
+            (lint_pass, registrar),
+            (
+                vec![
+                    "fn check_node(&mut self, node: &DecoratedNode<'_>) -> Vec<Diagnostic>;"
+                        .to_owned()
+                ],
+                vec!["fn register(&mut self, factory: LintPassFactory);".to_owned()],
+            ),
+            "a boundary trait's methods moved, which reorders its vtable; \
+             bump ABI_VERSION and update this test together",
+        );
+    }
+
+    #[test]
+    fn types_fingerprint_covers_every_boundary_type() {
+        let one = fingerprint(&[Shape::of::<Diagnostic>()]);
+
+        let all = TYPES_FINGERPRINT;
+
+        assert_ne!(all, one);
+        assert_ne!(all, 0);
     }
 }

--- a/crates/whisker-types/src/plugin/declaration.rs
+++ b/crates/whisker-types/src/plugin/declaration.rs
@@ -12,10 +12,11 @@ use crate::plugin::LintRegistrar;
 ///
 /// - [`abi_version`] is a bare integer at offset zero of a `#[repr(C)]`
 ///   struct, readable whatever else changed.
-/// - The version and fingerprint fields are pointers to NUL-terminated
-///   strings in the plugin's immutable data, readable across rustc
-///   versions. They are raw pointers rather than `&CStr`, because a
-///   reference's layout is only promised within one compiler.
+/// - [`rustc_version`] is a pointer to a NUL-terminated string in the
+///   plugin's immutable data, readable across rustc versions. It is a raw
+///   pointer rather than a `&CStr`, because a reference's layout is only
+///   promised within one compiler. The two fingerprints are plain `u64`,
+///   which needs no such promise.
 /// - [`register`] is a plain Rust function pointer. Calling it hands
 ///   `&mut dyn` trait objects across the boundary, which is only sound
 ///   once every prior field proved that both images agree on the ABI.
@@ -24,11 +25,12 @@ use crate::plugin::LintRegistrar;
 /// this struct is a wire format: the exporting macro constructs it in a
 /// `const` context and the loader consumes it field by field.
 ///
-/// `Send` and `Sync` are implemented by hand, because the string fields
-/// make the type `!Sync` by default; they are sound because every field
-/// points at immutable `'static` data in the plugin image.
+/// `Send` and `Sync` are implemented by hand, because the version pointer
+/// makes the type `!Sync` by default; they are sound because it points at
+/// immutable `'static` data in the plugin image.
 ///
 /// [`abi_version`]: PluginDeclaration::abi_version
+/// [`rustc_version`]: PluginDeclaration::rustc_version
 /// [`register`]: PluginDeclaration::register
 #[repr(C)]
 pub struct PluginDeclaration {
@@ -45,7 +47,7 @@ pub struct PluginDeclaration {
     /// The plugin's copy of [`TYPES_FINGERPRINT`]
     ///
     /// [`TYPES_FINGERPRINT`]: crate::plugin::TYPES_FINGERPRINT
-    pub types_fingerprint: *const c_char,
+    pub types_fingerprint: u64,
 
     /// The plugin's fingerprint of the language crate it was built against
     ///
@@ -54,7 +56,7 @@ pub struct PluginDeclaration {
     /// plugin whose dispatch was generated from a different grammar would
     /// not crash, but its checks would quietly never fire; the handshake
     /// turns that into a refusal.
-    pub language_fingerprint: *const c_char,
+    pub language_fingerprint: u64,
 
     /// Registers the plugin's lint passes with the host
     ///

--- a/crates/whisker-types/src/plugin/fingerprint.rs
+++ b/crates/whisker-types/src/plugin/fingerprint.rs
@@ -1,0 +1,251 @@
+use std::mem::{align_of, size_of};
+
+/// One type's contribution to a boundary fingerprint
+///
+/// A plugin and its host agree on a type when they place it in memory
+/// identically. Size and alignment catch a type that grew, shrank, or
+/// changed its alignment; the offsets a caller supplies catch fields that
+/// swapped places without changing either. Nothing here reads a field's
+/// name or its type, so renaming a private field costs nothing and moving
+/// one is refused.
+#[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug)]
+pub struct Shape {
+    size: usize,
+    align: usize,
+    offsets: &'static [usize],
+}
+
+impl Shape {
+    /// Returns the shape of `T`, with no field offsets recorded
+    ///
+    /// Use this for a type that crosses the boundary whole, such as an
+    /// enum the host only ever matches on, and [`Shape::of_fields`] for one
+    /// whose fields both images address.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use whisker_types::plugin::Shape;
+    ///
+    /// const SHAPE: Shape = Shape::of::<u64>();
+    ///
+    /// assert_eq!(SHAPE.size(), 8);
+    /// ```
+    pub const fn of<T>() -> Self {
+        Self {
+            size: size_of::<T>(),
+            align: align_of::<T>(),
+            offsets: &[],
+        }
+    }
+
+    /// Returns the shape of `T` together with the offsets of its fields
+    ///
+    /// Pass every offset the two images depend on, in a fixed order. The
+    /// caller supplies them because [`offset_of`] only reaches fields its
+    /// own crate can name.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use std::mem::offset_of;
+    ///
+    /// use whisker_types::plugin::Shape;
+    ///
+    /// struct Pair {
+    ///     first: u32,
+    ///     second: u32,
+    /// }
+    ///
+    /// const SHAPE: Shape = Shape::of_fields::<Pair>(&[offset_of!(Pair, first)]);
+    ///
+    /// assert_eq!(SHAPE.size(), 8);
+    /// ```
+    ///
+    /// [`offset_of`]: std::mem::offset_of
+    pub const fn of_fields<T>(offsets: &'static [usize]) -> Self {
+        Self {
+            size: size_of::<T>(),
+            align: align_of::<T>(),
+            offsets,
+        }
+    }
+
+    /// Returns the size this type occupies
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use whisker_types::plugin::Shape;
+    ///
+    /// assert_eq!(Shape::of::<u32>().size(), 4);
+    /// ```
+    pub const fn size(&self) -> usize {
+        self.size
+    }
+}
+
+/// Combines the shapes of every type that crosses the boundary into one hash
+///
+/// The result stands in for "these two images lay the boundary out the
+/// same way". It is FNV-1a, chosen because it is a handful of const
+/// operations rather than because it resists anything: the fingerprint
+/// detects drift between two builds of the same project, and a plugin that
+/// wants to lie about its layout can simply report the host's number.
+///
+/// # Examples
+///
+/// ```
+/// use whisker_types::plugin::{Shape, fingerprint};
+///
+/// const A: u64 = fingerprint(&[Shape::of::<u32>()]);
+/// const B: u64 = fingerprint(&[Shape::of::<u64>()]);
+///
+/// assert_ne!(A, B);
+/// ```
+pub const fn fingerprint(shapes: &[Shape]) -> u64 {
+    seeded_fingerprint(0xcbf2_9ce4_8422_2325, shapes)
+}
+
+/// Combines shapes with a value that is already a hash of something else
+///
+/// A language crate has more than layouts to answer for: whisker-rust
+/// generates its lint pass trait from a grammar, and the generated source
+/// is hashed at build time. This folds that hash in alongside the layouts
+/// rather than leaving the two to be combined by hand.
+///
+/// # Examples
+///
+/// ```
+/// use whisker_types::plugin::{Shape, seeded_fingerprint};
+///
+/// const A: u64 = seeded_fingerprint(1, &[Shape::of::<u32>()]);
+/// const B: u64 = seeded_fingerprint(2, &[Shape::of::<u32>()]);
+///
+/// assert_ne!(A, B);
+/// ```
+pub const fn seeded_fingerprint(seed: u64, shapes: &[Shape]) -> u64 {
+    let mut hash = mix(0xcbf2_9ce4_8422_2325, seed);
+
+    let mut index = 0;
+    while index < shapes.len() {
+        let shape = shapes[index];
+        hash = mix(hash, shape.size as u64);
+        hash = mix(hash, shape.align as u64);
+
+        let mut field = 0;
+        while field < shape.offsets.len() {
+            hash = mix(hash, shape.offsets[field] as u64);
+            field += 1;
+        }
+
+        hash = mix(hash, shape.offsets.len() as u64);
+        index += 1;
+    }
+
+    mix(hash, shapes.len() as u64)
+}
+
+/// Folds one value into a running FNV-1a hash, byte by byte
+const fn mix(hash: u64, value: u64) -> u64 {
+    let bytes = value.to_le_bytes();
+
+    let mut hash = hash;
+    let mut index = 0;
+    while index < bytes.len() {
+        hash ^= bytes[index] as u64;
+        hash = hash.wrapping_mul(0x0000_0100_0000_01b3);
+        index += 1;
+    }
+
+    hash
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn fingerprint_distinguishes_reordered_fields() {
+        let before = fingerprint(&[Shape::of_fields::<u64>(&[0, 4])]);
+
+        let after = fingerprint(&[Shape::of_fields::<u64>(&[4, 0])]);
+
+        assert_ne!(before, after);
+    }
+
+    #[test]
+    fn fingerprint_distinguishes_shapes_of_equal_size() {
+        let one = fingerprint(&[Shape::of_fields::<u64>(&[0])]);
+
+        let other = fingerprint(&[Shape::of_fields::<u64>(&[0, 0])]);
+
+        assert_ne!(one, other);
+    }
+
+    #[test]
+    fn fingerprint_of_the_same_shapes_is_stable() {
+        let shapes = [Shape::of::<u32>(), Shape::of_fields::<u64>(&[0, 4])];
+
+        let repeated = fingerprint(&shapes);
+
+        assert_eq!(fingerprint(&shapes), repeated);
+    }
+
+    #[test]
+    fn fingerprint_matches_its_default_seed() {
+        let seeded = seeded_fingerprint(0xcbf2_9ce4_8422_2325, &[Shape::of::<u32>()]);
+
+        let plain = fingerprint(&[Shape::of::<u32>()]);
+
+        assert_eq!(plain, seeded);
+    }
+
+    #[test]
+    fn fingerprint_of_the_empty_boundary_is_not_zero() {
+        let empty = fingerprint(&[]);
+
+        assert_ne!(empty, 0);
+    }
+
+    #[test]
+    fn fingerprint_orders_its_shapes() {
+        let one = fingerprint(&[Shape::of::<u32>(), Shape::of::<u64>()]);
+
+        let other = fingerprint(&[Shape::of::<u64>(), Shape::of::<u32>()]);
+
+        assert_ne!(one, other);
+    }
+
+    #[test]
+    fn of_fields_records_the_offsets_it_is_given() {
+        let shape = Shape::of_fields::<u64>(&[0, 4]);
+
+        assert_eq!(shape.offsets, &[0, 4]);
+    }
+
+    #[test]
+    fn of_records_no_offsets() {
+        let shape = Shape::of::<u64>();
+
+        assert!(shape.offsets.is_empty());
+    }
+
+    #[test]
+    fn trait_send() {
+        fn assert_send<T: Send>() {}
+        assert_send::<Shape>();
+    }
+
+    #[test]
+    fn trait_sync() {
+        fn assert_sync<T: Sync>() {}
+        assert_sync::<Shape>();
+    }
+
+    #[test]
+    fn trait_unpin() {
+        fn assert_unpin<T: Unpin>() {}
+        assert_unpin::<Shape>();
+    }
+}

--- a/crates/whisker-types/src/span.rs
+++ b/crates/whisker-types/src/span.rs
@@ -1,3 +1,4 @@
+use std::mem::offset_of;
 use std::path::Path;
 use std::sync::Arc;
 
@@ -48,6 +49,17 @@ impl Span {
         self.end
     }
 }
+
+/// The offsets of every field, in declaration order
+///
+/// The plugin handshake hashes these so a plugin that places a field
+/// somewhere else is refused rather than trusted. They live beside the
+/// struct, because a field added there has to be added here too.
+pub(crate) const FIELD_OFFSETS: &[usize] = &[
+    offset_of!(Span, file),
+    offset_of!(Span, start),
+    offset_of!(Span, end),
+];
 
 #[cfg(test)]
 mod tests {

--- a/crates/whisker-types/src/suggestion.rs
+++ b/crates/whisker-types/src/suggestion.rs
@@ -1,3 +1,5 @@
+use std::mem::offset_of;
+
 use crate::Span;
 
 /// A suggested source code replacement
@@ -36,6 +38,17 @@ impl Suggestion {
         &self.message
     }
 }
+
+/// The offsets of every field, in declaration order
+///
+/// The plugin handshake hashes these so a plugin that places a field
+/// somewhere else is refused rather than trusted. They live beside the
+/// struct, because a field added there has to be added here too.
+pub(crate) const FIELD_OFFSETS: &[usize] = &[
+    offset_of!(Suggestion, span),
+    offset_of!(Suggestion, replacement),
+    offset_of!(Suggestion, message),
+];
 
 #[cfg(test)]
 mod tests {

--- a/crates/whisker/src/custom_lints.rs
+++ b/crates/whisker/src/custom_lints.rs
@@ -191,8 +191,8 @@ fn load_library(library: &Path, host: &AbiIdentity) -> anyhow::Result<Vec<LintPa
     let plugin = AbiIdentity {
         abi_version: plugin_abi_version,
         rustc_version: read_declaration_string(declaration.rustc_version)?,
-        types_fingerprint: read_declaration_string(declaration.types_fingerprint)?,
-        language_fingerprint: read_declaration_string(declaration.language_fingerprint)?,
+        types_fingerprint: declaration.types_fingerprint,
+        language_fingerprint: declaration.language_fingerprint,
     };
     handshake::validate(host, &plugin)?;
 

--- a/crates/whisker/src/custom_lints/handshake.rs
+++ b/crates/whisker/src/custom_lints/handshake.rs
@@ -12,8 +12,8 @@ use whisker_rust::plugin;
 pub struct AbiIdentity {
     pub abi_version: u32,
     pub rustc_version: String,
-    pub types_fingerprint: String,
-    pub language_fingerprint: String,
+    pub types_fingerprint: u64,
+    pub language_fingerprint: u64,
 }
 
 impl AbiIdentity {
@@ -22,8 +22,8 @@ impl AbiIdentity {
         Self {
             abi_version: plugin::ABI_VERSION,
             rustc_version: plugin::RUSTC_VERSION.to_string_lossy().into_owned(),
-            types_fingerprint: plugin::TYPES_FINGERPRINT.to_string_lossy().into_owned(),
-            language_fingerprint: plugin::LANGUAGE_FINGERPRINT.to_string_lossy().into_owned(),
+            types_fingerprint: plugin::TYPES_FINGERPRINT,
+            language_fingerprint: plugin::LANGUAGE_FINGERPRINT,
         }
     }
 }
@@ -117,8 +117,8 @@ mod tests {
         AbiIdentity {
             abi_version: 1,
             rustc_version: "rustc 1.92.0-nightly (0000000 2026-08-11)".into(),
-            types_fingerprint: "00000000000000aa".into(),
-            language_fingerprint: "00000000000000bb".into(),
+            types_fingerprint: 0xaa,
+            language_fingerprint: 0xbb,
         }
     }
 
@@ -171,7 +171,7 @@ mod tests {
     #[test]
     fn validate_reports_a_differing_language_fingerprint() {
         let mut plugin = identity();
-        plugin.language_fingerprint = "00000000000000cc".into();
+        plugin.language_fingerprint = 0xcc;
 
         let error = validate(&identity(), &plugin).expect_err("should mismatch");
 
@@ -195,7 +195,7 @@ mod tests {
     #[test]
     fn validate_reports_a_differing_types_fingerprint() {
         let mut plugin = identity();
-        plugin.types_fingerprint = "00000000000000cc".into();
+        plugin.types_fingerprint = 0xcc;
 
         let error = validate(&identity(), &plugin).expect_err("should mismatch");
 

--- a/examples/custom_lint/Cargo.lock
+++ b/examples/custom_lint/Cargo.lock
@@ -295,7 +295,6 @@ dependencies = [
  "anyhow",
  "rustc_version",
  "tree-sitter",
- "whisker-codegen",
 ]
 
 [[package]]


### PR DESCRIPTION
The plugin handshake hashed the source directories of whisker-types and whisker-rust, so any edit to either crate refused every plugin in the tree until each one was rebuilt. A doc comment cost exactly as much as a changed field. That is affordable while `examples/custom_lint` is the only plugin, and not affordable at all if rules ship as plugins, where the cost scales with how many there are.

The fingerprints now hash what unsoundness actually turns on: the size, alignment, and field offsets of every type that crosses the boundary, computed by const evaluation from the types themselves, plus the lint pass trait whisker-rust generates from the grammar. Text that moves no field threatens nothing and no longer counts. Each boundary struct carries its own `FIELD_OFFSETS` beside its declaration, so a field added there has to be added to the fingerprint in the same place rather than in a list somebody forgets.

Layout cannot cover the one remaining thing. A trait object orders its vtable by declaration and no const reads that back, so the method lists of `LintPass` and `LintRegistrar` belong to `ABI_VERSION` instead. `abi_version_covers_the_boundary_traits` pins both lists and fails when either moves, so the bump is not left to memory.

Both fingerprint fields become `u64` rather than pointers to C strings, which is what takes `ABI_VERSION` to 2. An integer at a fixed offset in a `#[repr(C)]` struct is readable across rustc versions on exactly the terms a C string was, and it is one less pointer to read before the handshake has established anything.

Verified in both directions rather than by argument. Appending a function and a doc comment to `whisker-rust/src/lib.rs` leaves both fingerprints byte-identical, where before it moved the language fingerprint. Swapping two entries in `Span`'s offsets moves the types fingerprint and leaves the language one alone. The end-to-end `check_with_custom_lint_reports_its_diagnostic` test still loads a separately built cdylib and reports its diagnostic, so the handshake still does its job.