### PR TITLE
Load every lint plugin a directory builds

### DIFF
--- a/crates/whisker/src/custom_lints.rs
+++ b/crates/whisker/src/custom_lints.rs
@@ -106,13 +106,25 @@ fn configured_directories(config: &WhiskerConfig) -> anyhow::Result<Vec<PathBuf>
     Ok(directories)
 }
 
-/// Builds the package at `directory` and loads the lints it exports
+/// Builds the packages at `directory` and loads the lints they export
+///
+/// A directory may hold one package or a workspace of them, so every
+/// dynamic library the build produced is loaded, each with its own
+/// handshake.
 fn load_directory(directory: &Path, host: &AbiIdentity) -> anyhow::Result<Vec<LintPassFactory>> {
-    let library = build(directory)?;
-    load_library(&library, host)
+    let libraries = build(directory)?;
+    let mut factories = Vec::new();
+
+    for library in libraries {
+        let loaded = load_library(&library, host)
+            .with_context(|| format!("failed to load {}", library.display()))?;
+        factories.extend(loaded);
+    }
+
+    Ok(factories)
 }
 
-/// Compiles the plugin with the user's cargo and returns the built library
+/// Compiles the packages at `directory` and returns every library built
 ///
 /// The build inherits stderr, so compiler errors and progress render to
 /// the terminal exactly as they would for a direct `cargo build`; stdout
@@ -122,8 +134,8 @@ fn load_directory(directory: &Path, host: &AbiIdentity) -> anyhow::Result<Vec<Li
 /// # Errors
 ///
 /// Returns an error if cargo cannot be run, exits unsuccessfully, or
-/// produces no dynamic library for the package.
-fn build(directory: &Path) -> anyhow::Result<PathBuf> {
+/// produces no dynamic library.
+fn build(directory: &Path) -> anyhow::Result<Vec<PathBuf>> {
     let cargo = std::env::var_os("CARGO").unwrap_or_else(|| OsString::from("cargo"));
 
     let output = Command::new(cargo)
@@ -142,7 +154,7 @@ fn build(directory: &Path) -> anyhow::Result<PathBuf> {
 
     let stdout = String::from_utf8(output.stdout).context("cargo build wrote invalid UTF-8")?;
 
-    artifact::cdylib_artifact(&stdout, &directory.join("Cargo.toml"))
+    artifact::cdylib_artifacts(&stdout, directory)
 }
 
 /// Opens the built library, performs the handshake, and collects factories

--- a/crates/whisker/src/custom_lints/artifact.rs
+++ b/crates/whisker/src/custom_lints/artifact.rs
@@ -1,3 +1,4 @@
+use std::collections::BTreeMap;
 use std::path::{Path, PathBuf};
 
 use anyhow::Context as _;
@@ -26,22 +27,34 @@ struct Target {
     crate_types: Vec<String>,
 }
 
-/// Finds the dynamic library that cargo built for the package at `manifest`
+/// Finds every dynamic library cargo built from a package under `directory`
 ///
-/// `stdout` is the JSON message stream of a successful `cargo build`. The
-/// search matches artifacts by manifest path rather than by package name,
-/// so a dependency that happens to share the plugin's name cannot be
-/// loaded in its place.
+/// `stdout` is the JSON message stream of a successful `cargo build`. A
+/// configured entry may name a single package or a workspace of them, and
+/// a repository of shared rules is usually the latter, so the search
+/// collects all of them rather than one.
+///
+/// Artifacts are matched by where their manifest sits rather than by
+/// package name, so a dependency that happens to share a plugin's name
+/// cannot be loaded in its place. Dependencies resolve outside the
+/// configured directory, into cargo's registry and git caches, which is
+/// what makes containment a sufficient test.
+///
+/// The result is keyed by manifest path, which sorts it and keeps one
+/// library per package in a single step. Both matter: cargo emits
+/// artifacts in whatever order the build finished them, so lint order
+/// would otherwise shift between runs, and a package cargo reports twice
+/// would be loaded twice and report every finding twice.
 ///
 /// # Errors
 ///
-/// Returns an error if a message line is not valid JSON, if the build
-/// produced no artifact for `manifest`, or if the package does not build a
-/// `cdylib`. The last error quotes the manifest section to add, because a
-/// missing crate type is the most likely authoring mistake.
-pub fn cdylib_artifact(stdout: &str, manifest: &Path) -> anyhow::Result<PathBuf> {
-    let manifest = canonical(manifest);
-    let mut package_artifacts = Vec::new();
+/// Returns an error if a message line is not valid JSON, or if the build
+/// produced no dynamic library at all. The last error quotes the manifest
+/// section to add, because a missing crate type is the most likely
+/// authoring mistake.
+pub fn cdylib_artifacts(stdout: &str, directory: &Path) -> anyhow::Result<Vec<PathBuf>> {
+    let directory = canonical(directory);
+    let mut artifacts = BTreeMap::new();
 
     for line in stdout.lines().filter(|line| !line.trim().is_empty()) {
         let message: BuildMessage = serde_json::from_str(line)
@@ -51,53 +64,46 @@ pub fn cdylib_artifact(stdout: &str, manifest: &Path) -> anyhow::Result<PathBuf>
             continue;
         }
 
-        let Some(path) = &message.manifest_path else {
+        let Some(manifest) = &message.manifest_path else {
             continue;
         };
 
-        if canonical(path) == manifest {
-            package_artifacts.push(message);
+        let manifest = canonical(manifest);
+        if !manifest.starts_with(&directory) {
+            continue;
         }
+
+        let builds_cdylib = message
+            .target
+            .as_ref()
+            .is_some_and(|target| target.crate_types.iter().any(|kind| kind == "cdylib"));
+        if !builds_cdylib {
+            continue;
+        }
+
+        let Some(library) = message.filenames.iter().find(|file| {
+            file.extension()
+                .is_some_and(|extension| extension == std::env::consts::DLL_EXTENSION)
+        }) else {
+            anyhow::bail!(
+                "cargo reported no dynamic library file for {}",
+                manifest.display()
+            );
+        };
+
+        artifacts.insert(manifest, library.clone());
     }
 
     anyhow::ensure!(
-        !package_artifacts.is_empty(),
-        "cargo built no artifact for {}; the configured path must name a single cargo package, \
-         not a workspace",
-        manifest.display()
+        !artifacts.is_empty(),
+        "cargo built no dynamic library from {}; a custom lint package needs\n\n[lib]\ncrate-type \
+         = [\"cdylib\"]\n\nin its Cargo.toml",
+        directory.display()
     );
 
-    let cdylib = package_artifacts
-        .into_iter()
-        .rev()
-        .find(|artifact| {
-            artifact
-                .target
-                .as_ref()
-                .is_some_and(|target| target.crate_types.iter().any(|kind| kind == "cdylib"))
-        })
-        .with_context(|| {
-            format!(
-                "the package at {} does not build a dynamic library; add\n\n[lib]\ncrate-type = \
-                 [\"cdylib\"]\n\nto its Cargo.toml",
-                manifest.display()
-            )
-        })?;
+    let artifacts = artifacts.into_values().collect();
 
-    cdylib
-        .filenames
-        .iter()
-        .find(|file| {
-            file.extension()
-                .is_some_and(|extension| extension == std::env::consts::DLL_EXTENSION)
-        })
-        .cloned()
-        .with_context(|| {
-            format!(
-                "cargo reported no dynamic library file for {}",
-                manifest.display()
-            )
-        })
+    Ok(artifacts)
 }
 
 /// Resolves a path for comparison, or leaves it as written
@@ -114,6 +120,7 @@ fn canonical(path: &Path) -> PathBuf {
 mod tests {
     use super::*;
 
+    const DIRECTORY: &str = "/plugin";
     const MANIFEST: &str = "/plugin/Cargo.toml";
 
     fn artifact_line(manifest: &str, crate_types: &str, filenames: &str) -> String {
@@ -130,7 +137,7 @@ mod tests {
     }
 
     #[test]
-    fn cdylib_artifact_finds_the_dynamic_library() {
+    fn cdylib_artifacts_finds_the_dynamic_library() {
         let stdout = [
             r#"{"reason":"compiler-artifact","manifest_path":"/deps/other/Cargo.toml","target":{"crate_types":["lib"],"name":"other"},"filenames":["/deps/libother.rlib"]}"#.to_string(),
             artifact_line(MANIFEST, r#""cdylib""#, &dylib_name("libplugin")),
@@ -138,46 +145,126 @@ mod tests {
         ]
         .join("\n");
 
-        let artifact = cdylib_artifact(&stdout, Path::new(MANIFEST)).expect("should find");
+        let artifacts = cdylib_artifacts(&stdout, Path::new(DIRECTORY)).expect("should find");
 
-        assert!(artifact.to_string_lossy().contains("libplugin"));
+        assert_eq!(artifacts.len(), 1);
+        assert!(artifacts[0].to_string_lossy().contains("libplugin"));
+    }
+
+    /// A dependency that builds a cdylib of its own resolves outside the
+    /// configured directory, so containment keeps it out of the result.
+    #[test]
+    fn cdylib_artifacts_ignores_a_dependency_outside_the_directory() {
+        let stdout = [
+            r#"{"reason":"compiler-artifact","manifest_path":"/deps/other/Cargo.toml","target":{"crate_types":["cdylib"],"name":"other"},"filenames":["/deps/libother.so"]}"#.to_string(),
+            artifact_line(MANIFEST, r#""cdylib""#, &dylib_name("libplugin")),
+        ]
+        .join("\n");
+
+        let artifacts = cdylib_artifacts(&stdout, Path::new(DIRECTORY)).expect("should find");
+
+        assert_eq!(artifacts.len(), 1);
+        assert!(artifacts[0].to_string_lossy().contains("libplugin"));
     }
 
     #[test]
-    fn cdylib_artifact_ignores_unknown_message_reasons() {
+    fn cdylib_artifacts_ignores_unknown_message_reasons() {
         let stdout = [
             r#"{"reason":"a-future-cargo-message","novel_field":42}"#.to_string(),
             artifact_line(MANIFEST, r#""cdylib""#, &dylib_name("libplugin")),
         ]
         .join("\n");
 
-        let artifact = cdylib_artifact(&stdout, Path::new(MANIFEST));
+        let artifacts = cdylib_artifacts(&stdout, Path::new(DIRECTORY));
 
-        assert!(artifact.is_ok());
+        assert!(artifacts.is_ok());
+    }
+
+    /// A directory sharing a name prefix with the configured one is not
+    /// inside it, and `starts_with` compares whole components.
+    #[test]
+    fn cdylib_artifacts_ignores_a_sibling_with_a_shared_prefix() {
+        let stdout = [
+            artifact_line(
+                "/plugin_extra/Cargo.toml",
+                r#""cdylib""#,
+                "\"/plugin_extra/target/release/libextra.so\"",
+            ),
+            artifact_line(MANIFEST, r#""cdylib""#, &dylib_name("libplugin")),
+        ]
+        .join("\n");
+
+        let artifacts = cdylib_artifacts(&stdout, Path::new(DIRECTORY)).expect("should find");
+
+        assert_eq!(artifacts.len(), 1);
+        assert!(artifacts[0].to_string_lossy().contains("libplugin"));
     }
 
     #[test]
-    fn cdylib_artifact_picks_the_platform_library_among_filenames() {
+    fn cdylib_artifacts_picks_the_platform_library_among_filenames() {
         let filenames = format!(
             "\"/plugin/target/release/libplugin.rlib\", {}",
             dylib_name("libplugin")
         );
         let stdout = artifact_line(MANIFEST, r#""cdylib", "rlib""#, &filenames);
 
-        let artifact = cdylib_artifact(&stdout, Path::new(MANIFEST)).expect("should find");
+        let artifacts = cdylib_artifacts(&stdout, Path::new(DIRECTORY)).expect("should find");
 
         assert!(
-            artifact
+            artifacts[0]
                 .extension()
                 .is_some_and(|extension| extension == std::env::consts::DLL_EXTENSION)
         );
     }
 
     #[test]
-    fn cdylib_artifact_with_malformed_line_returns_error() {
+    fn cdylib_artifacts_of_a_workspace_returns_every_member_sorted() {
+        let stdout = [
+            artifact_line(
+                "/plugin/lints/second/Cargo.toml",
+                r#""cdylib""#,
+                &dylib_name("libsecond"),
+            ),
+            artifact_line(
+                "/plugin/lints/first/Cargo.toml",
+                r#""cdylib""#,
+                &dylib_name("libfirst"),
+            ),
+        ]
+        .join("\n");
+
+        let artifacts = cdylib_artifacts(&stdout, Path::new(DIRECTORY)).expect("should find");
+
+        assert_eq!(
+            artifacts,
+            vec![
+                PathBuf::from(dylib_name("libfirst").trim_matches('"')),
+                PathBuf::from(dylib_name("libsecond").trim_matches('"')),
+            ],
+            "members must load in a stable order, not in build-completion order"
+        );
+    }
+
+    /// Cargo reports a package once per built target, and loading the same
+    /// library twice would double every diagnostic it produces.
+    #[test]
+    fn cdylib_artifacts_reports_a_package_once() {
+        let stdout = [
+            artifact_line(MANIFEST, r#""cdylib""#, &dylib_name("libplugin")),
+            artifact_line(MANIFEST, r#""cdylib""#, &dylib_name("libplugin")),
+        ]
+        .join("\n");
+
+        let artifacts = cdylib_artifacts(&stdout, Path::new(DIRECTORY)).expect("should find");
+
+        assert_eq!(artifacts.len(), 1);
+    }
+
+    #[test]
+    fn cdylib_artifacts_with_malformed_line_returns_error() {
         let stdout = "this is not json\n";
 
-        let error = cdylib_artifact(stdout, Path::new(MANIFEST)).expect_err("should fail");
+        let error = cdylib_artifacts(stdout, Path::new(DIRECTORY)).expect_err("should fail");
 
         assert!(
             error.to_string().contains("cargo build message"),
@@ -186,14 +273,14 @@ mod tests {
     }
 
     #[test]
-    fn cdylib_artifact_without_cdylib_crate_type_names_the_remedy() {
+    fn cdylib_artifacts_without_cdylib_crate_type_names_the_remedy() {
         let stdout = artifact_line(
             MANIFEST,
             r#""lib""#,
             "\"/plugin/target/release/libplugin.rlib\"",
         );
 
-        let error = cdylib_artifact(&stdout, Path::new(MANIFEST)).expect_err("should fail");
+        let error = cdylib_artifacts(&stdout, Path::new(DIRECTORY)).expect_err("should fail");
 
         assert!(
             format!("{error:#}").contains("crate-type = [\"cdylib\"]"),
@@ -202,13 +289,13 @@ mod tests {
     }
 
     #[test]
-    fn cdylib_artifact_without_package_artifact_returns_error() {
+    fn cdylib_artifacts_without_package_artifact_returns_error() {
         let stdout = r#"{"reason":"compiler-artifact","manifest_path":"/deps/other/Cargo.toml","target":{"crate_types":["cdylib"],"name":"other"},"filenames":["/deps/libother.so"]}"#;
 
-        let error = cdylib_artifact(stdout, Path::new(MANIFEST)).expect_err("should fail");
+        let error = cdylib_artifacts(stdout, Path::new(DIRECTORY)).expect_err("should fail");
 
         assert!(
-            error.to_string().contains("no artifact"),
+            error.to_string().contains("no dynamic library"),
             "unexpected: {error:#}"
         );
     }

--- a/crates/whisker/tests/custom_lints.rs
+++ b/crates/whisker/tests/custom_lints.rs
@@ -53,6 +53,112 @@ fn whisker() -> Command {
     Command::cargo_bin("whisker").expect("whisker binary should exist")
 }
 
+/// Returns the build directory the plugin workspace uses
+///
+/// That workspace compiles against whisker-rust, and a target directory
+/// inside the temporary checkout would compile the dependency again on
+/// every run. One directory under the crate's own scratch space keeps a
+/// repeat run cheap and stays out of anyone else's target directory.
+fn shared_build_directory() -> PathBuf {
+    let directory = Path::new(env!("CARGO_TARGET_TMPDIR")).join("plugin-builds");
+    std::fs::create_dir_all(&directory).expect("the shared build directory should be created");
+
+    directory
+}
+
+/// Writes a workspace of two plugin packages and returns its root
+///
+/// The members differ in the node they answer to, so a source holding
+/// both proves that each library was loaded rather than one of them
+/// twice. Their dependencies are path dependencies on this repository,
+/// which is what makes the handshake pass: one toolchain builds whisker
+/// and both plugins.
+fn workspace_of_lints() -> TempDir {
+    let directory = tempfile::tempdir().expect("temporary directory should be created");
+    let crates = Path::new(env!("CARGO_MANIFEST_DIR")).join("..");
+    let crates = std::fs::canonicalize(crates).expect("the crates directory should exist");
+    let rust = toml::Value::from(
+        crates
+            .join("whisker-rust")
+            .to_str()
+            .expect("the path should be UTF-8"),
+    );
+    let types = toml::Value::from(
+        crates
+            .join("whisker-types")
+            .to_str()
+            .expect("the path should be UTF-8"),
+    );
+
+    std::fs::write(
+        directory.path().join("Cargo.toml"),
+        "[workspace]\nmembers = [\"first\", \"second\"]\nresolver = \"3\"\n",
+    )
+    .expect("the workspace manifest should be written");
+
+    for (name, rule, method) in [
+        ("first", "workspace.first", "check_function_item"),
+        ("second", "workspace.second", "check_macro_invocation"),
+    ] {
+        let member = directory.path().join(name);
+        std::fs::create_dir(&member).expect("the member should be created");
+        std::fs::create_dir(member.join("src")).expect("src should be created");
+        std::fs::write(
+            member.join("Cargo.toml"),
+            format!(
+                "[package]\nname = \"{name}\"\nversion = \"0.1.0\"\nedition = \"2024\"\n\
+                 publish = false\n\n[lib]\ncrate-type = [\"cdylib\"]\n\n[dependencies]\n\
+                 whisker-rust = {{ path = {rust}, default-features = false }}\n\
+                 whisker-types = {{ path = {types} }}\n"
+            ),
+        )
+        .expect("the member manifest should be written");
+        std::fs::write(
+            member.join("src").join("lib.rs"),
+            format!(
+                "use whisker_rust::RustLintPass;\n\
+                 use whisker_types::{{DecoratedNode, Diagnostic, RuleId, Severity}};\n\n\
+                 pub struct Flag;\n\n\
+                 impl RustLintPass for Flag {{\n\
+                 \x20   fn {method}(&mut self, node: &DecoratedNode<'_>) -> Vec<Diagnostic> {{\n\
+                 \x20       vec![Diagnostic::new(\n\
+                 \x20           RuleId::new(\"{rule}\"),\n\
+                 \x20           Severity::Warn,\n\
+                 \x20           \"the member fired\".into(),\n\
+                 \x20           node.span(),\n\
+                 \x20       )]\n\
+                 \x20   }}\n\
+                 }}\n\n\
+                 whisker_rust::export_lints![Flag];\n"
+            ),
+        )
+        .expect("the member source should be written");
+    }
+
+    directory
+}
+
+/// Pins that a configured directory may be a workspace of plugins
+///
+/// One entry naming a repository of rules is the reason this matters: a
+/// shared rule set is a workspace, and loading only its first library
+/// would run a fraction of the rules while looking like it ran them all.
+#[test]
+fn check_with_a_workspace_of_lints_reports_every_member() {
+    let target = package(TODO_SOURCE);
+    let workspace = workspace_of_lints();
+    configure_lint(target.path(), workspace.path());
+
+    whisker()
+        .env("CARGO_TARGET_DIR", shared_build_directory())
+        .arg("check")
+        .arg(target.path())
+        .assert()
+        .success()
+        .stderr(predicate::str::contains("warning[workspace.first]"))
+        .stderr(predicate::str::contains("warning[workspace.second]"));
+}
+
 /// Pins the whole path: configure, compile, handshake, lint, report
 ///
 /// One toolchain builds both sides here, as the setup documentation asks


### PR DESCRIPTION
A lint entry named exactly one cargo package. Whisker built that package
and took the one dynamic library from the build. A directory that held a
workspace caused an error.

Whisker now finds each dynamic library whose manifest is below the
configured directory. It loads each library and does a separate ABI
handshake for each one. A shared set of rules is a workspace. One entry
can thus name a repository of rules instead of one rule.

Whisker still matches an artifact by the position of its manifest, not by
the package name. A dependency with the same name as a plugin thus cannot
replace it. Dependencies resolve outside the configured directory, in the
caches of cargo. This is what makes the position sufficient.

The result uses the manifest path as its key. This sorts the libraries,
and it prevents a second load of a package that cargo reports twice.
Without the sort, the order of the lints would change between runs.

The new end-to-end test builds a workspace of two plugins. Each plugin
answers to a different node. The test thus shows that whisker loaded two
libraries, and not one library two times.
