### PR TITLE
Give this whisker a name that a publisher can build for

### DIFF
--- a/crates/whisker/build.rs
+++ b/crates/whisker/build.rs
@@ -1,0 +1,10 @@
+/// Bakes the platform this binary was built for into it
+///
+/// Cargo knows the target triple and the binary does not. Whisker needs
+/// it to ask a publisher for a prebuilt lint library that runs here.
+fn main() {
+    println!("cargo::rerun-if-changed=build.rs");
+
+    let target = std::env::var("TARGET").expect("cargo sets TARGET for a build script");
+    println!("cargo::rustc-env=WHISKER_TARGET={target}");
+}

--- a/crates/whisker/src/commands.rs
+++ b/crates/whisker/src/commands.rs
@@ -1,3 +1,4 @@
+mod abi;
 mod check;
 
 clawless::commands!();

--- a/crates/whisker/src/commands/abi.rs
+++ b/crates/whisker/src/commands/abi.rs
@@ -1,0 +1,14 @@
+use clawless::prelude::*;
+
+use crate::custom_lints::AbiTag;
+
+/// Print the tag that names the prebuilt lints this whisker can load
+#[derive(Debug, Args)]
+pub struct AbiArgs {}
+
+#[command]
+pub async fn abi(_args: AbiArgs, _context: Context) -> CommandResult {
+    println!("{}", AbiTag::host());
+
+    Ok(())
+}

--- a/crates/whisker/src/custom_lints.rs
+++ b/crates/whisker/src/custom_lints.rs
@@ -11,10 +11,14 @@ use whisker_types::plugin::{LintPassFactory, LintRegistrar, PluginDeclaration};
 use self::handshake::AbiIdentity;
 use crate::config::{LintSource, WhiskerConfig};
 
+mod abi_tag;
 mod artifact;
 mod cache;
+mod digest;
 mod git_source;
 mod handshake;
+
+pub use abi_tag::AbiTag;
 
 /// The lint passes loaded from the project's configured custom lint crates
 ///

--- a/crates/whisker/src/custom_lints/abi_tag.rs
+++ b/crates/whisker/src/custom_lints/abi_tag.rs
@@ -1,0 +1,202 @@
+use std::fmt;
+
+use super::digest::digest;
+use super::handshake::AbiIdentity;
+
+/// The target triple this binary was compiled for
+///
+/// Nothing at runtime reports it, so the build script reads it from cargo
+/// and bakes it in.
+const TARGET: &str = env!("WHISKER_TARGET");
+
+/// Names the whisker binary that a prebuilt lint library has to fit
+///
+/// The tag holds a digest of every value [`super::handshake`] compares,
+/// then the platform. A publisher of prebuilt lints puts it in the name
+/// of each archive. Whisker can therefore ask for a library that fits
+/// before it downloads one.
+///
+/// The tag covers what the handshake covers. An archive under this
+/// whisker's tag passes the handshake, and a whisker that no publisher
+/// built for finds no file at all.
+///
+/// A small digest suffices here. The handshake still decides whether a
+/// library loads, so a collision costs one wasted download.
+///
+/// The name is a contract with publishers, and [`AbiTag::new`] carries a
+/// test that pins it.
+#[derive(Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug)]
+pub struct AbiTag(String);
+
+impl AbiTag {
+    /// Returns the tag of the whisker binary that is running
+    ///
+    /// # Examples
+    ///
+    /// ```ignore
+    /// println!("this whisker loads lints tagged {}", AbiTag::host());
+    /// ```
+    pub fn host() -> Self {
+        Self::new(&AbiIdentity::host(), TARGET)
+    }
+
+    /// Returns the tag of a whisker with `identity` running on `target`
+    ///
+    /// A newline separates the values, and each fingerprint occupies a
+    /// fixed width. Two different identities therefore cannot produce one
+    /// input to the digest.
+    fn new(identity: &AbiIdentity, target: &str) -> Self {
+        let AbiIdentity {
+            abi_version,
+            rustc_version,
+            types_fingerprint,
+            language_fingerprint,
+        } = identity;
+
+        let key = digest(&format!(
+            "{abi_version}\n{rustc_version}\n{types_fingerprint:016x}\n{language_fingerprint:016x}"
+        ));
+
+        Self(format!("{key}-{target}"))
+    }
+}
+
+impl fmt::Display for AbiTag {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        self.0.fmt(f)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn identity() -> AbiIdentity {
+        AbiIdentity {
+            abi_version: 2,
+            rustc_version: "rustc 1.92.0-nightly (0123456 2026-08-11)".to_owned(),
+            types_fingerprint: 0x0123_4567_89ab_cdef,
+            language_fingerprint: 0xfedc_ba98_7654_3210,
+        }
+    }
+
+    /// Pins the tag that publishers write into an archive name
+    ///
+    /// Whisker stops finding every archive that carries the old tag if
+    /// this derivation changes. The test fails first, so whoever changes
+    /// it knows to republish.
+    #[test]
+    fn new_is_stable_across_releases() {
+        let tag = AbiTag::new(&identity(), "aarch64-apple-darwin");
+
+        assert_eq!(tag.to_string(), "4d1b722e64837210-aarch64-apple-darwin");
+    }
+
+    #[test]
+    fn new_separates_identities_that_differ_in_the_abi_version() {
+        let other = AbiIdentity {
+            abi_version: 3,
+            ..identity()
+        };
+
+        assert_ne!(
+            AbiTag::new(&identity(), "x86_64-unknown-linux-gnu"),
+            AbiTag::new(&other, "x86_64-unknown-linux-gnu")
+        );
+    }
+
+    #[test]
+    fn new_separates_identities_that_differ_in_the_language_fingerprint() {
+        let other = AbiIdentity {
+            language_fingerprint: 1,
+            ..identity()
+        };
+
+        assert_ne!(
+            AbiTag::new(&identity(), "x86_64-unknown-linux-gnu"),
+            AbiTag::new(&other, "x86_64-unknown-linux-gnu")
+        );
+    }
+
+    #[test]
+    fn new_separates_identities_that_differ_in_the_rustc_version() {
+        let other = AbiIdentity {
+            rustc_version: "rustc 1.92.0-nightly (0123456 2026-08-12)".to_owned(),
+            ..identity()
+        };
+
+        assert_ne!(
+            AbiTag::new(&identity(), "x86_64-unknown-linux-gnu"),
+            AbiTag::new(&other, "x86_64-unknown-linux-gnu")
+        );
+    }
+
+    #[test]
+    fn new_separates_identities_that_differ_in_the_types_fingerprint() {
+        let other = AbiIdentity {
+            types_fingerprint: 1,
+            ..identity()
+        };
+
+        assert_ne!(
+            AbiTag::new(&identity(), "x86_64-unknown-linux-gnu"),
+            AbiTag::new(&other, "x86_64-unknown-linux-gnu")
+        );
+    }
+
+    #[test]
+    fn new_separates_platforms() {
+        assert_ne!(
+            AbiTag::new(&identity(), "aarch64-apple-darwin"),
+            AbiTag::new(&identity(), "x86_64-unknown-linux-gnu")
+        );
+    }
+
+    /// Pins that one fingerprint cannot borrow a digit from the other
+    ///
+    /// At a variable width the two would run together. Two different
+    /// identities would then share one tag.
+    #[test]
+    fn new_separates_identities_whose_fingerprints_are_shifted() {
+        let first = AbiIdentity {
+            types_fingerprint: 0x0000_0000_0000_0001,
+            language_fingerprint: 0x0000_0000_0000_0023,
+            ..identity()
+        };
+        let second = AbiIdentity {
+            types_fingerprint: 0x0000_0000_0000_0012,
+            language_fingerprint: 0x0000_0000_0000_0003,
+            ..identity()
+        };
+
+        assert_ne!(
+            AbiTag::new(&first, "aarch64-apple-darwin"),
+            AbiTag::new(&second, "aarch64-apple-darwin")
+        );
+    }
+
+    #[test]
+    fn host_names_the_platform_the_binary_was_built_for() {
+        let tag = AbiTag::host().to_string();
+
+        assert!(tag.ends_with(&format!("-{TARGET}")), "{tag}");
+    }
+
+    #[test]
+    fn trait_send() {
+        fn assert_send<T: Send>() {}
+        assert_send::<AbiTag>();
+    }
+
+    #[test]
+    fn trait_sync() {
+        fn assert_sync<T: Sync>() {}
+        assert_sync::<AbiTag>();
+    }
+
+    #[test]
+    fn trait_unpin() {
+        fn assert_unpin<T: Unpin>() {}
+        assert_unpin::<AbiTag>();
+    }
+}

--- a/crates/whisker/src/custom_lints/cache.rs
+++ b/crates/whisker/src/custom_lints/cache.rs
@@ -17,6 +17,7 @@ use std::path::{Path, PathBuf};
 use anyhow::Context as _;
 use etcetera::base_strategy::{BaseStrategy as _, Xdg};
 
+use super::digest::digest;
 use crate::config::GitLintSource;
 
 /// The environment variable that moves the cache somewhere else
@@ -153,29 +154,6 @@ fn present(value: Option<OsString>) -> Option<OsString> {
     value.filter(|value| !value.is_empty())
 }
 
-/// Returns a short, stable digest of `text`
-///
-/// This distinguishes remotes; it does not authenticate them, so a small
-/// non-cryptographic hash is the right tool. It is spelled out rather than
-/// taken from the standard library because the value is written into a
-/// directory name that outlives the process: [`DefaultHasher`] promises
-/// nothing across releases, and a toolchain upgrade that silently moved
-/// every cached checkout would refetch the world.
-///
-/// [`DefaultHasher`]: std::hash::DefaultHasher
-fn digest(text: &str) -> String {
-    const OFFSET: u64 = 0xcbf2_9ce4_8422_2325;
-    const PRIME: u64 = 0x0000_0100_0000_01b3;
-
-    let mut hash = OFFSET;
-    for byte in text.as_bytes() {
-        hash ^= u64::from(*byte);
-        hash = hash.wrapping_mul(PRIME);
-    }
-
-    format!("{hash:016x}")
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -268,19 +246,6 @@ mod tests {
         let second = checkout_directory_in(Path::new(ROOT), &source("https://example.com/b/rules"));
 
         assert_ne!(first, second);
-    }
-
-    #[test]
-    fn digest_is_stable_across_releases() {
-        assert_eq!(digest("https://example.com/rules"), "cc3eedebbb64629b");
-    }
-
-    #[test]
-    fn digest_separates_different_remotes() {
-        assert_ne!(
-            digest("https://example.com/a/rules"),
-            digest("https://example.com/b/rules")
-        );
     }
 
     #[test]

--- a/crates/whisker/src/custom_lints/digest.rs
+++ b/crates/whisker/src/custom_lints/digest.rs
@@ -1,0 +1,68 @@
+//! A short, stable digest for names that outlive the process
+//!
+//! Whisker writes digests into the names of directories it keeps, and
+//! into the names of artifacts it looks for. Both outlive the run that
+//! wrote them. A later run, a later release, and another platform all
+//! reproduce them byte for byte.
+//!
+//! That rules out [`DefaultHasher`], which promises nothing across
+//! releases: a toolchain upgrade that silently moved every cached
+//! checkout would refetch the world. The algorithm is therefore spelled
+//! out here. It is FNV-1a, which is short enough to read inside a path
+//! and simple enough that the definition cannot drift.
+//!
+//! The digest distinguishes inputs; it does not authenticate them, and
+//! nothing here asks it to.
+//!
+//! [`DefaultHasher`]: std::hash::DefaultHasher
+
+/// Returns a short, stable digest of `text`
+///
+/// # Examples
+///
+/// ```ignore
+/// assert_eq!(digest("https://example.com/rules"), "cc3eedebbb64629b");
+/// ```
+pub fn digest(text: &str) -> String {
+    const OFFSET: u64 = 0xcbf2_9ce4_8422_2325;
+    const PRIME: u64 = 0x0000_0100_0000_01b3;
+
+    let mut hash = OFFSET;
+    for byte in text.as_bytes() {
+        hash ^= u64::from(*byte);
+        hash = hash.wrapping_mul(PRIME);
+    }
+
+    format!("{hash:016x}")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn digest_is_stable_across_releases() {
+        assert_eq!(digest("https://example.com/rules"), "cc3eedebbb64629b");
+    }
+
+    #[test]
+    fn digest_is_sixteen_hexadecimal_digits() {
+        let digest = digest("whatever");
+
+        assert_eq!(digest.len(), 16, "{digest}");
+        assert!(
+            digest
+                .chars()
+                .all(|c| c.is_ascii_hexdigit() && !c.is_uppercase()),
+            "{digest}"
+        );
+    }
+
+    #[test]
+    fn digest_separates_different_inputs() {
+        assert_ne!(
+            digest("https://example.com/a/rules"),
+            digest("https://example.com/b/rules")
+        );
+    }
+}

--- a/crates/whisker/src/main.rs
+++ b/crates/whisker/src/main.rs
@@ -3,6 +3,7 @@ mod config;
 mod custom_lints;
 mod discovery;
 
+use clawless::clap;
 use clawless::output::OutputFlags;
 use clawless::resolved_leaf::ResolvedLeaf;
 
@@ -10,6 +11,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     let app = OutputFlags::augment_command(commands::clawless_init())
         .name("whisker")
         .version(env!("CARGO_PKG_VERSION"));
+    let app = with_subcommands_in_order(app);
 
     match commands::clawless_resolve(app.get_matches()) {
         ResolvedLeaf::Command { matches, exec } => {
@@ -19,4 +21,24 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
             clawless::tui::runner::ApplicationRunner::run(matches, exec)
         }
     }
+}
+
+/// Returns `app` with its subcommands listed in a stable order
+///
+/// Clap lists subcommands in the order it receives them. Clawless hands
+/// them over in the order the linker laid out its registry. That order
+/// holds for one binary and can differ for the next, so two builds of
+/// whisker could print their commands in two orders.
+///
+/// One rank for every subcommand leaves clap to sort them by name. A
+/// reader looks for a command under its name, so that order also helps.
+fn with_subcommands_in_order(app: clap::Command) -> clap::Command {
+    let names: Vec<String> = app
+        .get_subcommands()
+        .map(|subcommand| subcommand.get_name().to_owned())
+        .collect();
+
+    names.into_iter().fold(app, |app, name| {
+        app.mut_subcommand(name, |subcommand| subcommand.display_order(0))
+    })
 }

--- a/crates/whisker/tests/abi.rs
+++ b/crates/whisker/tests/abi.rs
@@ -1,0 +1,35 @@
+use assert_cmd::Command;
+use predicates::prelude::*;
+
+/// Pins the shape of the tag the command prints
+///
+/// The digest is sixteen hexadecimal digits, and the platform follows it.
+/// Publishers put this string in an archive name, so the shape is a
+/// contract.
+#[test]
+fn abi_prints_a_digest_and_the_target_triple() {
+    let mut command = Command::cargo_bin("whisker").expect("whisker binary should exist");
+
+    let assertion = command.arg("abi").assert();
+
+    assertion.success().stdout(
+        predicate::str::is_match(r"^[0-9a-f]{16}-\S+\n$").expect("the pattern should compile"),
+    );
+}
+
+/// The build script bakes the target into the binary, and it bakes the
+/// same value into this test. The test therefore compares two values and
+/// describes neither.
+#[test]
+fn abi_names_the_target_the_binary_was_built_for() {
+    let mut command = Command::cargo_bin("whisker").expect("whisker binary should exist");
+
+    let assertion = command.arg("abi").assert();
+
+    assertion
+        .success()
+        .stdout(predicate::str::ends_with(format!(
+            "-{}\n",
+            env!("WHISKER_TARGET")
+        )));
+}

--- a/crates/whisker/tests/cmd/abi_help.md
+++ b/crates/whisker/tests/cmd/abi_help.md
@@ -1,0 +1,15 @@
+# whisker abi --help
+
+```console
+$ whisker abi --help
+Print the tag that names the prebuilt lints this whisker can load
+
+Usage: whisker abi [OPTIONS]
+
+Options:
+  -q, --quiet    Suppress informational messages
+  -v, --verbose  Show additional detail
+      --json     Output results as JSON
+  -h, --help     Print help
+
+```

--- a/crates/whisker/tests/cmd/help.md
+++ b/crates/whisker/tests/cmd/help.md
@@ -6,6 +6,7 @@ $ whisker --help
 Usage: whisker [OPTIONS] [COMMAND]
 
 Commands:
+  abi    Print the tag that names the prebuilt lints this whisker can load
   check  Run whisker lints against a project
   help   Print this message or the help of the given subcommand(s)
 

--- a/justfile
+++ b/justfile
@@ -94,7 +94,18 @@ package-whisker version target:
     fi
 
     cargo build --release --locked -p whisker --target "${target}"
-    "target/${target}/release/whisker" --version
+    whisker="target/${target}/release/whisker"
+    "${whisker}" --version
+
+    # The archive's name promises a platform, and the binary decides which
+    # prebuilt lints it asks a publisher for. A disagreement would send
+    # everyone who unpacks this archive looking for artifacts that were
+    # never published under that name, so the two are compared here.
+    tag="$("${whisker}" abi)"
+    if [ "${tag#*-}" != "${target}" ]; then
+        echo "the binary is built for ${tag#*-}, but the archive names ${target}" >&2
+        exit 1
+    fi
 
     name="whisker-${version}-${target}"
     rm -rf "dist/${name}"


### PR DESCRIPTION
Whisker loads a lint plugin into its own process. That is only sound when the same rustc compiles the plugin and whisker from the same whisker source. The handshake proves this for a library that whisker already holds. It cannot help whisker to ask for the right library. A whisker that ships as a binary must ask, because the user no longer has the toolchain that built it.

This change adds the tag that names what to ask for. The tag is a digest of every value that the handshake compares, followed by the target triple. The new command `whisker abi` prints it. A publisher of prebuilt lints names each archive with the tag of the whisker it built against.

The tag covers exactly what the handshake covers. An archive under this whisker's tag therefore passes the handshake. A whisker that nobody builds for finds no file, instead of a refusal after a download.

The digest is the small one that the cache already uses. It separates builds and does not authenticate them. That is enough, because the handshake makes a load sound, and it refuses a collision loudly. The digest function moves into a module of its own, because a second caller now wants it. It also gains a test that pins its shape, because both callers write it into names that outlive the process.

Whisker also sorts its own subcommands now. Clap lists them in the order that clawless adds them, and clawless adds them in the order that the linker lays out its registry. Two builds of whisker could therefore print two different orders. One subcommand hid this. Two subcommands show it, both in the help text and in a snapshot test that matches only one order.


---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>