### PR TITLE
Download prebuilt lints from a release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -89,6 +89,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d3fb67a6e08acf24fdeccbac2cb6ac4305825bd1f117462e0e6f2f193345ad56"
 
 [[package]]
+name = "ascii"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d92bec98840b8f03a5ff5413de5293bfcd8bf96467cf5452609f939ec6f5de16"
+
+[[package]]
 name = "assert_cmd"
 version = "2.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -189,6 +195,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
 dependencies = [
  "generic-array",
+]
+
+[[package]]
+name = "block-buffer"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2f6c7dbe95a6ed67ad9f18e57daf93a2f034c524b99fd2b76d18fdfeb6660aa"
+dependencies = [
+ "hybrid-array",
 ]
 
 [[package]]
@@ -328,6 +343,12 @@ dependencies = [
  "cpufeatures 0.3.0",
  "rand_core 0.10.1",
 ]
+
+[[package]]
+name = "chunked_transfer"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e4de3bc4ea267985becf712dc6d9eed8b04c953b3fcfb339ebc87acd9804901"
 
 [[package]]
 name = "clap"
@@ -498,6 +519,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "const-oid"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6ef517f0926dd24a1582492c791b6a4818a4d94e789a334894aa15b0d12f55c"
+
+[[package]]
 name = "content_inspector"
 version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -612,6 +639,15 @@ checksum = "78c8292055d1c1df0cce5d180393dc8cce0abec0a7102adb6c7b1eef6016d60a"
 dependencies = [
  "generic-array",
  "typenum",
+]
+
+[[package]]
+name = "crypto-common"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce6e4c961d6cd6c9a86db418387425e8bdeaf05b3c8bc1411e6dca4c252f1453"
+dependencies = [
+ "hybrid-array",
 ]
 
 [[package]]
@@ -764,8 +800,19 @@ version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
- "block-buffer",
- "crypto-common",
+ "block-buffer 0.10.4",
+ "crypto-common 0.1.7",
+]
+
+[[package]]
+name = "digest"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1dd6dbb5841937940781866fa1281a1ff7bd3bf827091440879f9994983d5c2"
+dependencies = [
+ "block-buffer 0.12.1",
+ "const-oid",
+ "crypto-common 0.2.2",
 ]
 
 [[package]]
@@ -928,6 +975,15 @@ name = "fixedbitset"
 version = "0.5.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d674e81391d1e1ab681a28d99df07927c6d4aa5b027d7da16ba32d1d21ecd99"
+
+[[package]]
+name = "flate2"
+version = "1.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e634e2e0ebac1ee034020da1ca582e17ffe4e0f5e985823721e168928136dcb"
+dependencies = [
+ "zlib-rs",
+]
 
 [[package]]
 name = "float-cmp"
@@ -2030,6 +2086,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
+name = "hex"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
+
+[[package]]
 name = "http"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2069,6 +2131,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6dbf3de79e51f3d586ab4cb9d5c3e2c14aa28ed23d180cf89b4df0454a69cc87"
 
 [[package]]
+name = "httpdate"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
+
+[[package]]
 name = "humantime"
 version = "2.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2082,6 +2150,15 @@ checksum = "57a3db5ea5923d99402c94e9feb261dc5ee9b4efa158b0315f788cf549cc200c"
 dependencies = [
  "humantime",
  "serde",
+]
+
+[[package]]
+name = "hybrid-array"
+version = "0.4.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "707114b52a152fa7bdb290cd7cd5912d9467273b6d74e21b8d81aca1f8533f6b"
+dependencies = [
+ "typenum",
 ]
 
 [[package]]
@@ -4244,7 +4321,7 @@ checksum = "a978451301f4db1d02937a4ab3ccce137717b81826e79b7d49ffe3244a13c3b8"
 dependencies = [
  "cfg-if",
  "cpufeatures 0.2.17",
- "digest",
+ "digest 0.10.7",
 ]
 
 [[package]]
@@ -4253,8 +4330,19 @@ version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "89f599ac0c323ebb1c6082821a54962b839832b03984598375bff3975b804423"
 dependencies = [
- "digest",
+ "digest 0.10.7",
  "sha1",
+]
+
+[[package]]
+name = "sha2"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "446ba717509524cb3f22f17ecc096f10f4822d76ab5c0b9822c5f9c284e825f4"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.3.0",
+ "digest 0.11.3",
 ]
 
 [[package]]
@@ -4443,6 +4531,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "tar"
+version = "0.4.46"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f6221d9a6003c78398e3b239969f352578258df48c8eb051caadae0015bc840"
+dependencies = [
+ "filetime",
+ "libc",
+]
+
+[[package]]
 name = "tempfile"
 version = "3.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4541,6 +4639,18 @@ checksum = "7e689342a48d2ea927c87ea50cabf8594854bf940e9310208848d680d668ed85"
 dependencies = [
  "num-conv",
  "time-core",
+]
+
+[[package]]
+name = "tiny_http"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "389915df6413a2e74fb181895f933386023c71110878cd0825588928e64cdc82"
+dependencies = [
+ "ascii",
+ "chunked_transfer",
+ "httpdate",
+ "log",
 ]
 
 [[package]]
@@ -5143,14 +5253,20 @@ dependencies = [
  "assert_cmd",
  "clawless",
  "etcetera",
+ "flate2",
  "gix",
+ "hex",
  "ignore",
  "kawauso-project",
  "libloading",
  "predicates",
+ "reqwest",
  "serde",
  "serde_json",
+ "sha2",
+ "tar",
  "tempfile",
+ "tiny_http",
  "toml",
  "trycmd",
  "whisker-core",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -55,6 +55,13 @@ gix = { version = "0.87", default-features = false, features = [
   "parallel",
   "sha1",
 ] }
+# Decompresses an archive of prebuilt lints. Its `zlib-rs` backend is the
+# one gitoxide already builds, so naming it saves a second copy of the
+# same algorithm.
+flate2 = { version = "1", default-features = false, features = ["zlib-rs"] }
+# Reads and writes the SHA-256 digest that travels beside an archive of
+# prebuilt lints.
+hex = "0.4"
 # The walker behind ripgrep. Whisker uses it instead of a plain directory walk
 # so that `.gitignore` and friends are honored: a linter that reports on
 # generated output such as `target/` is worse than no linter at all.
@@ -79,14 +86,30 @@ ra_ap_syntax = "0.0.350"
 ra_ap_vfs = "0.0.350"
 proc-macro2 = "1"
 quote = "1"
+# Asks a GitHub release for prebuilt lints and downloads them. Reqwest
+# rather than a smaller client, because gitoxide already fetches over it,
+# so both share one HTTP stack and one set of trusted roots.
+reqwest = { version = "0.13", default-features = false, features = [
+  "blocking",
+  "rustls",
+] }
 # Read by build scripts to bake the compiler's identity into the plugin
 # handshake: whisker refuses to load a custom lint plugin built by a
 # different rustc, because Rust's ABI is only coherent within one compiler.
 rustc_version = "0.4"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
+# Checks an archive of prebuilt lints against the digest its publisher
+# put beside it, which catches a truncated or corrupted download.
+sha2 = "0.11"
 syn = { version = "3", features = ["full", "extra-traits"] }
+# Unpacks an archive of prebuilt lints. The `xattr` feature is off,
+# because a lint library carries no extended attributes.
+tar = { version = "0.4", default-features = false }
 tempfile = "3"
+# Serves a release API to the tests that cover the download, so those
+# tests exercise the HTTP client whisker ships rather than a stand-in.
+tiny_http = "0.12"
 toml = "1"
 tree-sitter = "0.26"
 tree-sitter-rust = "0.24"

--- a/crates/whisker/Cargo.toml
+++ b/crates/whisker/Cargo.toml
@@ -17,12 +17,17 @@ workspace = true
 anyhow = "1"
 clawless = "0.6.0"
 etcetera.workspace = true
+flate2.workspace = true
 gix.workspace = true
+hex.workspace = true
 ignore.workspace = true
 kawauso-project.workspace = true
 libloading.workspace = true
+reqwest.workspace = true
 serde.workspace = true
 serde_json.workspace = true
+sha2.workspace = true
+tar.workspace = true
 whisker-core = { path = "../whisker-core" }
 whisker-reporting = { path = "../whisker-reporting" }
 whisker-rust = { path = "../whisker-rust" }
@@ -32,5 +37,6 @@ whisker-types = { path = "../whisker-types" }
 assert_cmd = "2"
 predicates = "3"
 tempfile.workspace = true
+tiny_http.workspace = true
 toml.workspace = true
 trycmd = "1.0"

--- a/crates/whisker/src/custom_lints.rs
+++ b/crates/whisker/src/custom_lints.rs
@@ -9,7 +9,7 @@ use whisker_types::LintPass;
 use whisker_types::plugin::{LintPassFactory, LintRegistrar, PluginDeclaration};
 
 use self::handshake::AbiIdentity;
-use crate::config::{LintSource, WhiskerConfig};
+use crate::config::{GitLintSource, LintSource, WhiskerConfig};
 
 mod abi_tag;
 mod artifact;
@@ -145,13 +145,7 @@ fn configured_sources(config: &WhiskerConfig, tag: &AbiTag) -> anyhow::Result<Ve
                 path.resolve(config.root()),
                 Contents::Sources(Locking::Unlocked),
             ),
-            LintSource::Git(git) => match prebuilt::resolve(git, tag)? {
-                Some(directory) => (directory, Contents::Libraries),
-                None => (
-                    git_source::checkout(git)?,
-                    Contents::Sources(Locking::Locked),
-                ),
-            },
+            LintSource::Git(git) => resolve_git(git, tag)?,
         };
 
         anyhow::ensure!(
@@ -189,6 +183,42 @@ fn configured_sources(config: &WhiskerConfig, tag: &AbiTag) -> anyhow::Result<Ve
     }
 
     Ok(sources)
+}
+
+/// Resolves a git entry, preferring whatever the machine already holds
+///
+/// The order is by what each answer costs. Prebuilt libraries whisker
+/// already unpacked are the cheapest and win outright. A checkout that is
+/// already there comes next: whisker has to compile it, but cargo has
+/// compiled it before, so asking a release API first would put a network
+/// request in front of a run that needs none, and every check on a train
+/// would stop working. Only a machine holding neither asks anyone.
+///
+/// A project with a warm checkout therefore keeps compiling it, even
+/// after its rules start to publish archives. A person moves the pin or
+/// clears the cache to pick those up.
+///
+/// # Errors
+///
+/// Returns an error if no cache location can be determined, or if the
+/// source has to be fetched and cannot be.
+fn resolve_git(source: &GitLintSource, tag: &AbiTag) -> anyhow::Result<(PathBuf, Contents)> {
+    if let Some(directory) = prebuilt::cached(source, tag)? {
+        return Ok((directory, Contents::Libraries));
+    }
+
+    if let Some(directory) = git_source::cached(source)? {
+        return Ok((directory, Contents::Sources(Locking::Locked)));
+    }
+
+    if let Some(directory) = prebuilt::fetch(source, tag)? {
+        return Ok((directory, Contents::Libraries));
+    }
+
+    Ok((
+        git_source::checkout(source)?,
+        Contents::Sources(Locking::Locked),
+    ))
 }
 
 /// Builds the packages at `directory` and loads the lints they export

--- a/crates/whisker/src/custom_lints/git_source.rs
+++ b/crates/whisker/src/custom_lints/git_source.rs
@@ -6,6 +6,24 @@ use anyhow::Context as _;
 use super::cache;
 use crate::config::{GitLintSource, GitRev, GitUrl};
 
+/// Returns the checkout of `source` the machine already holds, if any
+///
+/// This is [`checkout`] without the fetch. A caller asks it whether a
+/// source sits on the machine, before it decides to reach the network
+/// for anything else.
+///
+/// # Errors
+///
+/// Returns an error if no cache location can be determined.
+pub fn cached(source: &GitLintSource) -> anyhow::Result<Option<PathBuf>> {
+    let destination = cache::checkout_directory(source)?;
+
+    match holds(&destination, source.rev()) {
+        true => Ok(Some(destination)),
+        false => Ok(None),
+    }
+}
+
 /// Returns a checkout of `source`, fetching it if the cache lacks one
 ///
 /// A checkout is permanent once it exists, because a [`GitRev`] names one

--- a/crates/whisker/src/custom_lints/prebuilt.rs
+++ b/crates/whisker/src/custom_lints/prebuilt.rs
@@ -12,8 +12,10 @@
 //!
 //! So whisker looks for libraries that were built once, by whoever
 //! publishes the lints, against the whisker that is asking. The
-//! [`AbiTag`] is how it asks. This module owns what happens with the
-//! answer: where it is kept, and which files in it are libraries.
+//! [`AbiTag`] is how it asks. This module owns the asking and everything
+//! that follows it: which remote to ask, what to call the archive it
+//! wants, how to tell that the archive arrived whole, where to keep what
+//! it unpacks, and which of those files are libraries.
 //!
 //! Nothing here is trusted for being prebuilt. Every library still goes
 //! through the same handshake as one whisker compiled itself, and a
@@ -27,21 +29,33 @@ use std::path::{Path, PathBuf};
 
 use anyhow::Context as _;
 
+use self::archive::Sha256Digest;
+use self::asset_name::AssetName;
+use self::github_release::{GitHubApi, PrebuiltAsset};
+use self::github_repository::GitHubRepository;
 use super::abi_tag::AbiTag;
 use super::cache;
 use crate::config::GitLintSource;
 
-/// Returns the directory holding prebuilt lints for `source`, if any
+mod archive;
+mod asset_name;
+mod github_release;
+mod github_repository;
+
+/// What the downloaded archive is called while it is being checked
+const DOWNLOAD: &str = "archive.tar.gz";
+
+/// Returns the prebuilt lints for `source` that the machine already holds
 ///
 /// Whisker keeps what it unpacks, so a run that finds its directory
-/// touches nothing else. An empty directory does not count as a find.
-/// An interrupted unpack leaves one behind, and whisker replaces it.
+/// touches no network. An empty directory does not count as a find. An
+/// interrupted unpack leaves one behind, and whisker replaces it.
 ///
 /// # Errors
 ///
 /// Returns an error if no cache location can be determined, which is the
-/// same condition that stops a git checkout.
-pub fn resolve(source: &GitLintSource, tag: &AbiTag) -> anyhow::Result<Option<PathBuf>> {
+/// condition that also stops a git checkout.
+pub fn cached(source: &GitLintSource, tag: &AbiTag) -> anyhow::Result<Option<PathBuf>> {
     let directory = cache::prebuilt_directory(source, tag)?;
 
     match holds_libraries(&directory) {
@@ -50,14 +64,203 @@ pub fn resolve(source: &GitLintSource, tag: &AbiTag) -> anyhow::Result<Option<Pa
     }
 }
 
+/// Asks a release for prebuilt lints, and keeps them if it has any
+///
+/// This is the one path here that reaches the network, so a caller asks
+/// it only when the machine holds nothing that would serve instead.
+///
+/// Everything it does is best effort. A remote that publishes no
+/// releases, a release with nothing named for this whisker, an API it
+/// cannot reach, an archive that fails its digest: each one answers with
+/// nothing, and the caller then compiles the source. That fallback is
+/// what whisker did before any of this existed, and it is never wrong.
+///
+/// The cases differ in whether the reader hears about them. Whisker stays
+/// quiet about a failure it cannot tell apart from a repository that
+/// nobody built for.
+///
+/// # Errors
+///
+/// Returns an error if no cache location can be determined.
+pub fn fetch(source: &GitLintSource, tag: &AbiTag) -> anyhow::Result<Option<PathBuf>> {
+    let directory = cache::prebuilt_directory(source, tag)?;
+    let host = github_release::configured_repository_host();
+
+    let Some(repository) = GitHubRepository::from_url(source.url(), host.as_deref()) else {
+        return Ok(None);
+    };
+
+    let name = AssetName::new(source.rev(), tag);
+
+    match download(&repository, &name, &directory) {
+        Ok(Installed::Yes) => Ok(Some(directory)),
+        Ok(Installed::Absent) => Ok(None),
+        Err(error) => {
+            warn(source, &error);
+            Ok(None)
+        }
+    }
+}
+
+/// Runs the whole exchange with the release API on a thread of its own
+///
+/// The HTTP client owns an asynchronous runtime, and a program panics
+/// when it drops one runtime inside another. Whisker's check command is
+/// asynchronous, so this thread builds the client, uses it, and drops it.
+///
+/// A panic on that thread becomes an ordinary failure. It would otherwise
+/// vanish, and whisker would compile from source with nothing said.
+fn download(
+    repository: &GitHubRepository,
+    name: &AssetName,
+    destination: &Path,
+) -> anyhow::Result<Installed> {
+    std::thread::scope(|scope| {
+        let thread = scope.spawn(|| {
+            let api = GitHubApi::from_environment()?;
+
+            install(&api, repository, name, destination)
+        });
+
+        match thread.join() {
+            Ok(outcome) => outcome,
+            Err(_) => Err(anyhow::anyhow!("the download stopped unexpectedly")),
+        }
+    })
+}
+
+/// Whether a release had prebuilt lints to install
+#[derive(Copy, Clone, Eq, PartialEq, Debug)]
+enum Installed {
+    Yes,
+    Absent,
+}
+
+/// Tells the reader that whisker compiles what it hoped to download
+///
+/// Whisker says this once per source, and says nothing else about the
+/// prebuilt path. Nothing is broken when it appears. The check goes on
+/// and reports the same diagnostics, more slowly.
+fn warn(source: &GitLintSource, error: &anyhow::Error) {
+    eprintln!(
+        "warning: whisker cannot use the prebuilt lints for {source}: {error:#}; it builds them \
+         from source instead"
+    );
+}
+
+/// Downloads, checks, and unpacks the archive a release publishes
+///
+/// Whisker assembles the archive beside the directory it will become,
+/// then moves it into place whole. A run that stops halfway therefore
+/// leaves nothing a later run could mistake for a finished unpack.
+///
+/// Two runs may install the same archive at once. The move decides which
+/// one wins, and the loser reads what the winner installed, because both
+/// downloaded the same bytes.
+fn install(
+    api: &GitHubApi,
+    repository: &GitHubRepository,
+    name: &AssetName,
+    destination: &Path,
+) -> anyhow::Result<Installed> {
+    let Some(PrebuiltAsset { archive, sidecar }) = api.find_asset(repository, name)? else {
+        return Ok(Installed::Absent);
+    };
+
+    if destination.exists() {
+        std::fs::remove_dir_all(destination).with_context(|| {
+            format!(
+                "failed to discard the damaged directory at {}",
+                destination.display()
+            )
+        })?;
+    }
+
+    let staging = cache::staging_directory(destination);
+    if staging.exists() {
+        std::fs::remove_dir_all(&staging).with_context(|| {
+            format!(
+                "failed to discard the abandoned download at {}",
+                staging.display()
+            )
+        })?;
+    }
+
+    let parent = destination
+        .parent()
+        .context("the prebuilt directory has no parent")?;
+    std::fs::create_dir_all(parent)
+        .with_context(|| format!("failed to create {}", parent.display()))?;
+    std::fs::create_dir_all(&staging)
+        .with_context(|| format!("failed to create {}", staging.display()))?;
+
+    let outcome = unpack(api, &archive, &sidecar, &staging);
+
+    if outcome.is_err() {
+        let _ = std::fs::remove_dir_all(&staging);
+    }
+
+    outcome.with_context(|| format!("failed to unpack {name}"))?;
+
+    match std::fs::rename(&staging, destination) {
+        Ok(()) => Ok(Installed::Yes),
+        Err(error) => {
+            let _ = std::fs::remove_dir_all(&staging);
+
+            anyhow::ensure!(
+                holds_libraries(destination),
+                "failed to install the prebuilt lints at {}: {error}",
+                destination.display()
+            );
+
+            Ok(Installed::Yes)
+        }
+    }
+}
+
+/// Downloads the archive into `staging` and unpacks what it holds
+///
+/// This compares the digest before it unpacks anything, so a truncated or
+/// corrupted download never becomes files. It then removes the archive,
+/// because whisker installs the libraries and nothing else.
+fn unpack(
+    api: &GitHubApi,
+    archive: &github_release::ReleaseAsset,
+    sidecar: &github_release::ReleaseAsset,
+    staging: &Path,
+) -> anyhow::Result<()> {
+    let downloaded = staging.join(DOWNLOAD);
+
+    let published = api.download_text(sidecar)?;
+    let published = Sha256Digest::from_sidecar(&published)?;
+    let arrived = api.download(archive, &downloaded)?;
+
+    anyhow::ensure!(
+        arrived == published,
+        "the archive has digest {arrived}, but the sidecar beside it publishes {published}"
+    );
+
+    archive::extract(&downloaded, staging)?;
+
+    std::fs::remove_file(&downloaded)
+        .with_context(|| format!("failed to remove {}", downloaded.display()))?;
+
+    anyhow::ensure!(
+        holds_libraries(staging),
+        "the archive holds no dynamic library at its root"
+    );
+
+    Ok(())
+}
+
 /// Returns every dynamic library directly inside `directory`, in order
 ///
 /// A publisher ships one library per lint package, so a directory holds
 /// as many as the repository built. Whisker ignores every other file, so
 /// a publisher may add a manifest or a license beside them.
 ///
-/// Whisker sorts by file name, so two runs load the same lints in the
-/// same order and report the same diagnostics.
+/// The order is the file names', so that two runs load the same lints in
+/// the same order and report their diagnostics the same way.
 ///
 /// # Errors
 ///

--- a/crates/whisker/src/custom_lints/prebuilt/archive.rs
+++ b/crates/whisker/src/custom_lints/prebuilt/archive.rs
@@ -1,0 +1,444 @@
+use std::fs::File;
+use std::io::{BufReader, Read};
+use std::path::{Component, Path};
+
+use anyhow::Context as _;
+use flate2::read::GzDecoder;
+use sha2::{Digest as _, Sha256};
+
+/// How many bytes of a file are hashed at a time
+const CHUNK: usize = 64 * 1024;
+
+/// The SHA-256 digest of a file whisker downloaded
+///
+/// A publisher writes the digest of each archive beside it, and whisker
+/// compares the two before it unpacks anything. That catches a truncated
+/// download, a corrupted one, and a stale one.
+///
+/// The pair proves that the bytes arrived intact. It does not establish
+/// trust, because the same publisher writes both. Every library in the
+/// archive still passes the plugin handshake.
+#[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug)]
+pub struct Sha256Digest([u8; 32]);
+
+impl Sha256Digest {
+    /// Returns the digest of the file at `path`
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the file cannot be read.
+    pub fn of_file(path: &Path) -> anyhow::Result<Self> {
+        let file =
+            File::open(path).with_context(|| format!("failed to open {}", path.display()))?;
+        let mut reader = BufReader::new(file);
+        let mut hasher = Sha256::new();
+        let mut buffer = vec![0; CHUNK];
+
+        loop {
+            let read = reader
+                .read(&mut buffer)
+                .with_context(|| format!("failed to read {}", path.display()))?;
+
+            if read == 0 {
+                break;
+            }
+
+            hasher.update(&buffer[..read]);
+        }
+
+        Ok(Self(hasher.finalize().into()))
+    }
+
+    /// Reads the digest that a sidecar file publishes
+    ///
+    /// This accepts the spelling `sha256sum` and `shasum` write, which is
+    /// the digest, whitespace, and the file it describes. It also accepts
+    /// a digest on its own, which is what a publisher writes by hand.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the file holds no digest of the right shape.
+    pub fn from_sidecar(contents: &str) -> anyhow::Result<Self> {
+        let digest = contents
+            .split_whitespace()
+            .next()
+            .context("the sidecar is empty")?;
+
+        anyhow::ensure!(
+            digest.len() == 64,
+            "the sidecar holds {} characters where a SHA-256 digest has 64",
+            digest.len()
+        );
+
+        let mut bytes = [0; 32];
+        hex::decode_to_slice(digest.to_ascii_lowercase(), &mut bytes)
+            .context("the sidecar holds something that is not a SHA-256 digest")?;
+
+        Ok(Self(bytes))
+    }
+}
+
+impl std::fmt::Display for Sha256Digest {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        for byte in self.0 {
+            write!(f, "{byte:02x}")?;
+        }
+
+        Ok(())
+    }
+}
+
+/// Unpacks the files an archive holds at its root into `directory`
+///
+/// A publisher ships one library per lint package, side by side, so
+/// everything whisker needs sits at the root. Whisker skips every other
+/// entry rather than refuse it. That leaves a publisher free to add a
+/// manifest or a license, and whisker writes nothing it did not intend.
+///
+/// One rule keeps the unpack inside `directory`. A file at the root has
+/// exactly one path component, which a name with `..` or a leading slash
+/// fails. The rule also passes over a symbolic link, which is no regular
+/// file, so an archive cannot plant one.
+///
+/// This does not bound how much a well-formed archive unpacks to. The
+/// publisher already puts code in whisker's process, so a decompression
+/// bomb adds nothing to what they can do.
+///
+/// # Errors
+///
+/// Returns an error if the archive cannot be read or a file cannot be
+/// written.
+pub fn extract(archive: &Path, directory: &Path) -> anyhow::Result<()> {
+    let file =
+        File::open(archive).with_context(|| format!("failed to open {}", archive.display()))?;
+    let mut tar = tar::Archive::new(GzDecoder::new(BufReader::new(file)));
+
+    let entries = tar
+        .entries()
+        .with_context(|| format!("failed to read {}", archive.display()))?;
+
+    for entry in entries {
+        let mut entry = entry.with_context(|| format!("failed to read {}", archive.display()))?;
+
+        if entry.header().entry_type() != tar::EntryType::Regular {
+            continue;
+        }
+
+        let path = entry
+            .path()
+            .with_context(|| format!("failed to read a file name from {}", archive.display()))?
+            .into_owned();
+
+        let Some(name) = root_file_name(&path) else {
+            continue;
+        };
+
+        let destination = directory.join(name);
+        entry
+            .unpack(&destination)
+            .with_context(|| format!("failed to write {}", destination.display()))?;
+    }
+
+    Ok(())
+}
+
+/// Returns the name of `path` if it names a file at an archive's root
+///
+/// Exactly one ordinary component qualifies. A path with a directory in
+/// it fails, and so does an absolute path and one that climbs out with
+/// `..`. The unpack therefore needs no separate check for the last two.
+fn root_file_name(path: &Path) -> Option<&std::ffi::OsStr> {
+    let mut components = path.components();
+
+    let Some(Component::Normal(name)) = components.next() else {
+        return None;
+    };
+
+    match components.next() {
+        Some(_) => None,
+        None => Some(name),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::io::Write as _;
+
+    use tempfile::TempDir;
+
+    use super::*;
+
+    /// The digest of an empty input, from the SHA-256 specification
+    const EMPTY: &str = "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855";
+
+    /// Writes a gzipped tar holding `files`, and returns where it is
+    ///
+    /// This writes every name into the header as bytes rather than
+    /// through the builder. The builder refuses a name that holds `..`,
+    /// and several of these tests need exactly that archive.
+    fn archive_of(directory: &Path, files: &[(&str, &[u8])]) -> std::path::PathBuf {
+        archive_of_entries(
+            directory,
+            &files
+                .iter()
+                .map(|(name, contents)| (*name, *contents, tar::EntryType::Regular))
+                .collect::<Vec<_>>(),
+        )
+    }
+
+    /// Writes a gzipped tar holding `entries` of the kinds they name
+    fn archive_of_entries(
+        directory: &Path,
+        entries: &[(&str, &[u8], tar::EntryType)],
+    ) -> std::path::PathBuf {
+        let path = directory.join("archive.tar.gz");
+        let file = File::create(&path).expect("the archive should be created");
+        let encoder = flate2::write::GzEncoder::new(file, flate2::Compression::fast());
+        let mut builder = tar::Builder::new(encoder);
+
+        for (name, contents, kind) in entries {
+            let mut header = tar::Header::new_gnu();
+            set_raw_name(&mut header, name);
+            header.set_size(contents.len() as u64);
+            header.set_mode(0o644);
+            header.set_entry_type(*kind);
+            header.set_cksum();
+            builder
+                .append(&header, *contents)
+                .expect("the entry should be written");
+        }
+
+        builder
+            .into_inner()
+            .expect("the archive should be finished")
+            .finish()
+            .expect("the archive should be flushed");
+
+        path
+    }
+
+    /// Writes `name` into `header` without the checks a builder makes
+    ///
+    /// No honest tool writes an archive that climbs out of its
+    /// destination, so a test that proves whisker refuses one writes the
+    /// bytes itself.
+    fn set_raw_name(header: &mut tar::Header, name: &str) {
+        let gnu = header.as_gnu_mut().expect("the header should be a GNU one");
+        let bytes = name.as_bytes();
+
+        assert!(bytes.len() < gnu.name.len(), "the name should fit: {name}");
+
+        gnu.name[..bytes.len()].copy_from_slice(bytes);
+    }
+
+    /// Returns the names `extract` wrote into a fresh directory
+    fn extracted(files: &[(&str, &[u8])]) -> Vec<String> {
+        let directory = tempfile::tempdir().expect("temporary directory should be created");
+        let archive = archive_of(directory.path(), files);
+        let into = directory.path().join("into");
+        std::fs::create_dir(&into).expect("the destination should be created");
+
+        extract(&archive, &into).expect("the archive should unpack");
+
+        let mut names: Vec<String> = std::fs::read_dir(&into)
+            .expect("the destination should be readable")
+            .map(|entry| {
+                entry
+                    .expect("the entry should be readable")
+                    .file_name()
+                    .to_string_lossy()
+                    .into_owned()
+            })
+            .collect();
+        names.sort();
+
+        names
+    }
+
+    fn file(directory: &TempDir, name: &str, contents: &[u8]) -> std::path::PathBuf {
+        let path = directory.path().join(name);
+        let mut file = File::create(&path).expect("the file should be created");
+        file.write_all(contents)
+            .expect("the file should be written");
+
+        path
+    }
+
+    /// An archive must not write outside its destination. Such a name
+    /// holds more than one component, so the rule that skips a
+    /// subdirectory skips this too.
+    #[test]
+    fn extract_ignores_an_entry_that_climbs_out() {
+        let names = extracted(&[("../escaped", b"no" as &[u8]), ("kept", b"yes")]);
+
+        assert_eq!(names, vec!["kept".to_owned()]);
+    }
+
+    #[test]
+    fn extract_ignores_an_absolute_entry() {
+        let names = extracted(&[("/etc/passwd", b"no" as &[u8]), ("kept", b"yes")]);
+
+        assert_eq!(names, vec!["kept".to_owned()]);
+    }
+
+    /// An archive must not be able to plant a link pointing anywhere.
+    #[test]
+    fn extract_ignores_a_symbolic_link() {
+        let directory = tempfile::tempdir().expect("temporary directory should be created");
+        let archive = archive_of_entries(
+            directory.path(),
+            &[
+                ("link", b"" as &[u8], tar::EntryType::Symlink),
+                ("kept", b"yes", tar::EntryType::Regular),
+            ],
+        );
+        let into = directory.path().join("into");
+        std::fs::create_dir(&into).expect("the destination should be created");
+
+        extract(&archive, &into).expect("the archive should unpack");
+
+        assert!(!into.join("link").exists());
+        assert!(into.join("kept").is_file());
+    }
+
+    #[test]
+    fn extract_ignores_an_entry_in_a_subdirectory() {
+        let names = extracted(&[("nested/deep", b"no" as &[u8]), ("kept", b"yes")]);
+
+        assert_eq!(names, vec!["kept".to_owned()]);
+    }
+
+    #[test]
+    fn extract_of_an_empty_archive_writes_nothing() {
+        let names = extracted(&[]);
+
+        assert!(names.is_empty(), "{names:?}");
+    }
+
+    #[test]
+    fn extract_writes_every_file_at_the_root() {
+        let names = extracted(&[("first", b"one" as &[u8]), ("second", b"two")]);
+
+        assert_eq!(names, vec!["first".to_owned(), "second".to_owned()]);
+    }
+
+    #[test]
+    fn extract_writes_the_contents_it_was_given() {
+        let directory = tempfile::tempdir().expect("temporary directory should be created");
+        let archive = archive_of(directory.path(), &[("library", b"contents" as &[u8])]);
+        let into = directory.path().join("into");
+        std::fs::create_dir(&into).expect("the destination should be created");
+
+        extract(&archive, &into).expect("the archive should unpack");
+
+        let written = std::fs::read(into.join("library")).expect("the file should be readable");
+        assert_eq!(written, b"contents");
+    }
+
+    #[test]
+    fn from_sidecar_accepts_the_digest_alone() {
+        let digest = Sha256Digest::from_sidecar(EMPTY).expect("should parse");
+
+        assert_eq!(digest.to_string(), EMPTY);
+    }
+
+    #[test]
+    fn from_sidecar_accepts_what_shasum_writes() {
+        let digest =
+            Sha256Digest::from_sidecar(&format!("{EMPTY}  rules.tar.gz\n")).expect("should parse");
+
+        assert_eq!(digest.to_string(), EMPTY);
+    }
+
+    #[test]
+    fn from_sidecar_accepts_uppercase() {
+        let digest = Sha256Digest::from_sidecar(&EMPTY.to_ascii_uppercase()).expect("should parse");
+
+        assert_eq!(digest.to_string(), EMPTY);
+    }
+
+    #[test]
+    fn from_sidecar_of_an_empty_file_returns_error() {
+        let error = Sha256Digest::from_sidecar("   \n").expect_err("should fail");
+
+        assert!(format!("{error:#}").contains("empty"), "{error:#}");
+    }
+
+    #[test]
+    fn from_sidecar_of_a_short_digest_returns_error() {
+        let error = Sha256Digest::from_sidecar("abcdef").expect_err("should fail");
+
+        assert!(format!("{error:#}").contains("64"), "{error:#}");
+    }
+
+    #[test]
+    fn from_sidecar_of_something_that_is_not_hexadecimal_returns_error() {
+        let error = Sha256Digest::from_sidecar(&"z".repeat(64)).expect_err("should fail");
+
+        assert!(format!("{error:#}").contains("SHA-256"), "{error:#}");
+    }
+
+    #[test]
+    fn of_file_matches_the_published_digest_of_no_bytes() {
+        let directory = tempfile::tempdir().expect("temporary directory should be created");
+        let path = file(&directory, "empty", b"");
+
+        let digest = Sha256Digest::of_file(&path).expect("the file should be read");
+
+        assert_eq!(digest.to_string(), EMPTY);
+    }
+
+    /// Pins that the digest covers a file larger than one buffer
+    #[test]
+    fn of_file_reads_a_file_larger_than_one_chunk() {
+        let directory = tempfile::tempdir().expect("temporary directory should be created");
+        let contents = vec![7; CHUNK * 2 + 1];
+        let path = file(&directory, "large", &contents);
+
+        let digest = Sha256Digest::of_file(&path).expect("the file should be read");
+
+        let mut hasher = Sha256::new();
+        hasher.update(&contents);
+        assert_eq!(digest, Sha256Digest(hasher.finalize().into()));
+    }
+
+    #[test]
+    fn of_file_separates_different_contents() {
+        let directory = tempfile::tempdir().expect("temporary directory should be created");
+        let first = file(&directory, "first", b"one");
+        let second = file(&directory, "second", b"two");
+
+        assert_ne!(
+            Sha256Digest::of_file(&first).expect("the file should be read"),
+            Sha256Digest::of_file(&second).expect("the file should be read")
+        );
+    }
+
+    #[test]
+    fn of_a_missing_file_returns_error() {
+        let directory = tempfile::tempdir().expect("temporary directory should be created");
+
+        let error =
+            Sha256Digest::of_file(&directory.path().join("absent")).expect_err("should fail");
+
+        assert!(format!("{error:#}").contains("absent"), "{error:#}");
+    }
+
+    #[test]
+    fn trait_send() {
+        fn assert_send<T: Send>() {}
+        assert_send::<Sha256Digest>();
+    }
+
+    #[test]
+    fn trait_sync() {
+        fn assert_sync<T: Sync>() {}
+        assert_sync::<Sha256Digest>();
+    }
+
+    #[test]
+    fn trait_unpin() {
+        fn assert_unpin<T: Unpin>() {}
+        assert_unpin::<Sha256Digest>();
+    }
+}

--- a/crates/whisker/src/custom_lints/prebuilt/asset_name.rs
+++ b/crates/whisker/src/custom_lints/prebuilt/asset_name.rs
@@ -1,0 +1,130 @@
+use std::fmt;
+
+use crate::config::GitRev;
+use crate::custom_lints::AbiTag;
+
+/// The extension every archive of prebuilt lints carries
+const EXTENSION: &str = ".tar.gz";
+
+/// The extension of the file that publishes an archive's digest
+const SIDECAR: &str = ".sha256";
+
+/// What an archive of prebuilt lints is called on a release
+///
+/// The name answers two questions about an archive: which commit of the
+/// lints it holds, and which whisker it fits. A publisher writes the
+/// name and whisker reads it, and neither program asks the other, so the
+/// spelling here is a contract between them.
+///
+/// The commit comes first, because its width never varies. The
+/// [`AbiTag`] can then hold the dashes that every target triple has.
+///
+/// # Examples
+///
+/// ```ignore
+/// let name = AssetName::new(source.rev(), &AbiTag::host());
+///
+/// println!("looking for {name} and {}", name.sidecar());
+/// ```
+#[derive(Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug)]
+pub struct AssetName(String);
+
+impl AssetName {
+    /// Returns the name of the archive holding `rev` built for `tag`
+    pub fn new(rev: &GitRev, tag: &AbiTag) -> Self {
+        Self(format!("{rev}-{tag}{EXTENSION}"))
+    }
+
+    /// Returns the name as a publisher would have written it
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+
+    /// Returns the name of the file that publishes this archive's digest
+    pub fn sidecar(&self) -> String {
+        format!("{}{SIDECAR}", self.0)
+    }
+}
+
+impl fmt::Display for AssetName {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        self.0.fmt(f)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::custom_lints::handshake::AbiIdentity;
+
+    const REV: &str = "0123456789abcdef0123456789abcdef01234567";
+
+    fn tag() -> AbiTag {
+        AbiTag::new(
+            &AbiIdentity {
+                abi_version: 2,
+                rustc_version: "rustc 1.92.0-nightly (0123456 2026-08-11)".to_owned(),
+                types_fingerprint: 0,
+                language_fingerprint: 0,
+            },
+            "aarch64-apple-darwin",
+        )
+    }
+
+    fn name() -> AssetName {
+        AssetName::new(
+            &GitRev::new(REV).expect("the revision should be accepted"),
+            &tag(),
+        )
+    }
+
+    #[test]
+    fn new_ends_with_the_archive_extension() {
+        assert!(name().as_str().ends_with(".tar.gz"), "{}", name());
+    }
+
+    #[test]
+    fn new_names_the_commit_first() {
+        assert!(name().as_str().starts_with(REV), "{}", name());
+    }
+
+    /// The tag holds dashes, and so does the boundary before it. The
+    /// commit separates the two, because its width never varies.
+    #[test]
+    fn new_names_the_tag_after_the_commit() {
+        let name = name();
+
+        let rest = name
+            .as_str()
+            .strip_prefix(REV)
+            .and_then(|rest| rest.strip_prefix('-'))
+            .expect("the commit should come first");
+
+        assert_eq!(rest, format!("{}.tar.gz", tag()));
+    }
+
+    #[test]
+    fn sidecar_appends_to_the_archive_name() {
+        let name = name();
+
+        assert_eq!(name.sidecar(), format!("{name}.sha256"));
+    }
+
+    #[test]
+    fn trait_send() {
+        fn assert_send<T: Send>() {}
+        assert_send::<AssetName>();
+    }
+
+    #[test]
+    fn trait_sync() {
+        fn assert_sync<T: Sync>() {}
+        assert_sync::<AssetName>();
+    }
+
+    #[test]
+    fn trait_unpin() {
+        fn assert_unpin<T: Unpin>() {}
+        assert_unpin::<AssetName>();
+    }
+}

--- a/crates/whisker/src/custom_lints/prebuilt/github_release.rs
+++ b/crates/whisker/src/custom_lints/prebuilt/github_release.rs
@@ -1,0 +1,593 @@
+use std::io::Read;
+use std::path::Path;
+use std::time::Duration;
+
+use anyhow::Context as _;
+use reqwest::blocking::{Client, Response};
+use reqwest::header::{ACCEPT, AUTHORIZATION, USER_AGENT};
+use serde::Deserialize;
+
+use super::archive::Sha256Digest;
+use super::asset_name::AssetName;
+use super::github_repository::GitHubRepository;
+
+/// The API whisker asks when nothing else is configured
+const DEFAULT_BASE: &str = "https://api.github.com";
+
+/// The variable that points whisker at another release API
+///
+/// A GitHub Enterprise installation serves the same API under its own
+/// name. The tests serve it from a local port.
+const API_VARIABLE: &str = "WHISKER_GITHUB_API_URL";
+
+/// The variables a token is read from, in the order `gh` reads them
+const TOKEN_VARIABLES: [&str; 2] = ["GH_TOKEN", "GITHUB_TOKEN"];
+
+/// How long whisker waits to reach the API before giving up
+const CONNECT_TIMEOUT: Duration = Duration::from_secs(10);
+
+/// The most of a release listing whisker reads
+///
+/// A hundred releases with three files each sit far below this. The limit
+/// exists so that an endless answer costs a failed check and not the
+/// machine's memory.
+const MAX_LISTING: u64 = 8 * 1024 * 1024;
+
+/// The most of a digest file whisker reads
+///
+/// A sidecar holds one line.
+const MAX_SIDECAR: u64 = 4 * 1024;
+
+/// The most of an archive whisker writes to disk
+///
+/// A repository of rules builds one library per rule, so a real archive
+/// holds tens of megabytes. This limit sits far above that, and far below
+/// a full disk.
+const MAX_ARCHIVE: u64 = 512 * 1024 * 1024;
+
+/// How long whisker waits for one request to finish
+///
+/// One limit covers a small listing and a large archive. It allows a
+/// download on a slow link, and it still releases a hung connection.
+const REQUEST_TIMEOUT: Duration = Duration::from_secs(300);
+
+/// The release API whisker asks for prebuilt lints
+///
+/// This reads the environment once. It decides which API whisker asks,
+/// and whether whisker holds a token for it. A run that asks about
+/// several sources reuses one client, and therefore one connection
+/// pool.
+pub struct GitHubApi {
+    base: String,
+    api_host: Option<String>,
+    token: Option<String>,
+    client: Client,
+}
+
+/// Returns the extra remote host the configured API answers for
+///
+/// This reads the environment without a client, so whisker can rule a
+/// remote out before it builds one.
+pub fn configured_repository_host() -> Option<String> {
+    repository_host(&base_from(std::env::var(API_VARIABLE).ok()))
+}
+
+impl GitHubApi {
+    /// Builds the client the environment describes
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the HTTP client cannot be built.
+    pub fn from_environment() -> anyhow::Result<Self> {
+        let base = base_from(std::env::var(API_VARIABLE).ok());
+        let api_host = host_of(&base);
+        let token = TOKEN_VARIABLES
+            .into_iter()
+            .find_map(|variable| present(std::env::var(variable).ok()));
+
+        let client = Client::builder()
+            .connect_timeout(CONNECT_TIMEOUT)
+            .timeout(REQUEST_TIMEOUT)
+            .build()
+            .context("failed to build an HTTP client")?;
+
+        Ok(Self {
+            base,
+            api_host,
+            token,
+            client,
+        })
+    }
+
+    /// Returns the archive named `name` and its sidecar, if a release has them
+    ///
+    /// Whisker reads the first page of releases only. It misses an
+    /// archive in a repository that cut a hundred releases since it
+    /// published one, and the caller then compiles the source. A walk
+    /// through a paginated history on every check costs more.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the API cannot be reached or answers with
+    /// anything but a listing. A repository that does not exist is not an
+    /// error. Whisker sees that for a private repository it holds no
+    /// token for, and the caller compiles the source instead.
+    pub fn find_asset(
+        &self,
+        repository: &GitHubRepository,
+        name: &AssetName,
+    ) -> anyhow::Result<Option<PrebuiltAsset>> {
+        let url = format!("{}/repos/{repository}/releases?per_page=100", self.base);
+
+        let response = self
+            .get(&url, "application/vnd.github+json")
+            .with_context(|| format!("failed to ask {repository} for its releases"))?;
+
+        if response.status() == reqwest::StatusCode::NOT_FOUND {
+            return Ok(None);
+        }
+
+        let status = response.status();
+        anyhow::ensure!(
+            status.is_success(),
+            "the release API answered {status} for {repository}"
+        );
+
+        let body = read_text(
+            response,
+            MAX_LISTING,
+            &format!("the releases of {repository}"),
+        )?;
+        let releases: Vec<Release> = serde_json::from_str(&body)
+            .with_context(|| format!("failed to read the releases of {repository} as JSON"))?;
+
+        Ok(select_asset(&releases, name))
+    }
+
+    /// Downloads `asset` to `path` and returns the digest of what arrived
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the asset cannot be fetched or written.
+    pub fn download(&self, asset: &ReleaseAsset, path: &Path) -> anyhow::Result<Sha256Digest> {
+        let response = self
+            .get(&asset.url, "application/octet-stream")
+            .with_context(|| format!("failed to download {}", asset.name))?;
+
+        let status = response.status();
+        anyhow::ensure!(
+            status.is_success(),
+            "the release API answered {status} for {}",
+            asset.name
+        );
+
+        let mut file = std::fs::File::create(path)
+            .with_context(|| format!("failed to create {}", path.display()))?;
+        let written = std::io::copy(&mut response.take(MAX_ARCHIVE + 1), &mut file)
+            .with_context(|| format!("failed to write {}", path.display()))?;
+        drop(file);
+
+        anyhow::ensure!(
+            written <= MAX_ARCHIVE,
+            "{} is larger than the {MAX_ARCHIVE} bytes whisker will download",
+            asset.name
+        );
+
+        Sha256Digest::of_file(path)
+    }
+
+    /// Downloads `asset` and returns what it holds as text
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the asset cannot be fetched or is not text.
+    pub fn download_text(&self, asset: &ReleaseAsset) -> anyhow::Result<String> {
+        let response = self
+            .get(&asset.url, "application/octet-stream")
+            .with_context(|| format!("failed to download {}", asset.name))?;
+
+        let status = response.status();
+        anyhow::ensure!(
+            status.is_success(),
+            "the release API answered {status} for {}",
+            asset.name
+        );
+
+        read_text(response, MAX_SIDECAR, &asset.name)
+    }
+
+    /// Sends one request, and carries the token only to the API's own host
+    ///
+    /// GitHub answers a download with a redirect to a storage host. That
+    /// host signs the request itself and refuses one that also carries an
+    /// `Authorization` header. The host check keeps the token off that
+    /// second request, and away from anywhere whisker was not pointed.
+    fn get(&self, url: &str, accept: &str) -> anyhow::Result<Response> {
+        let mut request = self
+            .client
+            .get(url)
+            .header(USER_AGENT, concat!("whisker/", env!("CARGO_PKG_VERSION")))
+            .header(ACCEPT, accept);
+
+        if let Some(token) = self.token.as_deref().filter(|_| self.serves(url)) {
+            request = request.header(AUTHORIZATION, format!("Bearer {token}"));
+        }
+
+        request.send().context("the request failed")
+    }
+
+    /// Reports whether `url` is on the host this API answers for
+    fn serves(&self, url: &str) -> bool {
+        let Ok(url) = reqwest::Url::parse(url) else {
+            return false;
+        };
+
+        match (url.host_str(), self.api_host.as_deref()) {
+            (Some(host), Some(api)) => host.eq_ignore_ascii_case(api),
+            (_, _) => false,
+        }
+    }
+}
+
+/// One release, as much of it as whisker reads
+#[derive(Clone, Eq, PartialEq, Debug, Deserialize)]
+struct Release {
+    #[serde(default)]
+    draft: bool,
+
+    #[serde(default)]
+    assets: Vec<ReleaseAsset>,
+}
+
+/// One file attached to a release
+#[derive(Clone, Eq, PartialEq, Debug, Deserialize)]
+pub struct ReleaseAsset {
+    name: String,
+
+    /// The API's own address for the asset
+    ///
+    /// Whisker uses this rather than the browser's address, because only
+    /// this one serves a private repository to a request with a token.
+    url: String,
+}
+
+/// An archive of prebuilt lints and the digest published beside it
+///
+/// The two travel together. Whisker unpacks an archive only after it
+/// checks the archive against its digest.
+#[derive(Clone, Eq, PartialEq, Debug)]
+pub struct PrebuiltAsset {
+    pub archive: ReleaseAsset,
+    pub sidecar: ReleaseAsset,
+}
+
+/// Returns the archive named `name` and its sidecar, from any release
+///
+/// This passes over a draft, whose assets can still change. Otherwise
+/// the first release with both files wins. A name holds the commit and
+/// the tag, so two releases that carry it carry the same archive.
+fn select_asset(releases: &[Release], name: &AssetName) -> Option<PrebuiltAsset> {
+    let sidecar = name.sidecar();
+
+    releases
+        .iter()
+        .filter(|release| !release.draft)
+        .find_map(|release| {
+            let archive = release.assets.iter().find(|it| it.name == name.as_str())?;
+            let sidecar = release.assets.iter().find(|it| it.name == sidecar)?;
+
+            Some(PrebuiltAsset {
+                archive: archive.clone(),
+                sidecar: sidecar.clone(),
+            })
+        })
+}
+
+/// Returns the API base `value` names, without a trailing slash
+///
+/// A person who pastes a URL leaves a trailing slash behind, and a join
+/// onto it would ask for a path with an empty segment.
+fn base_from(value: Option<String>) -> String {
+    let value = present(value).unwrap_or_else(|| DEFAULT_BASE.to_owned());
+
+    value.trim_end_matches('/').to_owned()
+}
+
+/// Reads at most `cap` bytes of `source` as text
+///
+/// Whisker reads two things as text, and both are small: a page of
+/// releases, and a line that holds a digest. This refuses a body that
+/// runs past the limit.
+fn read_text(source: impl Read, cap: u64, what: &str) -> anyhow::Result<String> {
+    let mut body = String::new();
+
+    source
+        .take(cap + 1)
+        .read_to_string(&mut body)
+        .with_context(|| format!("failed to read {what}"))?;
+
+    anyhow::ensure!(
+        body.len() as u64 <= cap,
+        "{what} is longer than the {cap} bytes whisker reads"
+    );
+
+    Ok(body)
+}
+
+/// Returns the host the API at `base` is reached on
+///
+/// This scopes the token. A request to any other host carries no
+/// credential, including a request to the storage host that a download
+/// redirects to.
+fn host_of(base: &str) -> Option<String> {
+    let url = reqwest::Url::parse(base).ok()?;
+
+    Some(url.host_str()?.to_ascii_lowercase())
+}
+
+/// Returns the extra remote host that the API at `base` answers for
+///
+/// The public API lives on one host and serves repositories on another,
+/// so [`GitHubRepository`] names that pair rather than derive it.
+/// Anywhere else, the API and the repositories share a host, which is how
+/// a GitHub Enterprise installation looks.
+///
+/// [`GitHubRepository`]: super::github_repository::GitHubRepository
+fn repository_host(base: &str) -> Option<String> {
+    if base == DEFAULT_BASE {
+        return None;
+    }
+
+    host_of(base)
+}
+
+/// Returns a variable's value, and treats an empty one as unset
+///
+/// A shell leaves an empty variable behind when it expands something that
+/// was never set. An empty token would claim an authenticated request
+/// that is not one.
+fn present(value: Option<String>) -> Option<String> {
+    value.filter(|value| !value.is_empty())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::config::GitRev;
+    use crate::custom_lints::AbiTag;
+    use crate::custom_lints::handshake::AbiIdentity;
+
+    const REV: &str = "0123456789abcdef0123456789abcdef01234567";
+
+    fn name() -> AssetName {
+        let tag = AbiTag::new(
+            &AbiIdentity {
+                abi_version: 2,
+                rustc_version: "rustc 1.92.0-nightly (0123456 2026-08-11)".to_owned(),
+                types_fingerprint: 0,
+                language_fingerprint: 0,
+            },
+            "aarch64-apple-darwin",
+        );
+
+        AssetName::new(
+            &GitRev::new(REV).expect("the revision should be accepted"),
+            &tag,
+        )
+    }
+
+    /// Returns a client pointed at `base`, and reads no environment
+    fn api_for(base: &str) -> GitHubApi {
+        GitHubApi {
+            base: base.to_owned(),
+            api_host: host_of(base),
+            token: Some("a-secret".to_owned()),
+            client: Client::new(),
+        }
+    }
+
+    /// Returns releases parsed from the JSON a listing would answer with
+    fn releases(json: &str) -> Vec<Release> {
+        serde_json::from_str(json).expect("the fixture should parse")
+    }
+
+    /// Returns a listing holding one release with `assets` attached
+    fn listing(draft: bool, assets: &[&str]) -> String {
+        let assets: Vec<String> = assets
+            .iter()
+            .map(|name| format!(r#"{{"name":"{name}","url":"https://api/{name}","size":1}}"#))
+            .collect();
+
+        format!(r#"[{{"draft":{draft},"assets":[{}]}}]"#, assets.join(","))
+    }
+
+    #[test]
+    fn base_from_an_empty_value_is_the_public_api() {
+        assert_eq!(base_from(Some(String::new())), DEFAULT_BASE);
+    }
+
+    #[test]
+    fn base_from_no_value_is_the_public_api() {
+        assert_eq!(base_from(None), DEFAULT_BASE);
+    }
+
+    #[test]
+    fn base_from_a_value_drops_a_trailing_slash() {
+        assert_eq!(
+            base_from(Some("https://github.acme.example/api/v3/".to_owned())),
+            "https://github.acme.example/api/v3"
+        );
+    }
+
+    /// The token has to reach the public API too, and it once did not.
+    /// The host that scoped it was the one that serves repositories, and
+    /// the public API names no such host. Every request to it therefore
+    /// went out unauthenticated, and no private repository answered.
+    #[test]
+    fn host_of_the_public_api_names_it() {
+        assert_eq!(host_of(DEFAULT_BASE), Some("api.github.com".to_owned()));
+    }
+
+    #[test]
+    fn host_of_another_api_names_its_host() {
+        assert_eq!(
+            host_of("https://github.acme.example/api/v3"),
+            Some("github.acme.example".to_owned())
+        );
+    }
+
+    #[test]
+    fn repository_host_of_the_public_api_names_nothing() {
+        assert_eq!(repository_host(DEFAULT_BASE), None);
+    }
+
+    #[test]
+    fn repository_host_of_another_api_names_its_host() {
+        assert_eq!(
+            repository_host("https://github.acme.example/api/v3"),
+            Some("github.acme.example".to_owned())
+        );
+    }
+
+    /// A download redirects to a storage host. That host signs the
+    /// request itself and refuses one that carries an `Authorization`
+    /// header, so the token must not follow it there.
+    #[test]
+    fn serves_is_false_for_the_host_a_download_redirects_to() {
+        let api = api_for(DEFAULT_BASE);
+
+        assert!(!api.serves("https://objects.githubusercontent.com/whatever"));
+    }
+
+    #[test]
+    fn serves_is_true_for_the_public_api() {
+        let api = api_for(DEFAULT_BASE);
+
+        assert!(api.serves("https://api.github.com/repos/aonyx-ai/rules/releases"));
+    }
+
+    #[test]
+    fn serves_is_true_for_a_configured_api() {
+        let api = api_for("https://github.acme.example/api/v3");
+
+        assert!(api.serves("https://github.acme.example/api/v3/repos/team/rules/releases"));
+    }
+
+    #[test]
+    fn read_text_of_a_body_within_the_limit_returns_it() {
+        let body = read_text(b"digest".as_slice(), 64, "the sidecar").expect("should read");
+
+        assert_eq!(body, "digest");
+    }
+
+    #[test]
+    fn read_text_of_a_body_past_the_limit_returns_error() {
+        let error =
+            read_text(b"far too much".as_slice(), 4, "the sidecar").expect_err("should fail");
+
+        assert!(format!("{error:#}").contains("longer than"), "{error:#}");
+    }
+
+    #[test]
+    fn present_treats_an_empty_value_as_unset() {
+        assert_eq!(present(Some(String::new())), None);
+    }
+
+    #[test]
+    fn present_keeps_a_value_that_holds_something() {
+        assert_eq!(present(Some("token".to_owned())), Some("token".to_owned()));
+    }
+
+    #[test]
+    fn select_asset_finds_the_archive_and_its_sidecar() {
+        let name = name();
+        let releases = releases(&listing(false, &[name.as_str(), &name.sidecar()]));
+
+        let asset = select_asset(&releases, &name).expect("the pair should be found");
+
+        assert_eq!(asset.archive.name, name.as_str());
+        assert_eq!(asset.sidecar.name, name.sidecar());
+    }
+
+    /// Whisker unpacks no archive it cannot check.
+    #[test]
+    fn select_asset_without_a_sidecar_is_none() {
+        let name = name();
+        let releases = releases(&listing(false, &[name.as_str()]));
+
+        assert_eq!(select_asset(&releases, &name), None);
+    }
+
+    #[test]
+    fn select_asset_without_the_archive_is_none() {
+        let name = name();
+        let releases = releases(&listing(
+            false,
+            &["another.tar.gz", "another.tar.gz.sha256"],
+        ));
+
+        assert_eq!(select_asset(&releases, &name), None);
+    }
+
+    /// Nobody published a draft, and its assets can still change.
+    #[test]
+    fn select_asset_skips_a_draft() {
+        let name = name();
+        let releases = releases(&listing(true, &[name.as_str(), &name.sidecar()]));
+
+        assert_eq!(select_asset(&releases, &name), None);
+    }
+
+    #[test]
+    fn select_asset_reads_a_later_release_when_the_first_lacks_it() {
+        let name = name();
+        let json = format!(
+            "[{},{}]",
+            listing(false, &["other.tar.gz"]).trim_matches(['[', ']']),
+            listing(false, &[name.as_str(), &name.sidecar()]).trim_matches(['[', ']'])
+        );
+        let releases = releases(&json);
+
+        assert!(select_asset(&releases, &name).is_some());
+    }
+
+    /// A listing carries far more than whisker reads, and GitHub adds
+    /// fields over time. Neither fact may fail a check.
+    #[test]
+    fn releases_ignore_fields_whisker_does_not_read() {
+        let json = r#"[{"id":1,"tag_name":"v1","draft":false,"prerelease":true,
+            "assets":[{"name":"a","url":"https://api/a","label":null,"state":"uploaded"}]}]"#;
+
+        let releases = releases(json);
+
+        assert_eq!(releases.len(), 1);
+    }
+
+    #[test]
+    fn releases_without_assets_parse() {
+        let releases = releases(r#"[{"draft":false}]"#);
+
+        assert!(releases[0].assets.is_empty());
+    }
+
+    #[test]
+    fn trait_send() {
+        fn assert_send<T: Send>() {}
+        assert_send::<GitHubApi>();
+        assert_send::<PrebuiltAsset>();
+    }
+
+    #[test]
+    fn trait_sync() {
+        fn assert_sync<T: Sync>() {}
+        assert_sync::<GitHubApi>();
+        assert_sync::<PrebuiltAsset>();
+    }
+
+    #[test]
+    fn trait_unpin() {
+        fn assert_unpin<T: Unpin>() {}
+        assert_unpin::<GitHubApi>();
+        assert_unpin::<PrebuiltAsset>();
+    }
+}

--- a/crates/whisker/src/custom_lints/prebuilt/github_repository.rs
+++ b/crates/whisker/src/custom_lints/prebuilt/github_repository.rs
@@ -1,0 +1,222 @@
+use std::fmt;
+
+use gix::url::Scheme;
+
+use crate::config::GitUrl;
+
+/// The host whose repositories the public GitHub API serves
+const PUBLIC_HOST: &str = "github.com";
+
+/// A repository named the way GitHub's REST API names one
+///
+/// A release API answers one question: what does this owner's repository
+/// publish. Not every remote a project can pin has that shape. This type
+/// says which ones do, and whisker compiles the rest from source.
+#[derive(Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug)]
+pub struct GitHubRepository {
+    owner: String,
+    name: String,
+}
+
+impl GitHubRepository {
+    /// Returns the repository `url` names, if an API here serves it
+    ///
+    /// The API always serves a remote on github.com. It also serves one
+    /// on `api_host`, which is how a project inside a GitHub Enterprise
+    /// installation reaches its own releases. Whoever points whisker at
+    /// that API names the host it answers for.
+    ///
+    /// A remote whisker cannot spell as an owner and a repository is not
+    /// one of these. Neither is a local path, because `file://` serves no
+    /// releases.
+    pub fn from_url(url: &GitUrl, api_host: Option<&str>) -> Option<Self> {
+        let url = url.to_gix_url();
+
+        match url.scheme {
+            Scheme::Https | Scheme::Http | Scheme::Ssh | Scheme::Git => {}
+            Scheme::File | Scheme::Ext | Scheme::Helper(_) | Scheme::HelperUrl(_) => {
+                return None;
+            }
+        }
+
+        let host = url.host()?.to_ascii_lowercase();
+        let served = host == PUBLIC_HOST || api_host.is_some_and(|api| host == api);
+
+        if !served {
+            return None;
+        }
+
+        let path = url.path.to_string();
+        let mut segments = path.trim_matches('/').split('/');
+
+        let owner = segments.next()?;
+        let name = segments.next()?;
+
+        if segments.next().is_some() {
+            return None;
+        }
+
+        let name = name.strip_suffix(".git").unwrap_or(name);
+
+        if owner.is_empty() || name.is_empty() {
+            return None;
+        }
+
+        Some(Self {
+            owner: owner.to_owned(),
+            name: name.to_owned(),
+        })
+    }
+}
+
+impl fmt::Display for GitHubRepository {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let Self { owner, name } = self;
+
+        write!(f, "{owner}/{name}")
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn repository(url: &str) -> Option<GitHubRepository> {
+        let url = GitUrl::new(url).expect("the remote should be accepted");
+
+        GitHubRepository::from_url(&url, None)
+    }
+
+    #[test]
+    fn from_url_accepts_an_https_remote() {
+        let repository = repository("https://github.com/aonyx-ai/rules");
+
+        assert_eq!(
+            repository.map(|it| it.to_string()),
+            Some("aonyx-ai/rules".to_owned())
+        );
+    }
+
+    #[test]
+    fn from_url_accepts_the_scp_spelling_of_an_ssh_remote() {
+        let repository = repository("git@github.com:aonyx-ai/rules.git");
+
+        assert_eq!(
+            repository.map(|it| it.to_string()),
+            Some("aonyx-ai/rules".to_owned())
+        );
+    }
+
+    #[test]
+    fn from_url_accepts_an_ssh_remote() {
+        let repository = repository("ssh://git@github.com/aonyx-ai/rules.git");
+
+        assert_eq!(
+            repository.map(|it| it.to_string()),
+            Some("aonyx-ai/rules".to_owned())
+        );
+    }
+
+    #[test]
+    fn from_url_drops_the_git_suffix() {
+        let repository = repository("https://github.com/aonyx-ai/rules.git");
+
+        assert_eq!(
+            repository.map(|it| it.to_string()),
+            Some("aonyx-ai/rules".to_owned())
+        );
+    }
+
+    #[test]
+    fn from_url_accepts_a_trailing_slash() {
+        let repository = repository("https://github.com/aonyx-ai/rules/");
+
+        assert_eq!(
+            repository.map(|it| it.to_string()),
+            Some("aonyx-ai/rules".to_owned())
+        );
+    }
+
+    /// A host is not case sensitive, and a person pasting one from a
+    /// browser can capitalize it.
+    #[test]
+    fn from_url_accepts_a_host_in_capitals() {
+        let repository = repository("https://GitHub.com/aonyx-ai/rules");
+
+        assert_eq!(
+            repository.map(|it| it.to_string()),
+            Some("aonyx-ai/rules".to_owned())
+        );
+    }
+
+    /// Credentials belong to whoever fetches, never to the name of the
+    /// repository they fetch.
+    #[test]
+    fn from_url_ignores_credentials() {
+        let repository = repository("https://someone:secret@github.com/aonyx-ai/rules");
+
+        assert_eq!(
+            repository.map(|it| it.to_string()),
+            Some("aonyx-ai/rules".to_owned())
+        );
+    }
+
+    #[test]
+    fn from_url_of_a_configured_api_host_is_served() {
+        let url = GitUrl::new("https://github.acme.example/team/rules")
+            .expect("the remote should be accepted");
+
+        let repository = GitHubRepository::from_url(&url, Some("github.acme.example"));
+
+        assert_eq!(
+            repository.map(|it| it.to_string()),
+            Some("team/rules".to_owned())
+        );
+    }
+
+    #[test]
+    fn from_url_of_another_host_is_none() {
+        assert_eq!(repository("https://gitlab.com/aonyx-ai/rules"), None);
+    }
+
+    #[test]
+    fn from_url_of_a_local_path_is_none() {
+        assert_eq!(repository("file:///srv/rules"), None);
+    }
+
+    #[test]
+    fn from_url_of_a_deeper_path_is_none() {
+        assert_eq!(
+            repository("https://github.com/aonyx-ai/rules/tree/main"),
+            None
+        );
+    }
+
+    #[test]
+    fn from_url_of_an_owner_alone_is_none() {
+        assert_eq!(repository("https://github.com/aonyx-ai"), None);
+    }
+
+    #[test]
+    fn from_url_of_an_empty_name_is_none() {
+        assert_eq!(repository("https://github.com/aonyx-ai/.git"), None);
+    }
+
+    #[test]
+    fn trait_send() {
+        fn assert_send<T: Send>() {}
+        assert_send::<GitHubRepository>();
+    }
+
+    #[test]
+    fn trait_sync() {
+        fn assert_sync<T: Sync>() {}
+        assert_sync::<GitHubRepository>();
+    }
+
+    #[test]
+    fn trait_unpin() {
+        fn assert_unpin<T: Unpin>() {}
+        assert_unpin::<GitHubRepository>();
+    }
+}

--- a/crates/whisker/tests/custom_lints.rs
+++ b/crates/whisker/tests/custom_lints.rs
@@ -62,8 +62,17 @@ fn example_lint() -> PathBuf {
     std::fs::canonicalize(path).expect("the example lint should exist")
 }
 
+/// Returns a whisker with nothing of the caller's environment in it
+///
+/// A token or a release API of the person who runs the tests must not
+/// reach a fixture remote. No run here reads either one.
 fn whisker() -> Command {
-    Command::cargo_bin("whisker").expect("whisker binary should exist")
+    let mut command = Command::cargo_bin("whisker").expect("whisker binary should exist");
+    command.env_remove("GH_TOKEN");
+    command.env_remove("GITHUB_TOKEN");
+    command.env_remove("WHISKER_GITHUB_API_URL");
+
+    command
 }
 
 /// Returns the build directory the plugin workspace uses

--- a/crates/whisker/tests/git_lints.rs
+++ b/crates/whisker/tests/git_lints.rs
@@ -60,12 +60,18 @@ fn configure_git_lint(package: &Path, url: &str, rev: &str) {
 /// the identity in someone's `~/.gitconfig` passed everywhere it was
 /// written and failed on every build agent, which is where whisker most
 /// needs to work, so these tests run with the same nothing an agent has.
+///
+/// The same reasoning removes a token and a release API. Neither belongs
+/// near a fixture remote.
 fn whisker(cache: &TempDir) -> Command {
     let mut command = Command::cargo_bin("whisker").expect("whisker binary should exist");
     command.env("WHISKER_CACHE_DIR", cache.path());
     command.env("CARGO_TARGET_DIR", shared_build_directory());
     command.env("GIT_CONFIG_GLOBAL", "/dev/null");
     command.env("GIT_CONFIG_SYSTEM", "/dev/null");
+    command.env_remove("GH_TOKEN");
+    command.env_remove("GITHUB_TOKEN");
+    command.env_remove("WHISKER_GITHUB_API_URL");
 
     command
 }

--- a/crates/whisker/tests/prebuilt_lints.rs
+++ b/crates/whisker/tests/prebuilt_lints.rs
@@ -5,11 +5,14 @@ use assert_cmd::prelude::*;
 use predicates::prelude::*;
 use tempfile::TempDir;
 
+#[path = "support/fake_github.rs"]
+mod fake_github;
 #[path = "support/fixture_repository.rs"]
 mod fixture_repository;
 #[path = "support/mismatched_plugin.rs"]
 mod mismatched_plugin;
 
+use fake_github::{Answer, FakeGitHub};
 use fixture_repository::{FixtureRepository, Standalone, write_lint_package, write_lockfile};
 use mismatched_plugin::write_mismatched_lint_package;
 
@@ -50,12 +53,19 @@ fn configure_git_lint(package: &Path, url: &str, rev: &str) {
 }
 
 /// Returns a whisker that keeps everything it fetches inside `cache`
+///
+/// This removes what the person running the tests holds. Their token
+/// would otherwise reach a fixture server, and whisker would ask their
+/// API about a repository these tests invented.
 fn whisker(cache: &TempDir) -> Command {
     let mut command = Command::cargo_bin("whisker").expect("whisker binary should exist");
     command.env("WHISKER_CACHE_DIR", cache.path());
     command.env("CARGO_TARGET_DIR", shared_build_directory());
     command.env("GIT_CONFIG_GLOBAL", "/dev/null");
     command.env("GIT_CONFIG_SYSTEM", "/dev/null");
+    command.env_remove("GH_TOKEN");
+    command.env_remove("GITHUB_TOKEN");
+    command.env_remove("WHISKER_GITHUB_API_URL");
 
     command
 }
@@ -349,4 +359,370 @@ fn build_cdylib(directory: &Path, name: &str) -> PathBuf {
     assert!(library.is_file(), "expected a library at {library:?}");
 
     library
+}
+
+/// The remote every download test pins
+///
+/// The fake API answers for this host, so whisker asks about the remote.
+/// The host also serves no git. A test that falls back to the source
+/// therefore fails at once, and resolves no name.
+const REMOTE: &str = "https://127.0.0.1/aonyx/rules";
+
+/// Where the API serves the releases of that remote
+const RELEASES: &str = "/repos/aonyx/rules/releases";
+
+/// A commit of the right shape for the remote above
+const REV: &str = "0123456789abcdef0123456789abcdef01234567";
+
+/// Returns a whisker that asks `server` instead of GitHub
+fn whisker_asking(cache: &TempDir, api: &str) -> Command {
+    let mut command = whisker(cache);
+    command.env("WHISKER_GITHUB_API_URL", api);
+
+    command
+}
+
+/// Builds a lint package called `package` and returns its library
+///
+/// Every test names its package after itself, for the reason
+/// [`repository_with_one_lint`] gives.
+fn fixture_library(package: &str) -> PathBuf {
+    let source = tempfile::tempdir().expect("temporary directory should be created");
+    write_lint_package(source.path(), package, RULE, Standalone::Yes);
+
+    build_cdylib(source.path(), package)
+}
+
+/// Returns a gzipped tar holding `libraries` at its root
+fn archive_of(libraries: &[PathBuf]) -> Vec<u8> {
+    let encoder = flate2::write::GzEncoder::new(Vec::new(), flate2::Compression::fast());
+    let mut builder = tar::Builder::new(encoder);
+
+    for library in libraries {
+        let name = library
+            .file_name()
+            .expect("a library should have a name")
+            .to_string_lossy()
+            .into_owned();
+        builder
+            .append_path_with_name(library, name)
+            .expect("the library should be added");
+    }
+
+    builder
+        .into_inner()
+        .expect("the archive should be finished")
+        .finish()
+        .expect("the archive should be flushed")
+}
+
+/// Returns the SHA-256 of `bytes` in the spelling a sidecar uses
+fn digest_of(bytes: &[u8]) -> String {
+    use sha2::Digest as _;
+
+    let mut hasher = sha2::Sha256::new();
+    hasher.update(bytes);
+
+    hex::encode(hasher.finalize())
+}
+
+/// Returns a release listing offering `assets` from `server`
+fn listing(server: &FakeGitHub, assets: &[&str]) -> String {
+    let assets: Vec<String> = assets
+        .iter()
+        .map(|name| {
+            format!(
+                r#"{{"name":"{name}","url":"{}/assets/{name}"}}"#,
+                server.url()
+            )
+        })
+        .collect();
+
+    format!(r#"[{{"draft":false,"assets":[{}]}}]"#, assets.join(","))
+}
+
+/// Publishes an archive of `libraries` for `REV`, and returns its name
+fn publish(server: &FakeGitHub, libraries: &[PathBuf]) -> String {
+    let name = format!("{REV}-{}.tar.gz", abi_tag());
+    let sidecar = format!("{name}.sha256");
+    let bytes = archive_of(libraries);
+    let digest = digest_of(&bytes);
+
+    server.route(RELEASES, Answer::json(listing(server, &[&name, &sidecar])));
+    server.route(&format!("/assets/{name}"), Answer::bytes(bytes));
+    server.route(
+        &format!("/assets/{sidecar}"),
+        Answer::text(format!("{digest}  {name}\n")),
+    );
+
+    name
+}
+
+/// Pins the whole path from the question to the diagnostic
+///
+/// Whisker asks, downloads, checks the digest, unpacks, loads, and
+/// reports.
+#[test]
+fn check_with_a_published_archive_loads_it_without_a_source() {
+    let server = FakeGitHub::start();
+    let cache = tempfile::tempdir().expect("temporary directory should be created");
+    let target = package(TODO_SOURCE);
+    configure_git_lint(target.path(), REMOTE, REV);
+    publish(&server, &[fixture_library("published_lint")]);
+
+    whisker_asking(&cache, server.url())
+        .arg("check")
+        .arg(target.path())
+        .assert()
+        .success()
+        .stderr(predicate::str::contains(format!("warning[{RULE}]")))
+        .stderr(predicate::str::contains("finish this before it ships"));
+
+    assert!(
+        cache.path().join("prebuilt").is_dir(),
+        "the archive should have been kept"
+    );
+}
+
+/// Pins that what whisker kept is read without asking anyone
+#[test]
+fn check_with_prebuilt_lints_in_the_cache_asks_nothing() {
+    let server = FakeGitHub::start();
+    let cache = tempfile::tempdir().expect("temporary directory should be created");
+    let target = package(TODO_SOURCE);
+    configure_git_lint(target.path(), REMOTE, REV);
+    publish(&server, &[fixture_library("cached_lint")]);
+
+    whisker_asking(&cache, server.url())
+        .arg("check")
+        .arg(target.path())
+        .assert()
+        .success();
+    let asked = server.seen().len();
+
+    whisker_asking(&cache, server.url())
+        .arg("check")
+        .arg(target.path())
+        .assert()
+        .success()
+        .stderr(predicate::str::contains(format!("warning[{RULE}]")));
+
+    assert_eq!(
+        server.seen().len(),
+        asked,
+        "the second run should have asked nothing"
+    );
+}
+
+/// Pins that a repository nobody built for stays quiet
+///
+/// Whisker says nothing and compiles the source, as it did before any of
+/// this existed. A warning here would appear on every check of every
+/// project whose lints are not published.
+#[test]
+fn check_without_a_matching_asset_says_nothing() {
+    let server = FakeGitHub::start();
+    let cache = tempfile::tempdir().expect("temporary directory should be created");
+    let target = package(TODO_SOURCE);
+    configure_git_lint(target.path(), REMOTE, REV);
+    server.route(
+        RELEASES,
+        Answer::json(listing(&server, &["other.tar.gz", "other.tar.gz.sha256"])),
+    );
+
+    whisker_asking(&cache, server.url())
+        .arg("check")
+        .arg(target.path())
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains("warning: whisker cannot use").not());
+}
+
+/// Pins that a repository whisker cannot list is the same quiet case
+#[test]
+fn check_with_a_repository_the_api_does_not_know_says_nothing() {
+    let server = FakeGitHub::start();
+    let cache = tempfile::tempdir().expect("temporary directory should be created");
+    let target = package(TODO_SOURCE);
+    configure_git_lint(target.path(), REMOTE, REV);
+
+    whisker_asking(&cache, server.url())
+        .arg("check")
+        .arg(target.path())
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains("warning: whisker cannot use").not());
+}
+
+/// An archive that does not match its digest is not unpacked, and is said
+#[test]
+fn check_with_a_wrong_digest_warns() {
+    let server = FakeGitHub::start();
+    let cache = tempfile::tempdir().expect("temporary directory should be created");
+    let target = package(TODO_SOURCE);
+    configure_git_lint(target.path(), REMOTE, REV);
+    let name = publish(&server, &[fixture_library("digest_lint")]);
+    server.route(
+        &format!("/assets/{name}.sha256"),
+        Answer::text(format!("{}  {name}\n", "0".repeat(64))),
+    );
+
+    whisker_asking(&cache, server.url())
+        .arg("check")
+        .arg(target.path())
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains("warning: whisker cannot use"))
+        .stderr(predicate::str::contains("digest"));
+
+    assert!(
+        !cache.path().join("prebuilt").join("rules").exists(),
+        "nothing should have been kept"
+    );
+}
+
+/// An API that answers with a fault is worth saying, unlike a missing one
+#[test]
+fn check_with_a_failing_release_api_warns() {
+    let server = FakeGitHub::start();
+    let cache = tempfile::tempdir().expect("temporary directory should be created");
+    let target = package(TODO_SOURCE);
+    configure_git_lint(target.path(), REMOTE, REV);
+    server.route(RELEASES, Answer::failure(500));
+
+    whisker_asking(&cache, server.url())
+        .arg("check")
+        .arg(target.path())
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains("warning: whisker cannot use"))
+        .stderr(predicate::str::contains("500"));
+}
+
+/// A private repository answers only a request that carries a token
+#[test]
+fn check_with_a_token_sends_it_to_the_api() {
+    let server = FakeGitHub::start();
+    let cache = tempfile::tempdir().expect("temporary directory should be created");
+    let target = package(TODO_SOURCE);
+    configure_git_lint(target.path(), REMOTE, REV);
+    publish(&server, &[fixture_library("token_lint")]);
+
+    whisker_asking(&cache, server.url())
+        .env("GH_TOKEN", "a-secret")
+        .arg("check")
+        .arg(target.path())
+        .assert()
+        .success();
+
+    let carried = server
+        .seen()
+        .iter()
+        .filter(|seen| seen.header("authorization") == Some("Bearer a-secret"))
+        .count();
+
+    assert_eq!(carried, server.seen().len(), "{:?}", server.seen());
+}
+
+/// A remote the API does not answer for is never asked about
+///
+/// A project that keeps its lints in a repository somewhere else must not
+/// have that repository's name sent anywhere.
+#[test]
+fn check_with_a_remote_the_api_does_not_serve_asks_nothing() {
+    let server = FakeGitHub::start();
+    let cache = tempfile::tempdir().expect("temporary directory should be created");
+    let rules = repository_with_one_lint("unserved_lint", RULE);
+    let target = package(TODO_SOURCE);
+    configure_git_lint(target.path(), &rules.url(), rules.rev());
+
+    whisker_asking(&cache, server.url())
+        .arg("check")
+        .arg(target.path())
+        .assert()
+        .success()
+        .stderr(predicate::str::contains(format!("warning[{RULE}]")));
+
+    assert!(server.seen().is_empty(), "{:?}", server.seen());
+}
+
+/// Clones the fixture at `rules` into `destination`, detached at its commit
+///
+/// # Panics
+///
+/// Panics if git is unavailable or any step fails.
+fn clone_into(rules: &FixtureRepository, destination: &Path) {
+    let run = |arguments: &[&str], directory: &Path| {
+        let output = Command::new("git")
+            .args(arguments)
+            .current_dir(directory)
+            .env("GIT_CONFIG_GLOBAL", "/dev/null")
+            .env("GIT_CONFIG_SYSTEM", "/dev/null")
+            .output()
+            .unwrap_or_else(|error| panic!("git {arguments:?} should run: {error}"));
+
+        assert!(
+            output.status.success(),
+            "git {arguments:?} failed: {}",
+            String::from_utf8_lossy(&output.stderr)
+        );
+    };
+
+    let parent = destination.parent().expect("the path should have a parent");
+    std::fs::create_dir_all(parent).expect("the parent should be created");
+
+    let name = destination
+        .file_name()
+        .expect("the path should have a name")
+        .to_string_lossy()
+        .into_owned();
+
+    run(&["clone", "--quiet", &rules.url(), &name], parent);
+    run(
+        &["checkout", "--quiet", "--detach", rules.rev()],
+        destination,
+    );
+}
+
+/// Pins that whisker compiles a checkout it already holds, and asks nobody
+///
+/// Whisker once asked a release API before it looked at what it held. A
+/// project whose lints publish nothing then spent a request on every
+/// check, and stopped working away from a network.
+#[test]
+fn check_with_a_checkout_already_present_asks_nothing() {
+    let server = FakeGitHub::start();
+    let cache = tempfile::tempdir().expect("temporary directory should be created");
+    let rules = repository_with_one_lint("warm_lint", RULE);
+    let target = package(TODO_SOURCE);
+    configure_git_lint(target.path(), REMOTE, rules.rev());
+
+    // The first run cannot reach the remote, and fails. It leaves behind
+    // the directory whisker keeps that remote's checkouts in, and the
+    // run that matters needs a checkout there.
+    whisker_asking(&cache, server.url())
+        .arg("check")
+        .arg(target.path())
+        .assert()
+        .failure();
+    let remote = fetched_remote(&cache);
+    clone_into(
+        &rules,
+        &cache.path().join("git").join(&remote).join(rules.rev()),
+    );
+    let asked = server.seen().len();
+
+    whisker_asking(&cache, server.url())
+        .arg("check")
+        .arg(target.path())
+        .assert()
+        .success()
+        .stderr(predicate::str::contains(format!("warning[{RULE}]")));
+
+    assert_eq!(
+        server.seen().len(),
+        asked,
+        "the run should have asked nothing: {:?}",
+        server.seen()
+    );
 }

--- a/crates/whisker/tests/support/fake_github.rs
+++ b/crates/whisker/tests/support/fake_github.rs
@@ -1,0 +1,198 @@
+use std::collections::HashMap;
+use std::sync::{Arc, Mutex};
+use std::thread::JoinHandle;
+
+/// One answer the fake server is prepared to give
+#[derive(Clone, Eq, PartialEq, Debug)]
+pub struct Answer {
+    pub status: u16,
+    pub content_type: &'static str,
+    pub body: Vec<u8>,
+}
+
+impl Answer {
+    /// Returns a successful answer carrying `body` as JSON
+    pub fn json(body: impl Into<String>) -> Self {
+        Self {
+            status: 200,
+            content_type: "application/json",
+            body: body.into().into_bytes(),
+        }
+    }
+
+    /// Returns a successful answer carrying `body` as bytes
+    pub fn bytes(body: Vec<u8>) -> Self {
+        Self {
+            status: 200,
+            content_type: "application/octet-stream",
+            body,
+        }
+    }
+
+    /// Returns a successful answer carrying `body` as plain text
+    pub fn text(body: impl Into<String>) -> Self {
+        Self {
+            status: 200,
+            content_type: "text/plain",
+            body: body.into().into_bytes(),
+        }
+    }
+
+    /// Returns a failing answer with no body worth reading
+    pub fn failure(status: u16) -> Self {
+        Self {
+            status,
+            content_type: "text/plain",
+            body: Vec::new(),
+        }
+    }
+}
+
+/// What one request carried, as the server saw it
+#[derive(Clone, Eq, PartialEq, Debug)]
+pub struct Seen {
+    pub path: String,
+    pub headers: Vec<(String, String)>,
+}
+
+impl Seen {
+    /// Returns the value of `name`, whatever case the sender used
+    pub fn header(&self, name: &str) -> Option<&str> {
+        self.headers
+            .iter()
+            .find(|(header, _)| header.eq_ignore_ascii_case(name))
+            .map(|(_, value)| value.as_str())
+    }
+}
+
+/// A release API that answers from a table, and records what it was asked
+///
+/// The tests point whisker at this instead of at GitHub. It is a real
+/// server that speaks real HTTP, so the tests cover the client whisker
+/// ships rather than a stand-in.
+///
+/// A caller adds routes after the server listens. An answer carries the
+/// addresses of the assets it offers, and nobody knows those until the
+/// server has a port.
+pub struct FakeGitHub {
+    server: Arc<tiny_http::Server>,
+    url: String,
+    routes: Arc<Mutex<HashMap<String, Answer>>>,
+    seen: Arc<Mutex<Vec<Seen>>>,
+    thread: Option<JoinHandle<()>>,
+}
+
+impl FakeGitHub {
+    /// Starts a server on a port the operating system chooses
+    ///
+    /// # Panics
+    ///
+    /// Panics if no port can be bound.
+    pub fn start() -> Self {
+        let server = Arc::new(
+            tiny_http::Server::http("127.0.0.1:0").expect("the fake server should bind a port"),
+        );
+        let url = format!(
+            "http://{}",
+            server
+                .server_addr()
+                .to_ip()
+                .expect("the fake server should listen on a socket")
+        );
+
+        let routes: Arc<Mutex<HashMap<String, Answer>>> = Arc::new(Mutex::new(HashMap::new()));
+        let seen: Arc<Mutex<Vec<Seen>>> = Arc::new(Mutex::new(Vec::new()));
+
+        let thread = std::thread::spawn({
+            let server = Arc::clone(&server);
+            let routes = Arc::clone(&routes);
+            let seen = Arc::clone(&seen);
+
+            move || {
+                for request in server.incoming_requests() {
+                    let path = request
+                        .url()
+                        .split('?')
+                        .next()
+                        .unwrap_or_default()
+                        .to_owned();
+                    let headers = request
+                        .headers()
+                        .iter()
+                        .map(|header| {
+                            (
+                                header.field.as_str().as_str().to_owned(),
+                                header.value.as_str().to_owned(),
+                            )
+                        })
+                        .collect();
+
+                    seen.lock()
+                        .expect("the record should be available")
+                        .push(Seen {
+                            path: path.clone(),
+                            headers,
+                        });
+
+                    let answer = routes
+                        .lock()
+                        .expect("the routes should be available")
+                        .get(&path)
+                        .cloned()
+                        .unwrap_or_else(|| Answer::failure(404));
+
+                    let header = tiny_http::Header::from_bytes(
+                        &b"Content-Type"[..],
+                        answer.content_type.as_bytes(),
+                    )
+                    .expect("the content type should be a header");
+
+                    let _ = request.respond(
+                        tiny_http::Response::from_data(answer.body)
+                            .with_status_code(answer.status)
+                            .with_header(header),
+                    );
+                }
+            }
+        });
+
+        Self {
+            server,
+            url,
+            routes,
+            seen,
+            thread: Some(thread),
+        }
+    }
+
+    /// Returns the base address to point whisker at
+    pub fn url(&self) -> &str {
+        &self.url
+    }
+
+    /// Answers `path` with `answer` from now on
+    pub fn route(&self, path: &str, answer: Answer) {
+        self.routes
+            .lock()
+            .expect("the routes should be available")
+            .insert(path.to_owned(), answer);
+    }
+
+    /// Returns every request the server has seen, in order
+    pub fn seen(&self) -> Vec<Seen> {
+        self.seen
+            .lock()
+            .expect("the record should be available")
+            .clone()
+    }
+}
+
+impl Drop for FakeGitHub {
+    fn drop(&mut self) {
+        self.server.unblock();
+
+        if let Some(thread) = self.thread.take() {
+            let _ = thread.join();
+        }
+    }
+}


### PR DESCRIPTION
Whisker can load prebuilt lint libraries, but it has no way to obtain them. This change adds the missing half.

Whisker asks a release API for an archive when a lint source sits on a remote that the API answers for. The archive name holds the pinned commit and whisker's own tag. Whisker checks the archive against the digest published beside it, unpacks it, and keeps it.

The name is the whole protocol. A publisher builds lints against a whisker and writes that whisker's tag into the file name. To find a file is therefore the same question as to fit the binary. Whisker asks one repository once per source. It reads the first page of releases and takes the first release that carries both the archive and its digest.

Whisker asks only when the machine holds nothing better. Libraries that whisker already unpacked win outright. A checkout that is already present comes next, because cargo compiled it before. A network request in front of a run that needs none breaks every check away from a network. A project with a warm checkout therefore keeps compiling it, even after its rules start to publish archives. A user moves the pin or clears the cache to pick those up.

Every failure falls back to a source build. That is what whisker did before, and it is never wrong. What differs is whether the user hears about it. A repository with no matching archive is the ordinary case for a project that publishes no lints, so whisker stays silent. A warning there would greet most projects on every check. An API that answers with a fault, a download that fails its digest, and an archive that whisker cannot unpack each earn one line on stderr.

The digest guards against a truncated or corrupted download and nothing more, because the same party publishes the archive and the digest. The handshake is what makes the libraries safe to load. The unpack takes only regular files at the archive root. That single rule also stops an entry that climbs out of the directory, and an entry that is a symbolic link. Whisker limits how much it reads from a listing, a digest file, and an archive, so a server cannot answer with an endless body.

The exchange runs on a thread of its own. The HTTP client owns an asynchronous runtime, and the program panics when it drops one runtime inside another one.

The tests serve the release API from a real local server, so they cover the client that whisker ships. They also remove a token and an API address from whisker's environment before each run. Neither value belongs near a fixture remote.


---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>