### PR TITLE
Resolve a pinned repository to a cache directory

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -509,6 +509,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "etcetera"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "de48cc4d1c1d97a20fd819def54b890cadde72ed3ad0c614822a0a433361be96"
+dependencies = [
+ "cfg-if",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "fastrand"
 version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2887,6 +2897,7 @@ dependencies = [
  "anyhow",
  "assert_cmd",
  "clawless",
+ "etcetera",
  "gix-url",
  "ignore",
  "libloading",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -52,6 +52,7 @@ codespan-reporting = "0.13"
 # through `gix`, because reading a configuration file should not pull in a
 # whole git implementation; cargo resolves both to one version.
 gix-url = "0.37"
+etcetera = "0.11"
 # The walker behind ripgrep. Whisker uses it instead of a plain directory walk
 # so that `.gitignore` and friends are honored: a linter that reports on
 # generated output such as `target/` is worse than no linter at all.

--- a/crates/whisker/Cargo.toml
+++ b/crates/whisker/Cargo.toml
@@ -16,6 +16,7 @@ workspace = true
 [dependencies]
 anyhow = "1"
 clawless = "0.5.0"
+etcetera.workspace = true
 gix-url.workspace = true
 ignore.workspace = true
 libloading.workspace = true

--- a/crates/whisker/src/config/git_rev.rs
+++ b/crates/whisker/src/config/git_rev.rs
@@ -11,7 +11,7 @@
 /// ```ignore
 /// let rev = GitRev::new("0123456789abcdef0123456789abcdef01234567")?;
 ///
-/// assert_eq!(rev.to_string().len(), 40);
+/// assert_eq!(rev.as_str().len(), 40);
 /// ```
 #[derive(Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug)]
 pub struct GitRev(String);
@@ -49,6 +49,19 @@ impl GitRev {
 
         Ok(Self(rev))
     }
+
+    /// Returns the hash as written
+    ///
+    /// # Examples
+    ///
+    /// ```ignore
+    /// let rev = GitRev::new("0123456789abcdef0123456789abcdef01234567")?;
+    ///
+    /// assert!(rev.as_str().starts_with("0123"));
+    /// ```
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
 }
 
 impl std::fmt::Display for GitRev {
@@ -62,6 +75,13 @@ mod tests {
     use super::*;
 
     const VALID: &str = "0123456789abcdef0123456789abcdef01234567";
+
+    #[test]
+    fn as_str_returns_the_hash() {
+        let rev = GitRev::new(VALID).expect("the revision should be accepted");
+
+        assert_eq!(rev.as_str(), VALID);
+    }
 
     #[test]
     fn display_matches_source() {
@@ -94,7 +114,7 @@ mod tests {
     fn new_with_full_hash_is_accepted() {
         let rev = GitRev::new(VALID).expect("the revision should be accepted");
 
-        assert_eq!(rev.to_string(), VALID);
+        assert_eq!(rev.as_str(), VALID);
     }
 
     #[test]

--- a/crates/whisker/src/config/git_url.rs
+++ b/crates/whisker/src/config/git_url.rs
@@ -29,6 +29,9 @@ pub struct GitUrl(gix_url::Url);
 /// What stands in for credentials when a remote is printed
 const REDACTED_USERINFO: &str = "***";
 
+/// The directory name whisker uses when a remote yields no usable segment
+const FALLBACK_SLUG: &str = "repository";
+
 impl GitUrl {
     /// Creates a remote from its configured source
     ///
@@ -61,6 +64,45 @@ impl GitUrl {
             Err(gix_url::parse::Error::RelativeUrl { .. }) => {
                 anyhow::bail!("the git remote is relative")
             }
+        }
+    }
+
+    /// Returns a readable directory name for this remote
+    ///
+    /// The slug exists so that a person looking through the cache can tell
+    /// the checkouts apart. It is not an identity: two different remotes
+    /// can share a last path segment. The cache therefore pairs the slug
+    /// with a digest of the whole remote.
+    ///
+    /// The name comes from the parsed path, so every form of remote is read
+    /// the same way. An scp-like `git@host:org/repo` and an `https://` URL
+    /// spell their separators differently, and only the parser knows which
+    /// part of either is the path.
+    ///
+    /// # Examples
+    ///
+    /// ```ignore
+    /// let url = GitUrl::new("https://github.com/aonyx-ai/rules.git")?;
+    ///
+    /// assert_eq!(url.slug(), "rules");
+    /// ```
+    pub fn slug(&self) -> String {
+        let path = String::from_utf8_lossy(&self.0.path);
+        let slug = path.trim_end_matches('/');
+        let slug = slug.rsplit('/').next().unwrap_or(slug);
+        let slug = slug.strip_suffix(".git").unwrap_or(slug);
+        let slug: String = slug
+            .chars()
+            .map(|character| match character.is_ascii_alphanumeric() {
+                true => character,
+                false => '-',
+            })
+            .collect();
+        let slug = slug.trim_matches('-');
+
+        match slug.is_empty() {
+            true => FALLBACK_SLUG.to_owned(),
+            false => slug.to_owned(),
         }
     }
 }
@@ -197,6 +239,51 @@ mod tests {
             error.to_string().contains("names no repository"),
             "unexpected: {error:#}"
         );
+    }
+
+    #[test]
+    fn slug_of_a_local_path_uses_the_last_segment() {
+        let url = GitUrl::new("/src/checkouts/rules").expect("the remote should be accepted");
+
+        assert_eq!(url.slug(), "rules");
+    }
+
+    #[test]
+    fn slug_of_an_scp_style_remote_uses_the_last_segment() {
+        let url = GitUrl::new("git@github.com:aonyx-ai/rules.git")
+            .expect("the remote should be accepted");
+
+        assert_eq!(url.slug(), "rules");
+    }
+
+    #[test]
+    fn slug_replaces_characters_a_directory_name_should_not_hold() {
+        let url = GitUrl::new("https://example.com/we_ird").expect("the remote should be accepted");
+
+        assert_eq!(url.slug(), "we-ird");
+    }
+
+    #[test]
+    fn slug_strips_a_git_suffix() {
+        let url = GitUrl::new("https://github.com/aonyx-ai/rules.git")
+            .expect("the remote should be accepted");
+
+        assert_eq!(url.slug(), "rules");
+    }
+
+    #[test]
+    fn slug_strips_a_trailing_separator() {
+        let url = GitUrl::new("https://github.com/aonyx-ai/rules/")
+            .expect("the remote should be accepted");
+
+        assert_eq!(url.slug(), "rules");
+    }
+
+    #[test]
+    fn slug_with_no_usable_segment_falls_back() {
+        let url = GitUrl::new("https://example.com/").expect("the remote should be accepted");
+
+        assert_eq!(url.slug(), FALLBACK_SLUG);
     }
 
     #[test]

--- a/crates/whisker/src/config/lint_source.rs
+++ b/crates/whisker/src/config/lint_source.rs
@@ -65,6 +65,28 @@ impl GitLintSource {
     pub fn new(url: GitUrl, rev: GitRev) -> Self {
         Self { url, rev }
     }
+
+    /// Returns the remote the lints are fetched from
+    ///
+    /// # Examples
+    ///
+    /// ```ignore
+    /// println!("{}", source.url());
+    /// ```
+    pub fn url(&self) -> &GitUrl {
+        &self.url
+    }
+
+    /// Returns the commit the lints are checked out at
+    ///
+    /// # Examples
+    ///
+    /// ```ignore
+    /// println!("{}", source.rev());
+    /// ```
+    pub fn rev(&self) -> &GitRev {
+        &self.rev
+    }
 }
 
 impl std::fmt::Display for GitLintSource {
@@ -104,6 +126,20 @@ mod tests {
         let source = LintSource::Path(LintPath::new("lints/no_todo"));
 
         assert_eq!(source.to_string(), "lints/no_todo");
+    }
+
+    #[test]
+    fn rev_returns_the_configured_commit() {
+        let source = git_source();
+
+        assert_eq!(source.rev().as_str(), REV);
+    }
+
+    #[test]
+    fn url_returns_the_configured_remote() {
+        let source = git_source();
+
+        assert_eq!(source.url().to_string(), "https://example.com/rules");
     }
 
     #[test]

--- a/crates/whisker/src/custom_lints.rs
+++ b/crates/whisker/src/custom_lints.rs
@@ -12,6 +12,7 @@ use self::handshake::AbiIdentity;
 use crate::config::{LintSource, WhiskerConfig};
 
 mod artifact;
+mod git_source;
 mod handshake;
 
 /// The lint passes loaded from the project's configured custom lint crates
@@ -76,10 +77,7 @@ fn configured_directories(config: &WhiskerConfig) -> anyhow::Result<Vec<PathBuf>
     for entry in config.lints() {
         let directory = match entry {
             LintSource::Path(path) => path.resolve(config.root()),
-            LintSource::Git(git) => anyhow::bail!(
-                "the configured lint source {git} names a repository, and whisker cannot fetch \
-                 one yet"
-            ),
+            LintSource::Git(git) => git_source::checkout(git)?,
         };
 
         anyhow::ensure!(

--- a/crates/whisker/src/custom_lints/git_source.rs
+++ b/crates/whisker/src/custom_lints/git_source.rs
@@ -1,0 +1,33 @@
+use std::path::PathBuf;
+
+use crate::config::GitLintSource;
+
+mod cache;
+
+/// Returns the checkout the cache holds for `source`
+///
+/// A [`GitRev`] names one immutable commit, so a checkout that exists is
+/// the right one forever and whisker reuses it without asking the remote
+/// anything. That is what keeps a check working on a train, and it is
+/// also why the cache never expires: there is no later version of a
+/// commit to miss.
+///
+/// Fetching a checkout that is not there yet follows in its own change.
+///
+/// # Errors
+///
+/// Returns an error if no cache location can be determined, or if the
+/// cache holds no checkout of `source`.
+///
+/// [`GitRev`]: crate::config::GitRev
+pub fn checkout(source: &GitLintSource) -> anyhow::Result<PathBuf> {
+    let destination = cache::checkout_directory(source)?;
+
+    anyhow::ensure!(
+        destination.is_dir(),
+        "the cache holds no checkout of {source} at {}, and whisker cannot fetch one yet",
+        destination.display()
+    );
+
+    Ok(destination)
+}

--- a/crates/whisker/src/custom_lints/git_source/cache.rs
+++ b/crates/whisker/src/custom_lints/git_source/cache.rs
@@ -1,0 +1,323 @@
+use std::ffi::OsString;
+use std::path::{Path, PathBuf};
+
+use anyhow::Context as _;
+use etcetera::base_strategy::{BaseStrategy as _, Xdg};
+
+use crate::config::GitLintSource;
+
+/// The environment variable that moves the cache somewhere else
+///
+/// Tests set it so that a run never reads or writes the cache of the
+/// person running them, and a continuous integration job sets it to a
+/// directory it knows how to restore between runs.
+const CACHE_VARIABLE: &str = "WHISKER_CACHE_DIR";
+
+/// Where whisker may keep the lint sources it fetches
+///
+/// The candidates are read from the environment in one place and resolved
+/// in another, so the precedence between them can be tested without a
+/// process to set variables in.
+///
+/// Only the override is whisker's own. The directory beside it comes from
+/// etcetera, which reads `XDG_CACHE_HOME` and falls back to the home
+/// directory the way the base directory specification asks for, including
+/// ignoring a value that is not an absolute path.
+#[derive(Clone, Eq, PartialEq, Debug)]
+struct CacheLocation {
+    override_directory: Option<OsString>,
+    base_directory: Option<PathBuf>,
+}
+
+impl CacheLocation {
+    /// Reads the candidate locations from the environment
+    ///
+    /// An empty override counts as unset, because that is what a shell
+    /// leaves behind when it expands something that was never set, and
+    /// joining onto it would put the cache at the filesystem root.
+    fn from_environment() -> Self {
+        Self {
+            override_directory: present(std::env::var_os(CACHE_VARIABLE)),
+            base_directory: Xdg::new().ok().map(|base| base.cache_dir()),
+        }
+    }
+
+    /// Returns the directory whisker should keep fetched sources in
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if neither candidate is set, and names the override
+    /// in it, because that is the one the reader can act on.
+    fn resolve(&self) -> anyhow::Result<PathBuf> {
+        let Self {
+            override_directory,
+            base_directory,
+        } = self;
+
+        if let Some(directory) = override_directory {
+            return Ok(PathBuf::from(directory));
+        }
+
+        let base_directory = base_directory.as_ref().with_context(|| {
+            format!(
+                "failed to find a cache directory for git lint sources; set {CACHE_VARIABLE} to \
+                 the directory whisker should keep them in"
+            )
+        })?;
+
+        Ok(base_directory.join("whisker"))
+    }
+}
+
+/// Returns the directory whisker keeps fetched lint sources in
+///
+/// # Errors
+///
+/// Returns an error if the `WHISKER_CACHE_DIR` override is unset or empty
+/// and no home directory can be found.
+///
+/// # Examples
+///
+/// ```ignore
+/// let root = cache_root()?;
+///
+/// println!("checkouts live under {}", root.display());
+/// ```
+pub fn cache_root() -> anyhow::Result<PathBuf> {
+    CacheLocation::from_environment().resolve()
+}
+
+/// Returns the directory one pinned lint source is checked out in
+///
+/// # Errors
+///
+/// Returns an error if no cache location can be determined.
+pub fn checkout_directory(source: &GitLintSource) -> anyhow::Result<PathBuf> {
+    let root = cache_root()?;
+
+    Ok(checkout_directory_in(&root, source))
+}
+
+/// Returns where one pinned lint source sits under `root`
+///
+/// The remote contributes a readable name so that the cache can be
+/// browsed, and a digest so that two remotes ending in the same segment
+/// stay apart. The commit is the last segment rather than part of the
+/// name, which keeps every checkout of one remote together.
+///
+/// The digest reads the remote as it prints, credentials removed, so two
+/// people holding different tokens for one repository share a checkout
+/// rather than fetching the same commit twice.
+fn checkout_directory_in(root: &Path, source: &GitLintSource) -> PathBuf {
+    let remote = format!(
+        "{}-{}",
+        source.url().slug(),
+        digest(&source.url().to_string())
+    );
+
+    root.join("git").join(remote).join(source.rev().as_str())
+}
+
+/// Returns a variable's value, treating an empty one as unset
+///
+/// An empty variable is what a shell leaves behind when it expands
+/// something that was never set. Joining onto it would put the cache at
+/// the filesystem root, so whisker reads it as the absence it is.
+fn present(value: Option<OsString>) -> Option<OsString> {
+    value.filter(|value| !value.is_empty())
+}
+
+/// Returns a short, stable digest of `text`
+///
+/// This distinguishes remotes; it does not authenticate them, so a small
+/// non-cryptographic hash is the right tool. It is spelled out rather than
+/// taken from the standard library because the value is written into a
+/// directory name that outlives the process: [`DefaultHasher`] promises
+/// nothing across releases, and a toolchain upgrade that silently moved
+/// every cached checkout would refetch the world.
+///
+/// [`DefaultHasher`]: std::hash::DefaultHasher
+fn digest(text: &str) -> String {
+    const OFFSET: u64 = 0xcbf2_9ce4_8422_2325;
+    const PRIME: u64 = 0x0000_0100_0000_01b3;
+
+    let mut hash = OFFSET;
+    for byte in text.as_bytes() {
+        hash ^= u64::from(*byte);
+        hash = hash.wrapping_mul(PRIME);
+    }
+
+    format!("{hash:016x}")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::config::{GitRev, GitUrl};
+
+    const REV: &str = "0123456789abcdef0123456789abcdef01234567";
+    const ROOT: &str = "/cache";
+
+    fn location(override_directory: Option<&str>, base_directory: Option<&str>) -> CacheLocation {
+        CacheLocation {
+            override_directory: override_directory.map(OsString::from),
+            base_directory: base_directory.map(PathBuf::from),
+        }
+    }
+
+    fn source(url: &str) -> GitLintSource {
+        GitLintSource::new(
+            GitUrl::new(url).expect("the remote should be accepted"),
+            GitRev::new(REV).expect("the revision should be accepted"),
+        )
+    }
+
+    #[test]
+    fn checkout_directory_in_ends_with_the_commit() {
+        let directory =
+            checkout_directory_in(Path::new(ROOT), &source("https://example.com/rules"));
+
+        assert_eq!(
+            directory.file_name().expect("should have a name"),
+            std::ffi::OsStr::new(REV)
+        );
+    }
+
+    /// Pins that a token does not give a repository a cache of its own
+    ///
+    /// Two people can hold different tokens for one private repository, and
+    /// the commit either of them names is the same tree. The digest reads
+    /// the printed remote, which has no credentials in it.
+    #[test]
+    fn checkout_directory_in_ignores_credentials() {
+        let first = checkout_directory_in(Path::new(ROOT), &source("https://a@example.com/rules"));
+        let second = checkout_directory_in(Path::new(ROOT), &source("https://b@example.com/rules"));
+
+        assert_eq!(first, second);
+    }
+
+    #[test]
+    fn checkout_directory_in_keeps_one_remote_in_one_place() {
+        let first = checkout_directory_in(
+            Path::new(ROOT),
+            &GitLintSource::new(
+                GitUrl::new("https://example.com/rules").expect("the remote should be accepted"),
+                GitRev::new("a".repeat(40)).expect("the revision should be accepted"),
+            ),
+        );
+        let second = checkout_directory_in(
+            Path::new(ROOT),
+            &GitLintSource::new(
+                GitUrl::new("https://example.com/rules").expect("the remote should be accepted"),
+                GitRev::new("b".repeat(40)).expect("the revision should be accepted"),
+            ),
+        );
+
+        assert_eq!(first.parent(), second.parent());
+        assert_ne!(first, second);
+    }
+
+    #[test]
+    fn checkout_directory_in_names_the_remote_readably() {
+        let directory = checkout_directory_in(
+            Path::new(ROOT),
+            &source("https://github.com/aonyx-ai/rules.git"),
+        );
+
+        let remote = directory
+            .parent()
+            .and_then(Path::file_name)
+            .expect("should have a remote directory")
+            .to_string_lossy()
+            .into_owned();
+
+        assert!(remote.starts_with("rules-"), "unexpected: {remote}");
+    }
+
+    /// Two remotes can end in the same segment, and a checkout of one must
+    /// never be served for the other.
+    #[test]
+    fn checkout_directory_in_separates_remotes_that_share_a_last_segment() {
+        let first = checkout_directory_in(Path::new(ROOT), &source("https://example.com/a/rules"));
+        let second = checkout_directory_in(Path::new(ROOT), &source("https://example.com/b/rules"));
+
+        assert_ne!(first, second);
+    }
+
+    #[test]
+    fn digest_is_stable_across_releases() {
+        assert_eq!(digest("https://example.com/rules"), "cc3eedebbb64629b");
+    }
+
+    #[test]
+    fn digest_separates_different_remotes() {
+        assert_ne!(
+            digest("https://example.com/a/rules"),
+            digest("https://example.com/b/rules")
+        );
+    }
+
+    #[test]
+    fn resolve_names_whisker_under_the_base_directory() {
+        let location = location(None, Some("/xdg"));
+
+        let root = location.resolve().expect("should resolve");
+
+        assert_eq!(root, Path::new("/xdg/whisker"));
+    }
+
+    #[test]
+    fn resolve_prefers_the_override() {
+        let location = location(Some(ROOT), Some("/xdg"));
+
+        let root = location.resolve().expect("should resolve");
+
+        assert_eq!(root, Path::new(ROOT));
+    }
+
+    #[test]
+    fn resolve_without_any_location_returns_error() {
+        let location = location(None, None);
+
+        let error = location.resolve().expect_err("should fail");
+
+        assert!(
+            format!("{error:#}").contains(CACHE_VARIABLE),
+            "the error should name the way out: {error:#}"
+        );
+    }
+
+    /// A shell that expands an unset variable leaves an empty string
+    /// behind, and joining onto that would put the cache at the root.
+    #[test]
+    fn present_treats_an_empty_value_as_unset() {
+        let value = present(Some(OsString::new()));
+
+        assert_eq!(value, None);
+    }
+
+    #[test]
+    fn present_keeps_a_value_that_holds_something() {
+        let value = present(Some(OsString::from("/cache")));
+
+        assert_eq!(value, Some(OsString::from("/cache")));
+    }
+
+    #[test]
+    fn trait_send() {
+        fn assert_send<T: Send>() {}
+        assert_send::<CacheLocation>();
+    }
+
+    #[test]
+    fn trait_sync() {
+        fn assert_sync<T: Sync>() {}
+        assert_sync::<CacheLocation>();
+    }
+
+    #[test]
+    fn trait_unpin() {
+        fn assert_unpin<T: Unpin>() {}
+        assert_unpin::<CacheLocation>();
+    }
+}

--- a/crates/whisker/tests/custom_lints.rs
+++ b/crates/whisker/tests/custom_lints.rs
@@ -43,6 +43,17 @@ fn configure_lint(package: &Path, lint_path: &Path) {
     .expect("configuration should be written");
 }
 
+/// Points the package's whisker configuration at one pinned repository
+fn configure_git_lint(package: &Path, url: &str, rev: &str) {
+    let url = toml::Value::from(url);
+
+    std::fs::write(
+        package.join(".whisker.toml"),
+        format!("[[lints]]\ngit = {url}\nrev = \"{rev}\"\n"),
+    )
+    .expect("configuration should be written");
+}
+
 /// Returns the example plugin this repository ships
 fn example_lint() -> PathBuf {
     let path = Path::new(env!("CARGO_MANIFEST_DIR")).join("../../examples/custom_lint");
@@ -136,6 +147,36 @@ fn workspace_of_lints() -> TempDir {
     }
 
     directory
+}
+
+/// Pins where a pinned repository is looked for, and what is said if it
+/// is not there
+///
+/// The cache directory is the whole contract of this step: a run resolves
+/// a repository and a commit to one path and reads it, and the error has
+/// to name that path, because a reader who wants to prime the cache or
+/// clear it has nothing else to go on.
+#[test]
+fn check_with_a_git_lint_that_is_not_cached_names_the_checkout() {
+    let target = package(TODO_SOURCE);
+    let cache = tempfile::tempdir().expect("temporary directory should be created");
+    configure_git_lint(
+        target.path(),
+        "https://example.com/rules",
+        "0123456789abcdef0123456789abcdef01234567",
+    );
+
+    whisker()
+        .env("WHISKER_CACHE_DIR", cache.path())
+        .arg("check")
+        .arg(target.path())
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains("holds no checkout"))
+        .stderr(predicate::str::contains("https://example.com/rules"))
+        .stderr(predicate::str::contains(
+            "0123456789abcdef0123456789abcdef01234567",
+        ));
 }
 
 /// Pins that a configured directory may be a workspace of plugins


### PR DESCRIPTION
Whisker knew what a pinned repository was, but it had no place to put one.
This change adds the layout. A checkout is below the cache root, in a
directory named for the remote, with the commit as the last segment.

The root comes from WHISKER_CACHE_DIR, then from XDG_CACHE_HOME, and then
from the home directory. An empty variable counts as unset. A shell leaves
an empty variable behind when it expands a name that was never set. A join
onto that empty value would put the cache at the root of the filesystem.
The override is for tests, which must not touch the cache of the person
who runs them. A continuous integration job can also use the override.

The remote gives both a readable name and a digest of itself. The name
alone can collide, because two remotes can end with the same segment. The
digest alone would make the cache unreadable to a person. This change
writes the digest here and does not use the standard library. The hasher
of the standard library can change between releases. A cache path that
moved after a compiler upgrade would fetch everything again.

The commit is the last segment. This keeps each checkout of one remote
together. It also makes a checkout permanent: a hash names one tree, so a
checkout that exists is the correct one.

Whisker still cannot fetch. The error now names the path that whisker
examined, which is what a reader needs to fill or clear the cache.
