### PR TITLE
Document git lint sources

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -106,6 +106,24 @@ trait, the same
 decorations, the same test harness — and enters through
 `export_lints!` instead of the CLI's pass list.
 
+An entry names either a directory or a repository pinned to one commit.
+The two meet immediately: a git entry is fetched into the cache directory
+and from there is a directory like any other. That directory is
+`WHISKER_CACHE_DIR` when it is set, else `XDG_CACHE_HOME/whisker`, else
+`~/.cache/whisker`. The fetch
+asks the remote for that single commit, at depth one, over gitoxide rather
+than the `git` binary, so whisker's behavior does not depend on which git
+a machine has or whether it has one. Because a commit hash names an
+immutable tree, a checkout that exists is never refreshed and never
+revalidated against the remote, which is what keeps the network out of the
+common path. Only a git entry builds with `--locked`: the pin is worth
+what the lockfile behind it is worth.
+
+A directory may hold one package or a workspace of them, and every dynamic
+library the build produces is loaded and handshaken separately. That is
+what lets a repository of rules arrive through a single entry rather than
+one entry per rule.
+
 Rust has no stable ABI, so a loaded library is only coherent with the
 whisker binary when the same rustc compiled both and both lay the
 boundary out the same way. Whisker establishes that before trusting

--- a/README.md
+++ b/README.md
@@ -75,15 +75,35 @@ same way `ignore` patterns do:
 path = "lints/no_todo"
 ```
 
+An entry can also name a repository, which is how a set of rules is shared
+between projects. Whisker pins it to one commit, written out in full:
+
+```toml
+[[lints]]
+git = "https://github.com/aonyx-ai/whisker-aonyx-rules"
+rev = "0123456789abcdef0123456789abcdef01234567"
+```
+
+A branch or a tag is whatever the remote points it at today, so the same
+configuration would run different rules on different days. Whisker asks for
+that one commit and nothing else, keeps the checkout under
+`~/.cache/whisker`, and reuses it forever after, because the commit it
+names can never change. Set `WHISKER_CACHE_DIR` to keep those checkouts
+somewhere else. A git source builds with `--locked`, so commit the
+lockfile beside the rules.
+
 `whisker check` compiles each entry with your `cargo`, loads the built
-library, and runs its lints. Whisker ships no rules of its own, so the
+libraries, and runs their lints. Whisker ships no rules of its own, so the
 rules a project configures are exactly the rules it runs. The first build takes
 as long as any Rust compilation; afterwards cargo's cache makes it cheap.
 
 A custom lint crate is a `cdylib` that implements `RustLintPass` and hands
 its rules to `export_lints!`. The complete crate in
 [`examples/custom_lint`][example] is the template: a `Cargo.toml` declaring
-the crate type and the whisker dependencies, one rule, and its tests.
+the crate type and the whisker dependencies, one rule, and its tests. An
+entry may also name a directory holding a cargo workspace, in which case
+every plugin in it loads, which is what lets one entry bring a whole
+repository of rules.
 
 Rust has no stable ABI, so whisker only loads a plugin built by the same
 rustc from the same whisker source as the binary itself, and refuses


### PR DESCRIPTION
The README gains the entry that a project writes to pin a repository. It
also says what the pin gives: one commit, one fetch, and later runs
offline. The lockfile beside the rules is part of the pin, because a git
source builds with `--locked`.

ARCHITECTURE tells the same story from the inside. The two kinds of entry
meet as soon as a repository becomes a directory in the cache.

Both files also record that a configured directory can hold a workspace.
This is what lets one entry bring a repository of rules.
