### PR TITLE
Move the lint cache beside the sources that fill it

### DIFF
--- a/crates/whisker/src/custom_lints.rs
+++ b/crates/whisker/src/custom_lints.rs
@@ -12,6 +12,7 @@ use self::handshake::AbiIdentity;
 use crate::config::{LintSource, WhiskerConfig};
 
 mod artifact;
+mod cache;
 mod git_source;
 mod handshake;
 

--- a/crates/whisker/src/custom_lints/cache.rs
+++ b/crates/whisker/src/custom_lints/cache.rs
@@ -1,3 +1,16 @@
+//! Where whisker keeps what it fetches for custom lints
+//!
+//! A lint source that is not already a directory on the machine has to
+//! become one before whisker can use it. This module owns the layout of
+//! the cache those arrive in: where its root is, where one source sits
+//! under it, and where a fetch assembles a source before it is whole
+//! enough to install.
+//!
+//! The layout is written into directory names that outlive the process,
+//! so each part of it is stable by construction rather than by habit.
+//! The module sits beside the sources rather than inside one of them,
+//! because the cache is the platform's, not any one source's.
+
 use std::ffi::OsString;
 use std::path::{Path, PathBuf};
 

--- a/crates/whisker/src/custom_lints/git_source.rs
+++ b/crates/whisker/src/custom_lints/git_source.rs
@@ -3,9 +3,8 @@ use std::sync::atomic::AtomicBool;
 
 use anyhow::Context as _;
 
+use super::cache;
 use crate::config::{GitLintSource, GitRev, GitUrl};
-
-mod cache;
 
 /// Returns a checkout of `source`, fetching it if the cache lacks one
 ///


### PR DESCRIPTION
The cache module lived inside the git source module, because the git source was the only thing that fetched anything. Whisker gains a second way to obtain a lint source later in this stack. That second way needs the same cache root, the same directory per remote, and the same install by rename.

This change lifts the module one level. The cache now sits beside the sources rather than inside one of them. Nothing else moves. The layout, the environment override, and every test stay the same.

The module also gains documentation of its own. It had none while it was a private detail of a single caller.


---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>