### PR TITLE
Format the plugin packages the workspace excludes

### DIFF
--- a/justfile
+++ b/justfile
@@ -36,7 +36,13 @@ format-markdown fix="false": (prettier fix "md")
 
 # Format Rust files
 format-rust fix="false":
-    cargo fmt -- --unstable-features {{ if fix != "true" { "--check" } else { "" } }}
+    #!/usr/bin/env -S bash -euo pipefail
+    # The plugin packages sit outside the workspace, so a run at the root
+    # never reaches them. They are Rust like everything else and drift the
+    # moment nothing checks them.
+    for package in . examples/custom_lint; do
+        (cd "${package}" && cargo fmt -- --unstable-features {{ if fix != "true" { "--check" } else { "" } }})
+    done
 
 # Format TOML files
 format-toml fix="false":


### PR DESCRIPTION
A plugin package is deliberately outside the workspace. This is how a
plugin outside this repository is built, so the exclusion keeps the test
honest. The cost is that `cargo fmt` at the root never reaches such a
package. Its formatting thus drifts, and nothing reports the drift.

The recipe now runs the formatter in each excluded package and at the
root. A package that is added later joins the list beside its own change.
This change comes before the packages that need it.
