### PR TITLE
Load lint libraries that whisker did not build

### DIFF
--- a/crates/whisker/src/custom_lints.rs
+++ b/crates/whisker/src/custom_lints.rs
@@ -17,6 +17,7 @@ mod cache;
 mod digest;
 mod git_source;
 mod handshake;
+mod prebuilt;
 
 pub use abi_tag::AbiTag;
 
@@ -48,10 +49,24 @@ impl CustomLints {
         let host = AbiIdentity::host();
         let mut factories = Vec::new();
 
-        for Checkout { directory, locking } in configured_checkouts(config)? {
-            let loaded = load_directory(&directory, locking, &host).with_context(|| {
-                format!("failed to load the custom lints at {}", directory.display())
-            })?;
+        for Resolved {
+            directory,
+            contents,
+        } in configured_sources(config, &AbiTag::host())?
+        {
+            let loaded = match contents {
+                Contents::Sources(locking) => load_sources(&directory, locking, &host)
+                    .with_context(|| {
+                        format!("failed to load the custom lints at {}", directory.display())
+                    }),
+                Contents::Libraries => load_prebuilt(&directory, &host).with_context(|| {
+                    format!(
+                        "failed to load the prebuilt lints at {}",
+                        directory.display()
+                    )
+                }),
+            }?;
+
             factories.extend(loaded);
         }
 
@@ -64,15 +79,30 @@ impl CustomLints {
     }
 }
 
-/// A resolved lint source, ready to build
+/// A resolved lint source, ready to load
 ///
-/// Resolution loses the difference between a path and a repository, save
-/// for one thing the build still needs to know, so [`Locking`] rides along
-/// with the directory.
+/// Resolution loses the difference between a path and a repository. Two
+/// things survive it: a directory, and whether whisker has to compile
+/// what is in that directory.
 #[derive(Clone, Eq, PartialEq, Debug)]
-struct Checkout {
+struct Resolved {
     directory: PathBuf,
-    locking: Locking,
+    contents: Contents,
+}
+
+/// What a resolved directory holds
+///
+/// Both kinds end at the same place, which is a set of dynamic libraries
+/// that pass the handshake. They differ in who compiled them. Whisker
+/// compiles the first kind from cargo packages in the directory. A
+/// publisher compiled the second kind.
+#[derive(Copy, Clone, Eq, PartialEq, Debug)]
+enum Contents {
+    /// Cargo packages, which whisker builds before it loads them
+    Sources(Locking),
+
+    /// Dynamic libraries, which whisker loads as they are
+    Libraries,
 }
 
 /// Whether a build may change the lockfile it finds
@@ -92,23 +122,36 @@ enum Locking {
 ///
 /// Everything is resolved up front, so a typo in the second entry surfaces
 /// before the first entry's potentially long compilation, and a source
-/// configured twice is caught however it was spelled. A git source is
-/// fetched here, which is also why it happens before the builds: a network
-/// failure should not arrive after five minutes of compiling.
+/// configured twice is caught however it was spelled. A git source reaches
+/// the network here, which is also why it happens before the builds: a
+/// network failure should not arrive after five minutes of compiling.
+///
+/// Whisker looks for prebuilt libraries before it takes a git source. It
+/// fetches and compiles the source whenever it finds none. A project
+/// that no publisher builds for therefore behaves as it did before.
 ///
 /// # Errors
 ///
 /// Returns an error if an entry does not exist, is not a directory, holds
 /// no `Cargo.toml`, cannot be fetched, or resolves to the same directory
 /// as an earlier entry.
-fn configured_checkouts(config: &WhiskerConfig) -> anyhow::Result<Vec<Checkout>> {
-    let mut checkouts = Vec::new();
+fn configured_sources(config: &WhiskerConfig, tag: &AbiTag) -> anyhow::Result<Vec<Resolved>> {
+    let mut sources = Vec::new();
     let mut seen = HashSet::new();
 
     for entry in config.lints() {
-        let (directory, locking) = match entry {
-            LintSource::Path(path) => (path.resolve(config.root()), Locking::Unlocked),
-            LintSource::Git(git) => (git_source::checkout(git)?, Locking::Locked),
+        let (directory, contents) = match entry {
+            LintSource::Path(path) => (
+                path.resolve(config.root()),
+                Contents::Sources(Locking::Unlocked),
+            ),
+            LintSource::Git(git) => match prebuilt::resolve(git, tag)? {
+                Some(directory) => (directory, Contents::Libraries),
+                None => (
+                    git_source::checkout(git)?,
+                    Contents::Sources(Locking::Locked),
+                ),
+            },
         };
 
         anyhow::ensure!(
@@ -125,20 +168,27 @@ fn configured_checkouts(config: &WhiskerConfig) -> anyhow::Result<Vec<Checkout>>
         let directory = std::fs::canonicalize(&directory)
             .with_context(|| format!("failed to resolve the lint source {entry}"))?;
 
-        anyhow::ensure!(
-            directory.join("Cargo.toml").is_file(),
-            "the lint source {entry} holds no Cargo.toml"
-        );
+        match contents {
+            Contents::Sources(_) => anyhow::ensure!(
+                directory.join("Cargo.toml").is_file(),
+                "the lint source {entry} holds no Cargo.toml"
+            ),
+            Contents::Libraries => {}
+        }
+
         anyhow::ensure!(
             seen.insert(directory.clone()),
             "the lint source {entry} resolves to {}, which an earlier entry already configured",
             directory.display()
         );
 
-        checkouts.push(Checkout { directory, locking });
+        sources.push(Resolved {
+            directory,
+            contents,
+        });
     }
 
-    Ok(checkouts)
+    Ok(sources)
 }
 
 /// Builds the packages at `directory` and loads the lints they export
@@ -146,16 +196,48 @@ fn configured_checkouts(config: &WhiskerConfig) -> anyhow::Result<Vec<Checkout>>
 /// A directory may hold one package or a workspace of them, so every
 /// dynamic library the build produced is loaded, each with its own
 /// handshake.
-fn load_directory(
+fn load_sources(
     directory: &Path,
     locking: Locking,
     host: &AbiIdentity,
 ) -> anyhow::Result<Vec<LintPassFactory>> {
     let libraries = build(directory, locking)?;
+
+    load_libraries(&libraries, host)
+}
+
+/// Loads the lints exported by the prebuilt libraries at `directory`
+///
+/// Each library completes the same handshake as one whisker compiled
+/// itself, and a failure fails the run. The tag whisker asked under
+/// covers what the handshake compares. A library that fails therefore
+/// carries a tag that misdescribes it, and a quiet compile would leave
+/// that wrong for everyone who trusts the tag.
+///
+/// # Errors
+///
+/// Returns an error if the directory cannot be read, if it holds no
+/// library, or if any library fails to load.
+fn load_prebuilt(directory: &Path, host: &AbiIdentity) -> anyhow::Result<Vec<LintPassFactory>> {
+    let libraries = prebuilt::libraries(directory)?;
+
+    anyhow::ensure!(
+        !libraries.is_empty(),
+        "the directory holds no dynamic library; delete it and run whisker again to replace it"
+    );
+
+    load_libraries(&libraries, host)
+}
+
+/// Completes the handshake with each library and collects what registers
+fn load_libraries(
+    libraries: &[PathBuf],
+    host: &AbiIdentity,
+) -> anyhow::Result<Vec<LintPassFactory>> {
     let mut factories = Vec::new();
 
     for library in libraries {
-        let loaded = load_library(&library, host)
+        let loaded = load_library(library, host)
             .with_context(|| format!("failed to load {}", library.display()))?;
         factories.extend(loaded);
     }
@@ -335,11 +417,11 @@ mod tests {
     }
 
     fn directories(config: &WhiskerConfig) -> anyhow::Result<Vec<PathBuf>> {
-        let checkouts = configured_checkouts(config)?;
+        let sources = configured_sources(config, &AbiTag::host())?;
 
-        Ok(checkouts
+        Ok(sources
             .into_iter()
-            .map(|Checkout { directory, .. }| directory)
+            .map(|Resolved { directory, .. }| directory)
             .collect())
     }
 
@@ -364,7 +446,7 @@ mod tests {
     }
 
     #[test]
-    fn configured_checkouts_rejects_a_duplicate_entry() {
+    fn configured_sources_rejects_a_duplicate_entry() {
         let root = tempfile::tempdir().expect("temporary directory should be created");
         package(root.path(), "no_todo");
         let config = config_with(
@@ -381,7 +463,7 @@ mod tests {
     }
 
     #[test]
-    fn configured_checkouts_rejects_a_file_entry() {
+    fn configured_sources_rejects_a_file_entry() {
         let root = tempfile::tempdir().expect("temporary directory should be created");
         std::fs::write(root.path().join("lint.rs"), "").expect("file should be written");
         let config = config_with(root.path(), vec![LintPath::new("lint.rs")]);
@@ -395,7 +477,7 @@ mod tests {
     }
 
     #[test]
-    fn configured_checkouts_rejects_a_missing_entry() {
+    fn configured_sources_rejects_a_missing_entry() {
         let root = tempfile::tempdir().expect("temporary directory should be created");
         let config = config_with(root.path(), vec![LintPath::new("absent")]);
 
@@ -408,7 +490,7 @@ mod tests {
     }
 
     #[test]
-    fn configured_checkouts_rejects_an_entry_without_manifest() {
+    fn configured_sources_rejects_an_entry_without_manifest() {
         let root = tempfile::tempdir().expect("temporary directory should be created");
         std::fs::create_dir(root.path().join("empty")).expect("directory should be created");
         let config = config_with(root.path(), vec![LintPath::new("empty")]);
@@ -422,7 +504,7 @@ mod tests {
     }
 
     #[test]
-    fn configured_checkouts_resolves_entries_in_order() {
+    fn configured_sources_resolves_entries_in_order() {
         let root = tempfile::tempdir().expect("temporary directory should be created");
         let first = package(root.path(), "first");
         let second = package(root.path(), "second");
@@ -443,16 +525,16 @@ mod tests {
     }
 
     #[test]
-    fn configured_checkouts_leaves_a_path_source_unlocked() {
+    fn configured_sources_leaves_a_path_source_unlocked() {
         let root = tempfile::tempdir().expect("temporary directory should be created");
         package(root.path(), "no_todo");
         let config = config_with(root.path(), vec![LintPath::new("no_todo")]);
 
-        let checkouts = configured_checkouts(&config).expect("should resolve");
+        let sources = configured_sources(&config, &AbiTag::host()).expect("should resolve");
 
         assert_eq!(
-            checkouts.first().map(|checkout| checkout.locking),
-            Some(Locking::Unlocked),
+            sources.first().map(|source| source.contents),
+            Some(Contents::Sources(Locking::Unlocked)),
             "a lockfile on disk belongs to the person running whisker"
         );
     }

--- a/crates/whisker/src/custom_lints/abi_tag.rs
+++ b/crates/whisker/src/custom_lints/abi_tag.rs
@@ -45,7 +45,7 @@ impl AbiTag {
     /// A newline separates the values, and each fingerprint occupies a
     /// fixed width. Two different identities therefore cannot produce one
     /// input to the digest.
-    fn new(identity: &AbiIdentity, target: &str) -> Self {
+    pub(super) fn new(identity: &AbiIdentity, target: &str) -> Self {
         let AbiIdentity {
             abi_version,
             rustc_version,

--- a/crates/whisker/src/custom_lints/cache.rs
+++ b/crates/whisker/src/custom_lints/cache.rs
@@ -17,6 +17,7 @@ use std::path::{Path, PathBuf};
 use anyhow::Context as _;
 use etcetera::base_strategy::{BaseStrategy as _, Xdg};
 
+use super::abi_tag::AbiTag;
 use super::digest::digest;
 use crate::config::GitLintSource;
 
@@ -114,22 +115,55 @@ pub fn checkout_directory(source: &GitLintSource) -> anyhow::Result<PathBuf> {
 
 /// Returns where one pinned lint source sits under `root`
 ///
+/// The commit forms the last segment, so every checkout of one remote
+/// stays together under that remote's directory.
+fn checkout_directory_in(root: &Path, source: &GitLintSource) -> PathBuf {
+    root.join("git")
+        .join(remote_directory(source))
+        .join(source.rev().as_str())
+}
+
+/// Returns the directory whisker unpacks one set of prebuilt lints into
+///
+/// # Errors
+///
+/// Returns an error if no cache location can be determined.
+pub fn prebuilt_directory(source: &GitLintSource, tag: &AbiTag) -> anyhow::Result<PathBuf> {
+    let root = cache_root()?;
+
+    Ok(prebuilt_directory_in(&root, source, tag))
+}
+
+/// Returns where one set of prebuilt lints sits under `root`
+///
+/// One commit of one remote yields a different set of libraries for
+/// every whisker that loads them. Prebuilt libraries therefore sit apart
+/// from checkouts, under a last segment that holds the [`AbiTag`]. That
+/// tag names the whisker the libraries fit, and a whisker with another
+/// tag must not read them.
+fn prebuilt_directory_in(root: &Path, source: &GitLintSource, tag: &AbiTag) -> PathBuf {
+    root.join("prebuilt")
+        .join(remote_directory(source))
+        .join(source.rev().as_str())
+        .join(tag.to_string())
+}
+
+/// Returns the directory that holds everything cached for one remote
+///
 /// The remote contributes a readable name so that the cache can be
 /// browsed, and a digest so that two remotes ending in the same segment
-/// stay apart. The commit is the last segment rather than part of the
-/// name, which keeps every checkout of one remote together.
+/// stay apart. Both layouts under the cache root use this, so a remote is
+/// spelled the same way wherever it appears.
 ///
-/// The digest reads the remote as it prints, credentials removed, so two
-/// people holding different tokens for one repository share a checkout
-/// rather than fetching the same commit twice.
-fn checkout_directory_in(root: &Path, source: &GitLintSource) -> PathBuf {
-    let remote = format!(
+/// The digest reads the remote as it prints, credentials removed. Two
+/// people who hold different tokens for one repository therefore share a
+/// cache entry.
+fn remote_directory(source: &GitLintSource) -> String {
+    format!(
         "{}-{}",
         source.url().slug(),
         digest(&source.url().to_string())
-    );
-
-    root.join("git").join(remote).join(source.rev().as_str())
+    )
 }
 
 /// Returns the directory a checkout is assembled in before it is installed
@@ -158,15 +192,34 @@ fn present(value: Option<OsString>) -> Option<OsString> {
 mod tests {
     use super::*;
     use crate::config::{GitRev, GitUrl};
+    use crate::custom_lints::handshake::AbiIdentity;
 
     const REV: &str = "0123456789abcdef0123456789abcdef01234567";
     const ROOT: &str = "/cache";
+    const RUSTC: &str = "rustc 1.92.0-nightly (0123456 2026-08-11)";
+    const TARGET: &str = "aarch64-apple-darwin";
 
     fn location(override_directory: Option<&str>, base_directory: Option<&str>) -> CacheLocation {
         CacheLocation {
             override_directory: override_directory.map(OsString::from),
             base_directory: base_directory.map(PathBuf::from),
         }
+    }
+
+    /// Returns the tag of a whisker built by `rustc` for `target`
+    ///
+    /// These build real tags, so a change to how whisker spells one
+    /// reaches these paths too.
+    fn tag(rustc: &str, target: &str) -> AbiTag {
+        AbiTag::new(
+            &AbiIdentity {
+                abi_version: 2,
+                rustc_version: rustc.to_owned(),
+                types_fingerprint: 0,
+                language_fingerprint: 0,
+            },
+            target,
+        )
     }
 
     fn source(url: &str) -> GitLintSource {
@@ -246,6 +299,66 @@ mod tests {
         let second = checkout_directory_in(Path::new(ROOT), &source("https://example.com/b/rules"));
 
         assert_ne!(first, second);
+    }
+
+    #[test]
+    fn prebuilt_directory_in_ends_with_the_tag() {
+        let directory = prebuilt_directory_in(
+            Path::new(ROOT),
+            &source("https://example.com/rules"),
+            &tag(RUSTC, TARGET),
+        );
+
+        assert_eq!(
+            directory.file_name().expect("should have a name"),
+            std::ffi::OsStr::new(&tag(RUSTC, TARGET).to_string())
+        );
+    }
+
+    /// Two whiskers must never read each other's libraries
+    #[test]
+    fn prebuilt_directory_in_separates_tags() {
+        let source = source("https://example.com/rules");
+
+        let first = prebuilt_directory_in(Path::new(ROOT), &source, &tag(RUSTC, TARGET));
+        let second = prebuilt_directory_in(
+            Path::new(ROOT),
+            &source,
+            &tag("rustc 1.93.0-nightly (0000000 2026-09-01)", TARGET),
+        );
+
+        assert_ne!(first, second);
+    }
+
+    /// A checkout of a source and the libraries built from it are two
+    /// different things, and one must never be served for the other.
+    #[test]
+    fn prebuilt_directory_in_stays_apart_from_the_checkout() {
+        let source = source("https://example.com/rules");
+
+        let prebuilt = prebuilt_directory_in(Path::new(ROOT), &source, &tag(RUSTC, TARGET));
+        let checkout = checkout_directory_in(Path::new(ROOT), &source);
+
+        assert!(!prebuilt.starts_with(&checkout), "{prebuilt:?}");
+        assert!(!checkout.starts_with(&prebuilt), "{checkout:?}");
+    }
+
+    #[test]
+    fn prebuilt_directory_in_names_the_remote_the_way_a_checkout_does() {
+        let source = source("https://example.com/rules");
+
+        let prebuilt = prebuilt_directory_in(Path::new(ROOT), &source, &tag(RUSTC, TARGET));
+        let checkout = checkout_directory_in(Path::new(ROOT), &source);
+
+        let remote_of = |path: &Path, depth: usize| {
+            path.ancestors()
+                .nth(depth)
+                .and_then(Path::file_name)
+                .expect("should have a remote directory")
+                .to_owned()
+        };
+
+        assert_eq!(remote_of(&prebuilt, 2), remote_of(&checkout, 1));
     }
 
     #[test]

--- a/crates/whisker/src/custom_lints/prebuilt.rs
+++ b/crates/whisker/src/custom_lints/prebuilt.rs
@@ -1,0 +1,206 @@
+//! Lint libraries that someone else already built
+//!
+//! A git lint source is a repository of cargo packages, and whisker turns
+//! it into loadable libraries by compiling it. That costs a toolchain and
+//! several minutes, and it costs them again in every project and on every
+//! build agent that checks out the same pin.
+//!
+//! It is also the one step whisker cannot take on a machine that has no
+//! matching toolchain, which a machine running a released whisker binary
+//! usually has not: the handshake accepts a library only from the rustc
+//! that built whisker itself.
+//!
+//! So whisker looks for libraries that were built once, by whoever
+//! publishes the lints, against the whisker that is asking. The
+//! [`AbiTag`] is how it asks. This module owns what happens with the
+//! answer: where it is kept, and which files in it are libraries.
+//!
+//! Nothing here is trusted for being prebuilt. Every library still goes
+//! through the same handshake as one whisker compiled itself, and a
+//! library that fails it is an error rather than a reason to fall back:
+//! the tag is derived from exactly what the handshake compares, so a
+//! mismatch means the archive was misnamed, and building from source
+//! instead would hide that.
+
+use std::ffi::OsStr;
+use std::path::{Path, PathBuf};
+
+use anyhow::Context as _;
+
+use super::abi_tag::AbiTag;
+use super::cache;
+use crate::config::GitLintSource;
+
+/// Returns the directory holding prebuilt lints for `source`, if any
+///
+/// Whisker keeps what it unpacks, so a run that finds its directory
+/// touches nothing else. An empty directory does not count as a find.
+/// An interrupted unpack leaves one behind, and whisker replaces it.
+///
+/// # Errors
+///
+/// Returns an error if no cache location can be determined, which is the
+/// same condition that stops a git checkout.
+pub fn resolve(source: &GitLintSource, tag: &AbiTag) -> anyhow::Result<Option<PathBuf>> {
+    let directory = cache::prebuilt_directory(source, tag)?;
+
+    match holds_libraries(&directory) {
+        true => Ok(Some(directory)),
+        false => Ok(None),
+    }
+}
+
+/// Returns every dynamic library directly inside `directory`, in order
+///
+/// A publisher ships one library per lint package, so a directory holds
+/// as many as the repository built. Whisker ignores every other file, so
+/// a publisher may add a manifest or a license beside them.
+///
+/// Whisker sorts by file name, so two runs load the same lints in the
+/// same order and report the same diagnostics.
+///
+/// # Errors
+///
+/// Returns an error if the directory cannot be read.
+pub fn libraries(directory: &Path) -> anyhow::Result<Vec<PathBuf>> {
+    let entries = std::fs::read_dir(directory)
+        .with_context(|| format!("failed to read {}", directory.display()))?;
+
+    let mut libraries = Vec::new();
+
+    for entry in entries {
+        let entry =
+            entry.with_context(|| format!("failed to read an entry of {}", directory.display()))?;
+        let path = entry.path();
+
+        if path.extension() != Some(OsStr::new(std::env::consts::DLL_EXTENSION)) {
+            continue;
+        }
+
+        if !path.is_file() {
+            continue;
+        }
+
+        libraries.push(path);
+    }
+
+    libraries.sort();
+
+    Ok(libraries)
+}
+
+/// Returns whether `directory` holds at least one loadable library
+///
+/// A directory whisker cannot read counts as empty. Whisker replaces
+/// such a cache entry, and a run continues.
+fn holds_libraries(directory: &Path) -> bool {
+    libraries(directory).is_ok_and(|libraries| !libraries.is_empty())
+}
+
+#[cfg(test)]
+mod tests {
+    use std::fs::File;
+
+    use tempfile::TempDir;
+
+    use super::*;
+
+    /// Writes `names` as empty files in a new directory
+    fn directory_holding(names: &[&str]) -> TempDir {
+        let directory = tempfile::tempdir().expect("temporary directory should be created");
+
+        for name in names {
+            File::create(directory.path().join(name)).expect("the file should be created");
+        }
+
+        directory
+    }
+
+    /// Returns a file name that whisker would load on this platform
+    fn library(stem: &str) -> String {
+        format!(
+            "{}{stem}.{}",
+            std::env::consts::DLL_PREFIX,
+            std::env::consts::DLL_EXTENSION
+        )
+    }
+
+    #[test]
+    fn holds_libraries_with_a_library_is_true() {
+        let directory = directory_holding(&[&library("one")]);
+
+        assert!(holds_libraries(directory.path()));
+    }
+
+    #[test]
+    fn holds_libraries_with_nothing_to_load_is_false() {
+        let directory = directory_holding(&["README.md"]);
+
+        assert!(!holds_libraries(directory.path()));
+    }
+
+    /// An unpack that was interrupted leaves a directory behind, and the
+    /// next run has to be able to replace it rather than fail on it.
+    #[test]
+    fn holds_libraries_of_a_missing_directory_is_false() {
+        let directory = directory_holding(&[]);
+        let missing = directory.path().join("absent");
+
+        assert!(!holds_libraries(&missing));
+    }
+
+    #[test]
+    fn libraries_are_ordered_by_name() {
+        let directory = directory_holding(&[&library("b"), &library("a"), &library("c")]);
+
+        let libraries = libraries(directory.path()).expect("the directory should be read");
+
+        let names: Vec<_> = libraries
+            .iter()
+            .filter_map(|path| path.file_name())
+            .collect();
+        let mut sorted = names.clone();
+        sorted.sort();
+
+        assert_eq!(names, sorted);
+    }
+
+    #[test]
+    fn libraries_ignores_a_directory_that_looks_like_one() {
+        let directory = directory_holding(&[&library("real")]);
+        std::fs::create_dir(directory.path().join(library("fake")))
+            .expect("the directory should be created");
+
+        let libraries = libraries(directory.path()).expect("the directory should be read");
+
+        assert_eq!(libraries.len(), 1, "{libraries:?}");
+    }
+
+    #[test]
+    fn libraries_ignores_everything_that_is_not_a_library() {
+        let directory = directory_holding(&[&library("one"), "README.md", "notes.txt", "plain"]);
+
+        let libraries = libraries(directory.path()).expect("the directory should be read");
+
+        assert_eq!(libraries.len(), 1, "{libraries:?}");
+    }
+
+    #[test]
+    fn libraries_of_an_empty_directory_is_empty() {
+        let directory = directory_holding(&[]);
+
+        let libraries = libraries(directory.path()).expect("the directory should be read");
+
+        assert!(libraries.is_empty(), "{libraries:?}");
+    }
+
+    #[test]
+    fn libraries_of_a_missing_directory_returns_error() {
+        let directory = directory_holding(&[]);
+        let missing = directory.path().join("absent");
+
+        let error = libraries(&missing).expect_err("should fail");
+
+        assert!(format!("{error:#}").contains("absent"), "{error:#}");
+    }
+}

--- a/crates/whisker/tests/prebuilt_lints.rs
+++ b/crates/whisker/tests/prebuilt_lints.rs
@@ -1,0 +1,352 @@
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+use assert_cmd::prelude::*;
+use predicates::prelude::*;
+use tempfile::TempDir;
+
+#[path = "support/fixture_repository.rs"]
+mod fixture_repository;
+#[path = "support/mismatched_plugin.rs"]
+mod mismatched_plugin;
+
+use fixture_repository::{FixtureRepository, Standalone, write_lint_package, write_lockfile};
+use mismatched_plugin::write_mismatched_lint_package;
+
+/// Source that trips the fixture lint and nothing whisker ships
+const TODO_SOURCE: &str = "pub fn later() {\n    todo!()\n}\n";
+
+/// A manifest for a standalone package with no dependencies
+const MANIFEST: &str = "[package]\nname = \"target\"\nversion = \"0.1.0\"\nedition = \"2024\"\n";
+
+/// The rule the fixture lint reports under
+const RULE: &str = "fixture.no-todo";
+
+/// Creates a minimal Cargo package whose `src/lib.rs` holds `source`
+fn package(source: &str) -> TempDir {
+    let directory = tempfile::tempdir().expect("temporary directory should be created");
+
+    std::fs::write(directory.path().join("Cargo.toml"), MANIFEST)
+        .expect("manifest should be written");
+    std::fs::create_dir(directory.path().join("src")).expect("src should be created");
+    std::fs::write(directory.path().join("src").join("lib.rs"), source)
+        .expect("source should be written");
+
+    directory
+}
+
+/// Points the package's whisker configuration at one git lint source
+fn configure_git_lint(package: &Path, url: &str, rev: &str) {
+    let url = toml::Value::from(url);
+    let rev = toml::Value::from(rev);
+
+    let config = package.join(".config");
+    std::fs::create_dir_all(&config).expect("the config directory should be created");
+    std::fs::write(
+        config.join("whisker.toml"),
+        format!("[[lints]]\ngit = {url}\nrev = {rev}\n"),
+    )
+    .expect("configuration should be written");
+}
+
+/// Returns a whisker that keeps everything it fetches inside `cache`
+fn whisker(cache: &TempDir) -> Command {
+    let mut command = Command::cargo_bin("whisker").expect("whisker binary should exist");
+    command.env("WHISKER_CACHE_DIR", cache.path());
+    command.env("CARGO_TARGET_DIR", shared_build_directory());
+    command.env("GIT_CONFIG_GLOBAL", "/dev/null");
+    command.env("GIT_CONFIG_SYSTEM", "/dev/null");
+
+    command
+}
+
+/// Returns the build directory every fixture plugin in this file shares
+///
+/// This is the directory `git_lints.rs` uses. Both files compile the same
+/// fixture against the same whisker, so one warm directory serves both.
+fn shared_build_directory() -> PathBuf {
+    let directory = Path::new(env!("CARGO_TARGET_TMPDIR")).join("git_lint_plugins");
+    std::fs::create_dir_all(&directory).expect("the build directory should be created");
+
+    directory
+}
+
+/// Returns the tag this whisker asks publishers of prebuilt lints for
+///
+/// The test reads it from the binary rather than deriving it, so that the
+/// name a publisher would use and the name whisker looks for are the same
+/// string by construction.
+fn abi_tag() -> String {
+    let output = Command::cargo_bin("whisker")
+        .expect("whisker binary should exist")
+        .arg("abi")
+        .output()
+        .expect("whisker abi should run");
+
+    assert!(output.status.success(), "whisker abi failed");
+
+    String::from_utf8(output.stdout)
+        .expect("whisker should write UTF-8")
+        .trim()
+        .to_owned()
+}
+
+/// Returns the file name a cdylib named `stem` builds to on this platform
+fn library_name(stem: &str) -> String {
+    format!(
+        "{}{stem}.{}",
+        std::env::consts::DLL_PREFIX,
+        std::env::consts::DLL_EXTENSION
+    )
+}
+
+/// Creates a repository holding one lint package called `package`
+///
+/// Every test names its package after itself. The fixtures of this file
+/// and of `git_lints.rs` compile into one build directory, so two tests
+/// that built a package of the same name would replace each other's
+/// library while a third read it.
+fn repository_with_one_lint(package: &str, rule: &str) -> FixtureRepository {
+    let package = package.to_owned();
+
+    FixtureRepository::new(move |directory| {
+        write_lint_package(directory, &package, rule, Standalone::Yes);
+        write_lockfile(directory);
+    })
+}
+
+/// Returns the name whisker gave the remote it fetched into `cache`
+///
+/// The seed below puts libraries where whisker looks for them, and that
+/// place comes from the remote. This reads the name back from whisker's
+/// own cache. A change to how whisker spells a remote therefore fails
+/// the test.
+fn fetched_remote(cache: &TempDir) -> PathBuf {
+    let git = cache.path().join("git");
+    let mut remotes: Vec<PathBuf> = std::fs::read_dir(&git)
+        .expect("whisker should have fetched into the cache")
+        .map(|entry| entry.expect("the cache should be readable").path())
+        .collect();
+    remotes.sort();
+
+    assert_eq!(remotes.len(), 1, "expected one remote: {remotes:?}");
+
+    remotes
+        .pop()
+        .expect("the cache should hold one remote")
+        .file_name()
+        .expect("the remote should have a name")
+        .into()
+}
+
+/// Puts `libraries` where whisker looks for prebuilt lints of `rev`
+fn seed_prebuilt(cache: &TempDir, remote: &Path, rev: &str, libraries: &[PathBuf]) -> PathBuf {
+    let destination = cache
+        .path()
+        .join("prebuilt")
+        .join(remote)
+        .join(rev)
+        .join(abi_tag());
+
+    std::fs::create_dir_all(&destination).expect("the prebuilt directory should be created");
+
+    for library in libraries {
+        let name = library.file_name().expect("a library should have a name");
+        std::fs::copy(library, destination.join(name)).expect("the library should be copied");
+    }
+
+    destination
+}
+
+/// Removes every way to reach the lints except the prebuilt directory
+///
+/// After this there is no checkout to load, no remote to fetch it from,
+/// and no source to compile. A run that still reports the lint can only
+/// have read what was seeded.
+fn strand(cache: &TempDir, rules: FixtureRepository) {
+    std::fs::remove_dir_all(cache.path().join("git")).expect("the checkouts should be removable");
+    rules.remove();
+}
+
+/// Pins that whisker loads prebuilt lints and needs nothing else
+///
+/// A source build produces the libraries a publisher would ship, so the
+/// first run makes them. The second run has nothing left to fetch or
+/// compile. The diagnostic can therefore come only from the seeded
+/// libraries.
+#[test]
+fn check_with_prebuilt_lints_loads_them_without_a_source() {
+    let cache = tempfile::tempdir().expect("temporary directory should be created");
+    let rules = repository_with_one_lint("loaded_lint", RULE);
+    let target = package(TODO_SOURCE);
+    configure_git_lint(target.path(), &rules.url(), rules.rev());
+
+    whisker(&cache)
+        .arg("check")
+        .arg(target.path())
+        .assert()
+        .success();
+
+    let remote = fetched_remote(&cache);
+    let built = shared_build_directory()
+        .join("release")
+        .join(library_name("loaded_lint"));
+    seed_prebuilt(&cache, &remote, rules.rev(), &[built]);
+    strand(&cache, rules);
+
+    whisker(&cache)
+        .arg("check")
+        .arg(target.path())
+        .assert()
+        .success()
+        .stderr(predicate::str::contains(format!("warning[{RULE}]")))
+        .stderr(predicate::str::contains("finish this before it ships"));
+}
+
+/// Pins that every library in a prebuilt directory is loaded
+///
+/// A repository of rules is a workspace, and every member builds its own
+/// library. One configured entry therefore ships as many libraries as
+/// the repository has rules. Whisker must load all of them.
+#[test]
+fn check_with_several_prebuilt_libraries_loads_every_one() {
+    let cache = tempfile::tempdir().expect("temporary directory should be created");
+    let rules = FixtureRepository::new(|directory| {
+        std::fs::write(
+            directory.join("Cargo.toml"),
+            "[workspace]\nmembers = [\"lints/*\"]\nresolver = \"3\"\n",
+        )
+        .expect("the workspace manifest should be written");
+        write_lint_package(
+            &directory.join("lints").join("first"),
+            "workspace_first",
+            "fixture.first",
+            Standalone::No,
+        );
+        write_lint_package(
+            &directory.join("lints").join("second"),
+            "workspace_second",
+            "fixture.second",
+            Standalone::No,
+        );
+        write_lockfile(directory);
+    });
+    let target = package(TODO_SOURCE);
+    configure_git_lint(target.path(), &rules.url(), rules.rev());
+
+    whisker(&cache)
+        .arg("check")
+        .arg(target.path())
+        .assert()
+        .success();
+
+    let remote = fetched_remote(&cache);
+    let release = shared_build_directory().join("release");
+    let built = vec![
+        release.join(library_name("workspace_first")),
+        release.join(library_name("workspace_second")),
+    ];
+    seed_prebuilt(&cache, &remote, rules.rev(), &built);
+    strand(&cache, rules);
+
+    whisker(&cache)
+        .arg("check")
+        .arg(target.path())
+        .assert()
+        .success()
+        .stderr(predicate::str::contains("warning[fixture.first]"))
+        .stderr(predicate::str::contains("warning[fixture.second]"));
+}
+
+/// Pins that a prebuilt directory holding nothing loadable is not an answer
+///
+/// An unpack that was interrupted leaves an empty directory behind.
+/// Whisker has to treat that as an absent one and fall back, rather than
+/// fail a run over a cache entry it can replace.
+#[test]
+fn check_with_an_empty_prebuilt_directory_builds_from_source() {
+    let cache = tempfile::tempdir().expect("temporary directory should be created");
+    let rules = repository_with_one_lint("empty_lint", RULE);
+    let target = package(TODO_SOURCE);
+    configure_git_lint(target.path(), &rules.url(), rules.rev());
+
+    whisker(&cache)
+        .arg("check")
+        .arg(target.path())
+        .assert()
+        .success();
+
+    let remote = fetched_remote(&cache);
+    seed_prebuilt(&cache, &remote, rules.rev(), &[]);
+
+    whisker(&cache)
+        .arg("check")
+        .arg(target.path())
+        .assert()
+        .success()
+        .stderr(predicate::str::contains(format!("warning[{RULE}]")));
+}
+
+/// Pins that the handshake still runs on a library whisker did not build
+///
+/// A library that fails the handshake carries a tag that misdescribes
+/// it. A compile of the source would hide that from everyone who trusts
+/// the tag. The run fails instead, and names the directory to delete.
+#[test]
+fn check_with_a_prebuilt_that_fails_the_handshake_fails() {
+    let cache = tempfile::tempdir().expect("temporary directory should be created");
+    let rules = repository_with_one_lint("handshake_lint", RULE);
+    let target = package(TODO_SOURCE);
+    configure_git_lint(target.path(), &rules.url(), rules.rev());
+
+    whisker(&cache)
+        .arg("check")
+        .arg(target.path())
+        .assert()
+        .success();
+
+    let remote = fetched_remote(&cache);
+    let mismatched = tempfile::tempdir().expect("temporary directory should be created");
+    write_mismatched_lint_package(mismatched.path(), "mismatched_lint");
+    let built = build_cdylib(mismatched.path(), "mismatched_lint");
+    let destination = seed_prebuilt(&cache, &remote, rules.rev(), &[built]);
+
+    whisker(&cache)
+        .arg("check")
+        .arg(target.path())
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains("protocol version"))
+        .stderr(predicate::str::contains(
+            destination.to_string_lossy().into_owned(),
+        ));
+}
+
+/// Builds the package at `directory` and returns the library it produced
+///
+/// # Panics
+///
+/// Panics if cargo cannot be run or the build fails.
+fn build_cdylib(directory: &Path, name: &str) -> PathBuf {
+    let cargo = std::env::var_os("CARGO").unwrap_or_else(|| "cargo".into());
+    let target = shared_build_directory();
+
+    let output = Command::new(cargo)
+        .args(["build", "--release"])
+        .current_dir(directory)
+        .env("CARGO_TARGET_DIR", &target)
+        .output()
+        .expect("cargo should run");
+
+    assert!(
+        output.status.success(),
+        "cargo build failed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let library = target.join("release").join(library_name(name));
+
+    assert!(library.is_file(), "expected a library at {library:?}");
+
+    library
+}

--- a/crates/whisker/tests/support/mismatched_plugin.rs
+++ b/crates/whisker/tests/support/mismatched_plugin.rs
@@ -1,0 +1,51 @@
+use std::path::Path;
+
+use crate::fixture_repository::whisker_crates;
+
+/// Writes a package whose declaration claims a protocol whisker refuses
+///
+/// The library it builds is a real one: whisker can open it and find the
+/// declaration it looks for. Only the protocol version is wrong, which is
+/// the first thing the handshake compares, so the refusal comes from the
+/// handshake rather than from the loader failing earlier.
+///
+/// A test uses this to prove that a library whisker did not compile
+/// itself is held to the same standard as one it did.
+///
+/// # Panics
+///
+/// Panics if the package cannot be written.
+pub fn write_mismatched_lint_package(directory: &Path, name: &str) {
+    let crates = whisker_crates();
+    let crates = crates.to_str().expect("the path should be UTF-8");
+
+    std::fs::create_dir_all(directory.join("src")).expect("the package should be created");
+    std::fs::write(
+        directory.join("Cargo.toml"),
+        format!(
+            "[workspace]\n\n[package]\nname = \"{name}\"\nversion = \"0.1.0\"\nedition = \
+             \"2024\"\npublish = false\n\n[lib]\ncrate-type = [\"cdylib\"]\n\n[dependencies]\n\
+             whisker-types = {{ path = \"{crates}/whisker-types\" }}\n"
+        ),
+    )
+    .expect("the manifest should be written");
+    std::fs::write(
+        directory.join("src").join("lib.rs"),
+        r#"use whisker_types::plugin::{LintRegistrar, PluginDeclaration};
+
+/// Registers no lint, because the handshake refuses this library first
+fn register(_registrar: &mut dyn LintRegistrar) {}
+
+#[unsafe(no_mangle)]
+#[allow(non_upper_case_globals)]
+pub static whisker_plugin_declaration: PluginDeclaration = PluginDeclaration {
+    abi_version: whisker_types::plugin::ABI_VERSION + 1,
+    rustc_version: whisker_types::plugin::RUSTC_VERSION.as_ptr(),
+    types_fingerprint: whisker_types::plugin::TYPES_FINGERPRINT,
+    language_fingerprint: 0,
+    register,
+};
+"#,
+    )
+    .expect("the source should be written");
+}


### PR DESCRIPTION
Whisker turns a git lint source into loadable libraries with a compile step. That step costs a toolchain and several minutes. It costs them again in every project and on every build agent that pins the same commit. It is also the one step that a released whisker binary usually cannot take. The handshake accepts a library only from the rustc that built whisker, and the user does not have that toolchain.

This change teaches whisker to load libraries that somebody else builds. Whisker looks in its cache for a directory that belongs to this commit and to its own tag, and it loads what it finds. Nothing puts a directory there yet, and the next pull request in this stack does that. This pull request adds the half that decides whether whisker may use a prebuilt library at all.

Whisker does not trust a library because it arrives prebuilt. Each library completes the same handshake as one that whisker compiles itself. A failure fails the run, and whisker does not fall back to a source build. The tag covers exactly what the handshake compares, so a library that fails the handshake carries a tag that does not describe it. A silent source build hides that from everyone else who trusts the tag. The error names the directory, which is all a reader needs in order to clear it.

An empty directory is a different case. An interrupted unpack leaves one behind. Whisker reads it as an absent directory and builds from source. A failure there would stop a run over a cache entry that whisker can simply replace.


---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>