### PR TITLE
Accept a pinned repository as a lint source

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -510,9 +510,9 @@ dependencies = [
 
 [[package]]
 name = "fastrand"
-version = "2.3.0"
+version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
+checksum = "da7c62ceae207dd37ea5b845da6a0696c799f85e97da1ab5b7910be3c1c80223"
 
 [[package]]
 name = "filetime"
@@ -632,6 +632,58 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.119",
+]
+
+[[package]]
+name = "gix-path"
+version = "0.12.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b075e730586bba7341304d6fc1b4efc1d10cf64532622521c0e07f30e661046"
+dependencies = [
+ "bstr",
+ "gix-trace",
+ "gix-validate",
+ "thiserror",
+]
+
+[[package]]
+name = "gix-trace"
+version = "0.1.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be3eb81d9dc914335923e50d52829c551feefd6a72d176c4130c546b67a60814"
+
+[[package]]
+name = "gix-url"
+version = "0.37.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "31bdfc93aa880cda3272718a5879ce3aa7723fa13514320dd6608151607afe72"
+dependencies = [
+ "bstr",
+ "gix-path",
+ "gix-utils",
+ "percent-encoding",
+ "thiserror",
+]
+
+[[package]]
+name = "gix-utils"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0da1c46491b49458a446cc76f0085860f8164c2290742e0aa8c653ce67240a97"
+dependencies = [
+ "bstr",
+ "fastrand",
+ "getrandom 0.4.2",
+ "unicode-normalization",
+]
+
+[[package]]
+name = "gix-validate"
+version = "0.11.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4dae8780f63ed8a803b8bdabbd7aa5f5c5d74592c8b50eed875c1bb4f6545a6a"
+dependencies = [
+ "bstr",
 ]
 
 [[package]]
@@ -1064,6 +1116,12 @@ dependencies = [
  "smallvec",
  "windows-link",
 ]
+
+[[package]]
+name = "percent-encoding"
+version = "2.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 
 [[package]]
 name = "perf-event"
@@ -2420,6 +2478,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "tinyvec"
+version = "1.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb4ebadaa0af04fab11ae01eb5f9fdb5f9c5b875506e210e71c07873528baa7f"
+dependencies = [
+ "tinyvec_macros",
+]
+
+[[package]]
+name = "tinyvec_macros"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
+
+[[package]]
 name = "tokio"
 version = "1.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2692,6 +2765,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
 
 [[package]]
+name = "unicode-normalization"
+version = "0.1.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5fd4f6878c9cb28d874b009da9e8d183b5abc80117c40bbd187a1fde336be6e8"
+dependencies = [
+ "tinyvec",
+]
+
+[[package]]
 name = "unicode-properties"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2805,6 +2887,7 @@ dependencies = [
  "anyhow",
  "assert_cmd",
  "clawless",
+ "gix-url",
  "ignore",
  "libloading",
  "predicates",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,6 +45,13 @@ opt-level = 2
 [workspace.dependencies]
 anyhow = "1"
 codespan-reporting = "0.13"
+# Reads the remote a git lint source names. Git accepts forms a general URL
+# parser rejects, such as an scp-like `git@host:org/repo` and a bare local
+# path, and this is the parser gitoxide itself uses, so the configuration and
+# the fetch agree on what a remote is. Whisker takes it directly rather than
+# through `gix`, because reading a configuration file should not pull in a
+# whole git implementation; cargo resolves both to one version.
+gix-url = "0.37"
 # The walker behind ripgrep. Whisker uses it instead of a plain directory walk
 # so that `.gitignore` and friends are honored: a linter that reports on
 # generated output such as `target/` is worse than no linter at all.

--- a/crates/whisker/Cargo.toml
+++ b/crates/whisker/Cargo.toml
@@ -16,6 +16,7 @@ workspace = true
 [dependencies]
 anyhow = "1"
 clawless = "0.5.0"
+gix-url.workspace = true
 ignore.workspace = true
 libloading.workspace = true
 serde.workspace = true

--- a/crates/whisker/src/config.rs
+++ b/crates/whisker/src/config.rs
@@ -3,23 +3,29 @@ use std::path::{Path, PathBuf};
 use anyhow::Context as _;
 use serde::Deserialize;
 
+mod git_rev;
+mod git_url;
 mod ignore_pattern;
 mod lint_path;
+mod lint_source;
 
+pub use git_rev::GitRev;
+pub use git_url::GitUrl;
 pub use ignore_pattern::IgnorePattern;
 pub use lint_path::LintPath;
+pub use lint_source::{GitLintSource, LintSource};
 
 /// Whisker's configuration for a single target project
 ///
 /// Whisker reads a TOML file that any project can write, whatever language
 /// it is in. The file holds the [`IgnorePattern`]s that exclude files from
-/// discovery and the [`LintPath`]s of the project's custom lints. Both
+/// discovery and the [`LintSource`]s of the project's custom lints. Both
 /// anchor at the project directory, which [`WhiskerConfig::root`] returns.
 #[derive(Clone, Eq, PartialEq, Debug)]
 pub struct WhiskerConfig {
     root: PathBuf,
     ignore: Vec<IgnorePattern>,
-    lints: Vec<LintPath>,
+    lints: Vec<LintSource>,
 }
 
 impl WhiskerConfig {
@@ -34,7 +40,7 @@ impl WhiskerConfig {
     ///     Vec::new(),
     /// );
     /// ```
-    pub fn new(root: PathBuf, ignore: Vec<IgnorePattern>, lints: Vec<LintPath>) -> Self {
+    pub fn new(root: PathBuf, ignore: Vec<IgnorePattern>, lints: Vec<LintSource>) -> Self {
         Self {
             root,
             ignore,
@@ -54,7 +60,8 @@ impl WhiskerConfig {
     ///
     /// Returns an error if `path` cannot be resolved, or if one directory
     /// holds both accepted file names. A file that whisker cannot read as an
-    /// `ignore` list of strings is also an error. An unrecognized key is an
+    /// `ignore` list of strings is also an error. So is a `[[lints]]` entry
+    /// that does not describe exactly one source. An unrecognized key is an
     /// error too, because it is most likely a typo.
     ///
     /// # Examples
@@ -80,8 +87,14 @@ impl WhiskerConfig {
         let ignore = ignore.into_iter().map(IgnorePattern::new).collect();
         let lints = lints
             .into_iter()
-            .map(|LintEntry { path }| LintPath::new(path))
-            .collect();
+            .enumerate()
+            .map(|(index, entry)| {
+                entry
+                    .into_source()
+                    .with_context(|| format!("failed to read [[lints]] entry {}", index + 1))
+            })
+            .collect::<anyhow::Result<Vec<_>>>()
+            .with_context(|| format!("failed to read {}", file.display()))?;
 
         Ok(Self::new(root, ignore, lints))
     }
@@ -116,10 +129,10 @@ impl WhiskerConfig {
         &self.ignore
     }
 
-    /// Returns the paths of the project's custom lint crates
+    /// Returns the sources of the project's custom lint crates
     ///
-    /// Relative paths anchor at [`WhiskerConfig::root`]; resolve them with
-    /// [`LintPath::resolve`].
+    /// A [`LintSource::Path`] holding a relative path anchors at
+    /// [`WhiskerConfig::root`]; resolve it with [`LintPath::resolve`].
     ///
     /// # Examples
     ///
@@ -128,7 +141,7 @@ impl WhiskerConfig {
     ///
     /// assert!(config.lints().is_empty());
     /// ```
-    pub fn lints(&self) -> &[LintPath] {
+    pub fn lints(&self) -> &[LintSource] {
         &self.lints
     }
 }
@@ -150,12 +163,58 @@ struct ConfigTable {
 
 /// One `[[lints]]` entry as written on disk
 ///
-/// An entry is a table rather than a bare string, so options like a build
-/// profile can join `path` later without another shape change.
+/// The fields are all optional here, and [`LintEntry::into_source`] sorts
+/// them out rather than an untagged enum. Serde reports a failed untagged
+/// match as "data did not match any variant". The author of a broken entry
+/// deserves to be told which combination they wrote, and what to do about
+/// it.
 #[derive(Debug, Deserialize)]
 #[serde(deny_unknown_fields)]
 struct LintEntry {
-    path: String,
+    #[serde(default)]
+    path: Option<String>,
+
+    #[serde(default)]
+    git: Option<String>,
+
+    #[serde(default)]
+    rev: Option<String>,
+}
+
+impl LintEntry {
+    /// Turns one configured entry into the source it describes
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the entry names neither a path nor a repository,
+    /// or names both. Returns one too if the entry omits the revision a
+    /// repository needs, or pins a path to a revision.
+    ///
+    /// Each error names the keys at fault and nothing else.
+    /// [`WhiskerConfig::load`] is the caller that knows which entry the
+    /// reader has to find.
+    fn into_source(self) -> anyhow::Result<LintSource> {
+        let Self { path, git, rev } = self;
+
+        match (path, git, rev) {
+            (Some(_), Some(_), _) => {
+                anyhow::bail!("can only define either path or git, not both")
+            }
+            (Some(_), None, Some(_)) => {
+                anyhow::bail!("can only define rev with git, not with path")
+            }
+            (Some(path), None, None) => Ok(LintSource::Path(LintPath::new(path))),
+            (None, Some(git), Some(rev)) => {
+                let url = GitUrl::new(git)?;
+                let rev = GitRev::new(rev)?;
+
+                Ok(LintSource::Git(GitLintSource::new(url, rev)))
+            }
+            (None, Some(_), None) => anyhow::bail!("must define rev with git"),
+            (None, None, Some(_)) => anyhow::bail!("must define git with rev"),
+            (None, None, None) => anyhow::bail!("must define either path, or git and rev"),
+        }
+    }
 }
 
 /// A configuration file whisker found, and the directory it anchors to
@@ -241,6 +300,9 @@ mod tests {
 
     use super::*;
 
+    /// A commit hash of the right shape for a configuration under test
+    const REV: &str = "0123456789abcdef0123456789abcdef01234567";
+
     /// Returns the resolved path of a temporary directory
     ///
     /// Temporary directories commonly sit behind a symlink, and the search
@@ -272,6 +334,27 @@ mod tests {
         std::fs::create_dir_all(&config).expect("config directory should be created");
         std::fs::write(config.join("whisker.toml"), contents)
             .expect("configuration should be written");
+    }
+
+    /// Pins that an error names which entry the reader has to go and fix
+    ///
+    /// The keys of a broken entry rarely tell it apart from the entry
+    /// above it, and a repository may configure several. The position in
+    /// the file is what always distinguishes them.
+    #[test]
+    fn load_with_a_broken_second_lint_entry_names_its_position() {
+        let directory = repository();
+        write_dotfile(
+            directory.path(),
+            "[[lints]]\npath = \"lints/first\"\n\n[[lints]]\npath = \"lints/second\"\ngit = \"https://example.com/rules\"\n",
+        );
+
+        let error = WhiskerConfig::load(directory.path()).expect_err("configuration should fail");
+
+        assert!(
+            format!("{error:#}").contains("[[lints]] entry 2"),
+            "error should name the entry at fault: {error:#}"
+        );
     }
 
     #[test]
@@ -347,6 +430,103 @@ mod tests {
     }
 
     #[test]
+    fn load_with_git_lint_entry_holding_a_branch_name_returns_error() {
+        let directory = repository();
+        write_dotfile(
+            directory.path(),
+            "[[lints]]\ngit = \"https://example.com/rules\"\nrev = \"main\"\n",
+        );
+
+        let error = WhiskerConfig::load(directory.path()).expect_err("configuration should fail");
+
+        assert!(
+            format!("{error:#}").contains("40 characters"),
+            "error should explain the pin: {error:#}"
+        );
+        assert!(
+            format!("{error:#}").contains("[[lints]] entry 1"),
+            "error should name the entry it read: {error:#}"
+        );
+    }
+
+    #[test]
+    fn load_with_git_lint_entry_holding_an_abbreviated_rev_returns_error() {
+        let directory = repository();
+        write_dotfile(
+            directory.path(),
+            "[[lints]]\ngit = \"https://example.com/rules\"\nrev = \"0123456\"\n",
+        );
+
+        let error = WhiskerConfig::load(directory.path()).expect_err("configuration should fail");
+
+        assert!(
+            format!("{error:#}").contains("40 characters"),
+            "error should explain the pin: {error:#}"
+        );
+    }
+
+    /// Pins that a token in a remote never reaches an error message
+    ///
+    /// A remote is where a token sits when someone pins a private rule
+    /// repository, and stderr becomes a CI log. Reading a bad entry is the
+    /// first thing whisker does with a remote, so it is the first place a
+    /// token could escape.
+    #[test]
+    fn load_with_git_lint_entry_holding_credentials_hides_them() {
+        let directory = repository();
+        write_dotfile(
+            directory.path(),
+            "[[lints]]\ngit = \"https://user:s3cret@example.com/rules\"\nrev = \"main\"\n",
+        );
+
+        let error = WhiskerConfig::load(directory.path()).expect_err("configuration should fail");
+
+        assert!(
+            !format!("{error:#}").contains("s3cret"),
+            "error should not carry the credentials: {error:#}"
+        );
+    }
+
+    #[test]
+    fn load_with_git_lint_entry_missing_rev_returns_error() {
+        let directory = repository();
+        write_dotfile(
+            directory.path(),
+            "[[lints]]\ngit = \"https://example.com/rules\"\n",
+        );
+
+        let error = WhiskerConfig::load(directory.path()).expect_err("configuration should fail");
+
+        assert!(
+            format!("{error:#}").contains("must define rev with git"),
+            "error should name the missing key: {error:#}"
+        );
+        assert!(
+            format!("{error:#}").contains("[[lints]] entry 1"),
+            "error should name the entry it read: {error:#}"
+        );
+    }
+
+    #[test]
+    fn load_with_git_lint_entry_returns_a_git_source() {
+        let directory = repository();
+        write_dotfile(
+            directory.path(),
+            &format!("[[lints]]\ngit = \"https://example.com/rules\"\nrev = \"{REV}\"\n"),
+        );
+
+        let config = WhiskerConfig::load(directory.path()).expect("configuration should load");
+
+        assert_eq!(
+            config.lints(),
+            vec![LintSource::Git(GitLintSource::new(
+                GitUrl::new("https://example.com/rules").expect("the remote should be accepted"),
+                GitRev::new(REV).expect("the revision should be accepted"),
+            ))]
+        );
+    }
+
+    #[test]
     fn load_with_ignore_patterns_returns_them_in_order() {
         let directory = repository();
         write_dotfile(directory.path(), "ignore = [\"examples/\", \"a/b.rs\"]\n");
@@ -388,9 +568,54 @@ mod tests {
         assert_eq!(
             config.lints(),
             vec![
-                LintPath::new("lints/no_todo"),
-                LintPath::new("lints/prefer_expect")
+                LintSource::Path(LintPath::new("lints/no_todo")),
+                LintSource::Path(LintPath::new("lints/prefer_expect")),
             ]
+        );
+    }
+
+    #[test]
+    fn load_with_lint_entry_holding_git_and_path_returns_error() {
+        let directory = repository();
+        write_dotfile(
+            directory.path(),
+            &format!(
+                "[[lints]]\npath = \"lints/no_todo\"\ngit = \"https://example.com/rules\"\nrev = \
+                 \"{REV}\"\n"
+            ),
+        );
+
+        let error = WhiskerConfig::load(directory.path()).expect_err("configuration should fail");
+
+        assert!(
+            format!("{error:#}").contains("can only define either path or git"),
+            "error should name the conflict: {error:#}"
+        );
+    }
+
+    #[test]
+    fn load_with_lint_entry_holding_neither_path_nor_git_returns_error() {
+        let directory = repository();
+        write_dotfile(directory.path(), "[[lints]]\n");
+
+        let error = WhiskerConfig::load(directory.path()).expect_err("configuration should fail");
+
+        assert!(
+            format!("{error:#}").contains("must define either path, or git and rev"),
+            "error should explain what an entry needs: {error:#}"
+        );
+    }
+
+    #[test]
+    fn load_with_lint_entry_holding_rev_without_git_returns_error() {
+        let directory = repository();
+        write_dotfile(directory.path(), &format!("[[lints]]\nrev = \"{REV}\"\n"));
+
+        let error = WhiskerConfig::load(directory.path()).expect_err("configuration should fail");
+
+        assert!(
+            format!("{error:#}").contains("must define git with rev"),
+            "error should name the missing key: {error:#}"
         );
     }
 
@@ -404,6 +629,22 @@ mod tests {
         assert!(
             format!("{error:#}").contains(".whisker.toml"),
             "error should name the offending file: {error:#}"
+        );
+    }
+
+    #[test]
+    fn load_with_lint_entry_pinning_a_path_returns_error() {
+        let directory = repository();
+        write_dotfile(
+            directory.path(),
+            &format!("[[lints]]\npath = \"lints/no_todo\"\nrev = \"{REV}\"\n"),
+        );
+
+        let error = WhiskerConfig::load(directory.path()).expect_err("configuration should fail");
+
+        assert!(
+            format!("{error:#}").contains("can only define rev with git"),
+            "error should name the conflict: {error:#}"
         );
     }
 
@@ -467,16 +708,6 @@ mod tests {
     }
 
     #[test]
-    fn load_without_lint_entries_returns_no_lints() {
-        let directory = repository();
-        write_dotfile(directory.path(), "ignore = []\n");
-
-        let config = WhiskerConfig::load(directory.path()).expect("configuration should load");
-
-        assert!(config.lints().is_empty());
-    }
-
-    #[test]
     fn load_with_unknown_key_returns_error() {
         let directory = repository();
         write_dotfile(directory.path(), "ignore = []\nexclude = [\"examples/\"]\n");
@@ -487,6 +718,16 @@ mod tests {
             format!("{error:#}").contains("exclude"),
             "error should name the key whisker does not recognize: {error:#}"
         );
+    }
+
+    #[test]
+    fn load_without_lint_entries_returns_no_lints() {
+        let directory = repository();
+        write_dotfile(directory.path(), "ignore = []\n");
+
+        let config = WhiskerConfig::load(directory.path()).expect("configuration should load");
+
+        assert!(config.lints().is_empty());
     }
 
     #[test]

--- a/crates/whisker/src/config/git_rev.rs
+++ b/crates/whisker/src/config/git_rev.rs
@@ -1,0 +1,141 @@
+/// The full commit hash a git lint source is pinned to
+///
+/// Whisker accepts only a complete, unabbreviated hash. A branch or tag
+/// names whatever the remote points it at today, so the same configuration
+/// would check the same code against different rules on different days,
+/// and a shortened hash can grow ambiguous as a repository gains objects.
+/// Neither is something a linter should leave open, so the pin is exact.
+///
+/// # Examples
+///
+/// ```ignore
+/// let rev = GitRev::new("0123456789abcdef0123456789abcdef01234567")?;
+///
+/// assert_eq!(rev.to_string().len(), 40);
+/// ```
+#[derive(Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug)]
+pub struct GitRev(String);
+
+/// The number of hexadecimal characters in a full SHA-1 commit hash
+const HASH_LENGTH: usize = 40;
+
+impl GitRev {
+    /// Creates a revision from its configured source
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if `rev` is not exactly 40 lowercase hexadecimal
+    /// characters. The error names the rule the value broke, because a
+    /// branch name and an abbreviated hash are the likely mistakes and
+    /// each takes a different fix.
+    ///
+    /// # Examples
+    ///
+    /// ```ignore
+    /// let rev = GitRev::new("0123456789abcdef0123456789abcdef01234567")?;
+    /// ```
+    pub fn new(rev: impl Into<String>) -> anyhow::Result<Self> {
+        let rev = rev.into();
+
+        anyhow::ensure!(
+            rev.len() == HASH_LENGTH,
+            "git revision {rev:?} does not have {HASH_LENGTH} characters"
+        );
+        anyhow::ensure!(
+            rev.chars()
+                .all(|character| character.is_ascii_digit() || ('a'..='f').contains(&character)),
+            "git revision {rev:?} contains characters that are not lowercase hexadecimal"
+        );
+
+        Ok(Self(rev))
+    }
+}
+
+impl std::fmt::Display for GitRev {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        self.0.fmt(f)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const VALID: &str = "0123456789abcdef0123456789abcdef01234567";
+
+    #[test]
+    fn display_matches_source() {
+        let rev = GitRev::new(VALID).expect("the revision should be accepted");
+
+        assert_eq!(rev.to_string(), VALID);
+    }
+
+    #[test]
+    fn new_with_abbreviated_hash_returns_error() {
+        let error = GitRev::new("0123456").expect_err("the revision should be rejected");
+
+        assert!(
+            error.to_string().contains("40 characters"),
+            "unexpected: {error:#}"
+        );
+    }
+
+    #[test]
+    fn new_with_branch_name_returns_error() {
+        let error = GitRev::new("main").expect_err("the revision should be rejected");
+
+        assert!(
+            error.to_string().contains("40 characters"),
+            "unexpected: {error:#}"
+        );
+    }
+
+    #[test]
+    fn new_with_full_hash_is_accepted() {
+        let rev = GitRev::new(VALID).expect("the revision should be accepted");
+
+        assert_eq!(rev.to_string(), VALID);
+    }
+
+    #[test]
+    fn new_with_non_hexadecimal_characters_returns_error() {
+        let rev = "z".repeat(HASH_LENGTH);
+
+        let error = GitRev::new(rev).expect_err("the revision should be rejected");
+
+        assert!(
+            error.to_string().contains("lowercase hexadecimal"),
+            "unexpected: {error:#}"
+        );
+    }
+
+    /// An uppercase hash is a hash, but accepting it would let one commit
+    /// be written two ways, and the cache is keyed by the text.
+    #[test]
+    fn new_with_uppercase_hash_returns_error() {
+        let error = GitRev::new(VALID.to_uppercase()).expect_err("the revision should be rejected");
+
+        assert!(
+            error.to_string().contains("lowercase hexadecimal"),
+            "unexpected: {error:#}"
+        );
+    }
+
+    #[test]
+    fn trait_send() {
+        fn assert_send<T: Send>() {}
+        assert_send::<GitRev>();
+    }
+
+    #[test]
+    fn trait_sync() {
+        fn assert_sync<T: Sync>() {}
+        assert_sync::<GitRev>();
+    }
+
+    #[test]
+    fn trait_unpin() {
+        fn assert_unpin<T: Unpin>() {}
+        assert_unpin::<GitRev>();
+    }
+}

--- a/crates/whisker/src/config/git_url.rs
+++ b/crates/whisker/src/config/git_url.rs
@@ -1,0 +1,219 @@
+/// The remote a git lint source is fetched from
+///
+/// Git accepts more forms than a general URL parser does. An `https://` or
+/// an `ssh://` remote, an scp-like `git@host:org/repo`, and the `file://`
+/// and plain local paths a test or a vendored checkout uses all name a
+/// repository.
+///
+/// Whisker therefore reads a remote with gitoxide's parser, which the fetch
+/// uses later too. A remote the configuration accepts is a remote the
+/// transport accepts. One that nothing can read fails while the file is
+/// read, rather than minutes into a check.
+///
+/// The parsed form also makes the credential rule structural: a token is a
+/// field to clear rather than a substring to find.
+///
+/// # Examples
+///
+/// ```ignore
+/// let url = GitUrl::new("https://github.com/aonyx-ai/whisker-aonyx-rules")?;
+///
+/// assert_eq!(
+///     url.to_string(),
+///     "https://github.com/aonyx-ai/whisker-aonyx-rules"
+/// );
+/// ```
+#[derive(Clone, Eq, PartialEq, Ord, PartialOrd, Hash)]
+pub struct GitUrl(gix_url::Url);
+
+/// What stands in for credentials when a remote is printed
+const REDACTED_USERINFO: &str = "***";
+
+impl GitUrl {
+    /// Creates a remote from its configured source
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if git cannot read the text as a remote. The error
+    /// names the fault and never quotes the remote, because gitoxide's own
+    /// parse error carries the text in full, credentials and all.
+    ///
+    /// # Examples
+    ///
+    /// ```ignore
+    /// let url = GitUrl::new("https://github.com/aonyx-ai/whisker-aonyx-rules")?;
+    /// ```
+    pub fn new(url: impl AsRef<str>) -> anyhow::Result<Self> {
+        match gix_url::parse(url.as_ref()) {
+            Ok(url) => Ok(Self(url)),
+            Err(gix_url::parse::Error::Utf8 { .. }) => {
+                anyhow::bail!("the git remote is not valid UTF-8")
+            }
+            Err(gix_url::parse::Error::Url { .. }) => {
+                anyhow::bail!("cannot read the git remote as a URL")
+            }
+            Err(gix_url::parse::Error::TooLong { .. }) => {
+                anyhow::bail!("the git remote names a host that is too long")
+            }
+            Err(gix_url::parse::Error::MissingRepositoryPath { .. }) => {
+                anyhow::bail!("the git remote names no repository")
+            }
+            Err(gix_url::parse::Error::RelativeUrl { .. }) => {
+                anyhow::bail!("the git remote is relative")
+            }
+        }
+    }
+}
+
+/// Returns the remote with any credentials removed
+///
+/// A remote may carry a token, either as `https://<token>@host` or as
+/// `https://user:<token>@host`, and whisker prints the remote whenever a
+/// lint source fails. Stderr becomes a CI log, so the whole userinfo goes
+/// rather than the password half of it. Both forms carry secrets, and one
+/// rule cannot be applied to the wrong one.
+///
+/// [`gix_url::Url`] hides only the password and prints the name beside it,
+/// which is why this does not delegate to its own [`Display`].
+///
+/// An scp-style remote such as `git@github.com:org/repo` keeps its name.
+/// A name there is an ssh login rather than a place a token goes, and the
+/// form has no other way to spell one.
+///
+/// [`Display`]: std::fmt::Display
+fn redacted(url: &gix_url::Url) -> String {
+    let mut redacted = url.clone();
+
+    redacted.set_password(None);
+    redacted.set_user(match (url.serialize_alternative_form, url.user()) {
+        (true, user) => user.map(str::to_owned),
+        (false, Some(_)) => Some(REDACTED_USERINFO.to_owned()),
+        (false, None) => None,
+    });
+
+    redacted.to_bstring().to_string()
+}
+
+impl std::fmt::Display for GitUrl {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        redacted(&self.0).fmt(f)
+    }
+}
+
+/// Prints the remote the way [`Display`] does, credentials removed
+///
+/// The derive would print the field as written, and a `{:?}` of a
+/// configuration reaches a panic message as easily as a `{}` reaches
+/// stderr, so both go through the same redaction.
+///
+/// [`Display`]: std::fmt::Display
+impl std::fmt::Debug for GitUrl {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_tuple("GitUrl").field(&redacted(&self.0)).finish()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn debug_hides_credentials() {
+        let url = GitUrl::new("https://x-access-token:secret@example.com/rules")
+            .expect("the remote should be accepted");
+
+        let shown = format!("{url:?}");
+
+        assert!(!shown.contains("secret"), "{shown}");
+    }
+
+    #[test]
+    fn display_hides_a_password() {
+        let url = GitUrl::new("https://user:secret@example.com/rules")
+            .expect("the remote should be accepted");
+
+        assert_eq!(url.to_string(), "https://***@example.com/rules");
+    }
+
+    #[test]
+    fn display_hides_a_password_that_holds_a_marker() {
+        let url = GitUrl::new("https://user:pass@word@example.com/rules")
+            .expect("the remote should be accepted");
+
+        assert_eq!(url.to_string(), "https://***@example.com/rules");
+    }
+
+    #[test]
+    fn display_hides_a_token_used_as_a_name() {
+        let url =
+            GitUrl::new("https://secret@example.com/rules").expect("the remote should be accepted");
+
+        assert_eq!(url.to_string(), "https://***@example.com/rules");
+    }
+
+    /// Pins that a remote whisker never has to fetch over is left alone
+    ///
+    /// A local path is how a test and a vendored checkout name their rules,
+    /// and it carries no credentials to remove.
+    #[test]
+    fn display_keeps_a_local_path_whole() {
+        let url = GitUrl::new("/srv/rules").expect("the remote should be accepted");
+
+        assert_eq!(url.to_string(), "/srv/rules");
+    }
+
+    #[test]
+    fn display_keeps_an_scp_style_remote_whole() {
+        let url = GitUrl::new("git@github.com:aonyx-ai/rules.git")
+            .expect("the remote should be accepted");
+
+        assert_eq!(url.to_string(), "git@github.com:aonyx-ai/rules.git");
+    }
+
+    #[test]
+    fn display_matches_a_remote_without_credentials() {
+        let url = GitUrl::new("https://example.com/rules").expect("the remote should be accepted");
+
+        assert_eq!(url.to_string(), "https://example.com/rules");
+    }
+
+    /// Pins that credentials go even where there is no path to keep
+    ///
+    /// The redaction rebuilds the remote from its parts rather than cutting
+    /// the text apart. A remote with nothing after the host is where a rule
+    /// that reads from the left would run past the end.
+    #[test]
+    fn display_of_a_remote_without_a_path_hides_credentials() {
+        let url = GitUrl::new("https://secret@example.com").expect("the remote should be accepted");
+
+        assert_eq!(url.to_string(), "https://***@example.com/");
+    }
+
+    #[test]
+    fn new_with_an_empty_remote_returns_error() {
+        let error = GitUrl::new("").expect_err("the remote should be rejected");
+
+        assert!(
+            error.to_string().contains("names no repository"),
+            "unexpected: {error:#}"
+        );
+    }
+
+    #[test]
+    fn trait_send() {
+        fn assert_send<T: Send>() {}
+        assert_send::<GitUrl>();
+    }
+
+    #[test]
+    fn trait_sync() {
+        fn assert_sync<T: Sync>() {}
+        assert_sync::<GitUrl>();
+    }
+
+    #[test]
+    fn trait_unpin() {
+        fn assert_unpin<T: Unpin>() {}
+        assert_unpin::<GitUrl>();
+    }
+}

--- a/crates/whisker/src/config/lint_source.rs
+++ b/crates/whisker/src/config/lint_source.rs
@@ -1,0 +1,129 @@
+use crate::config::{GitRev, GitUrl, LintPath};
+
+/// Where one configured set of custom lints comes from
+///
+/// A project either keeps its lints beside its code or shares them with
+/// other projects through a repository. The two arrive at the same place,
+/// a directory holding cargo packages that whisker builds and loads, so
+/// they differ only in how that directory comes to exist: a path is
+/// already there, and a git source is fetched into the cache first.
+///
+/// # Examples
+///
+/// ```ignore
+/// let source = LintSource::Path(LintPath::new("lints/no_todo"));
+///
+/// assert_eq!(source.to_string(), "lints/no_todo");
+/// ```
+#[derive(Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug)]
+pub enum LintSource {
+    /// Lints in a directory of the project or of the machine
+    Path(LintPath),
+
+    /// Lints in a repository, pinned to one commit
+    Git(GitLintSource),
+}
+
+impl std::fmt::Display for LintSource {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Path(path) => path.fmt(f),
+            Self::Git(git) => git.fmt(f),
+        }
+    }
+}
+
+/// A repository and the commit whisker checks its lints out at
+///
+/// Both halves are required, and the [`GitRev`] is a full hash, so the
+/// source names exactly one tree. That is what lets whisker treat a
+/// checkout as permanent once it exists: the cache never has to ask
+/// whether the remote moved, because this source cannot follow it.
+///
+/// # Examples
+///
+/// ```ignore
+/// let source = GitLintSource::new(
+///     GitUrl::new("https://github.com/aonyx-ai/whisker-aonyx-rules")?,
+///     GitRev::new("0123456789abcdef0123456789abcdef01234567")?,
+/// );
+/// ```
+#[derive(Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug)]
+pub struct GitLintSource {
+    url: GitUrl,
+    rev: GitRev,
+}
+
+impl GitLintSource {
+    /// Creates a git lint source from a remote and a pinned commit
+    ///
+    /// # Examples
+    ///
+    /// ```ignore
+    /// let source = GitLintSource::new(url, rev);
+    /// ```
+    pub fn new(url: GitUrl, rev: GitRev) -> Self {
+        Self { url, rev }
+    }
+}
+
+impl std::fmt::Display for GitLintSource {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{} at {}", self.url, self.rev)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const REV: &str = "0123456789abcdef0123456789abcdef01234567";
+
+    fn git_source() -> GitLintSource {
+        GitLintSource::new(
+            GitUrl::new("https://example.com/rules").expect("the remote should be accepted"),
+            GitRev::new(REV).expect("the revision should be accepted"),
+        )
+    }
+
+    #[test]
+    fn display_of_a_git_source_names_the_remote_and_the_commit() {
+        let source = LintSource::Git(git_source());
+
+        let displayed = source.to_string();
+
+        assert!(
+            displayed.contains("https://example.com/rules"),
+            "{displayed}"
+        );
+        assert!(displayed.contains(REV), "{displayed}");
+    }
+
+    #[test]
+    fn display_of_a_path_source_matches_the_path() {
+        let source = LintSource::Path(LintPath::new("lints/no_todo"));
+
+        assert_eq!(source.to_string(), "lints/no_todo");
+    }
+
+    #[test]
+    fn trait_send() {
+        fn assert_send<T: Send>() {}
+        assert_send::<LintSource>();
+        assert_send::<GitLintSource>();
+    }
+
+    #[test]
+    fn trait_sync() {
+        fn assert_sync<T: Sync>() {}
+        assert_sync::<LintSource>();
+        assert_sync::<GitLintSource>();
+    }
+
+    #[test]
+    fn trait_unpin() {
+        fn assert_unpin<T: Unpin>() {}
+        assert_unpin::<LintSource>();
+        assert_unpin::<GitLintSource>();
+    }
+}

--- a/crates/whisker/src/custom_lints.rs
+++ b/crates/whisker/src/custom_lints.rs
@@ -9,7 +9,7 @@ use whisker_types::LintPass;
 use whisker_types::plugin::{LintPassFactory, LintRegistrar, PluginDeclaration};
 
 use self::handshake::AbiIdentity;
-use crate::config::WhiskerConfig;
+use crate::config::{LintSource, WhiskerConfig};
 
 mod artifact;
 mod handshake;
@@ -74,30 +74,36 @@ fn configured_directories(config: &WhiskerConfig) -> anyhow::Result<Vec<PathBuf>
     let mut seen = HashSet::new();
 
     for entry in config.lints() {
-        let directory = entry.resolve(config.root());
+        let directory = match entry {
+            LintSource::Path(path) => path.resolve(config.root()),
+            LintSource::Git(git) => anyhow::bail!(
+                "the configured lint source {git} names a repository, and whisker cannot fetch \
+                 one yet"
+            ),
+        };
 
         anyhow::ensure!(
             directory.exists(),
-            "the configured lint path {entry} resolves to {}, which does not exist",
+            "the lint source {entry} resolves to {}, which does not exist",
             directory.display()
         );
         anyhow::ensure!(
             directory.is_dir(),
-            "the configured lint path {entry} resolves to {}, which is not a directory",
+            "the lint source {entry} resolves to {}, which is not a directory",
             directory.display()
         );
 
         let directory = std::fs::canonicalize(&directory)
-            .with_context(|| format!("failed to resolve the configured lint path {entry}"))?;
+            .with_context(|| format!("failed to resolve the lint source {entry}"))?;
 
         anyhow::ensure!(
             directory.join("Cargo.toml").is_file(),
-            "the configured lint path {entry} holds no Cargo.toml; custom lints are cargo \
-             packages"
+            "the lint source {entry} holds no Cargo.toml"
         );
         anyhow::ensure!(
             seen.insert(directory.clone()),
-            "the configured lint path {entry} names a package that is already configured"
+            "the lint source {entry} resolves to {}, which an earlier entry already configured",
+            directory.display()
         );
 
         directories.push(directory);
@@ -279,6 +285,8 @@ mod tests {
     use crate::config::LintPath;
 
     fn config_with(root: &Path, lints: Vec<LintPath>) -> WhiskerConfig {
+        let lints = lints.into_iter().map(LintSource::Path).collect();
+
         WhiskerConfig::new(root.to_path_buf(), Vec::new(), lints)
     }
 


### PR DESCRIPTION
A lint entry named a directory. An entry can now name a repository and a
commit. A project needs this to share its rules with a different project.

Whisker accepts a full commit hash and nothing else. It does not accept a
branch or a tag. A branch can point to a different commit on a different
day. The same configuration would then run different rules and give
different results. Whisker checks the hash when it reads the
configuration, so a mistake is visible before any fetch or build.

Each incorrect entry gets its own error, because the correction is
different each time. The five errors are: both keys set, a revision beside
a path, a repository without a revision, a revision without a repository,
and an entry that names nothing.

A remote can contain a token. Whisker prints the remote each time an entry
fails. Display and Debug thus remove the full userinfo from the remote.
Both `https://<token>@host` and `https://user:<token>@host` are forms that
people use. The transport continues to read the remote as written. This
correction comes from the Copilot review of the first version of this
work.

Whisker cannot fetch a repository yet, and it says so when it finds one.
The fetch comes in a later change. It thus arrives against a
configuration surface that is already reviewed.
