### PR TITLE
Document installation and prebuilt lints

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -119,6 +119,60 @@ revalidated against the remote, which is what keeps the network out of the
 common path. Only a git entry builds with `--locked`: the pin is worth
 what the lockfile behind it is worth.
 
+Resolving an entry and loading it are separate stages. Every entry is
+resolved before any of them is compiled, so a typo in the second entry
+surfaces before the first one's five-minute build, and everything that
+reaches the network happens there rather than between two compilations.
+
+## Prebuilt lints
+
+Compiling a repository of rules costs a toolchain and several minutes, in
+every project and on every build agent pinning the same commit. It is
+also the step a released whisker binary usually cannot take at all: the
+handshake accepts a plugin only from the rustc that built whisker, and
+whoever downloaded the binary does not have that toolchain.
+
+So a git entry is offered prebuilt libraries first. Whisker asks the
+remote's releases for an archive named `<rev>-<tag>.tar.gz`, where the tag
+is the one `whisker abi` prints: a digest of every value the handshake
+compares, followed by the target triple the build script baked in.
+
+The tag is what makes this safe by construction. It covers exactly what
+the handshake covers, so an archive published under a whisker's tag passes
+that whisker's handshake, and a whisker nobody built for finds no file
+rather than downloading one and being refused. A library that arrives
+prebuilt and then fails the handshake is therefore not a reason to fall
+back — it means the archive was published under a tag that does not
+describe it, and compiling the source instead would hide that from
+everyone else who trusts the tag. It ends the run and names the directory
+to delete.
+
+The archive is checked against a `.sha256` published beside it, then
+unpacked into
+`<cache>/prebuilt/<remote>/<rev>/<tag>/`, staged and renamed the way a
+checkout is. `<remote>` is spelled exactly as it is under `<cache>/git/`,
+because both layouts derive it from the same function. Only regular files
+at the archive's root are unpacked, which is one rule doing three jobs: it
+skips what whisker has no use for, and an entry cannot climb out of the
+directory or plant a symbolic link without failing it.
+
+The digest guards against a truncated or corrupted download. It is
+published by the same party as the archive, so it establishes nothing
+about trust; the handshake does that, and configuring a repository of
+lints is already a decision to run its code.
+
+Everything past the cache is best effort, because compiling the source is
+always available and always correct. What varies is whether the reader
+hears about it. A remote the API does not serve, a repository it will not
+list, and a release with nothing named for this whisker are all the
+ordinary case for a project nobody publishes lints for, so whisker is
+silent; warning there would greet most projects on every check. An API
+that answers with a fault, a digest that does not match, and an archive
+that will not unpack each earn one line on stderr.
+
+The exchange runs on a thread of its own, because the HTTP client owns an
+asynchronous runtime and dropping one inside another panics.
+
 A directory may hold one package or a workspace of them, and every dynamic
 library the build produces is loaded and handshaken separately. That is
 what lets a repository of rules arrive through a single entry rather than

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -126,52 +126,51 @@ reaches the network happens there rather than between two compilations.
 
 ## Prebuilt lints
 
-Compiling a repository of rules costs a toolchain and several minutes, in
-every project and on every build agent pinning the same commit. It is
-also the step a released whisker binary usually cannot take at all: the
-handshake accepts a plugin only from the rustc that built whisker, and
-whoever downloaded the binary does not have that toolchain.
+A git entry can arrive as libraries that its publisher compiled, and
+whisker looks for those before it compiles the source. It asks the
+remote's releases for an archive named `<rev>-<tag>.tar.gz`, where the
+tag is the one `whisker abi` prints: a digest of every value the
+handshake compares, followed by the target triple the build script baked
+in.
 
-So a git entry is offered prebuilt libraries first. Whisker asks the
-remote's releases for an archive named `<rev>-<tag>.tar.gz`, where the tag
-is the one `whisker abi` prints: a digest of every value the handshake
-compares, followed by the target triple the build script baked in.
+Compiling costs a toolchain and several minutes, in every project and on
+every build agent that pins the same commit. A released whisker binary
+also cannot compile lints on most machines. The handshake accepts a
+library only from the rustc that built whisker, and whoever downloaded
+the binary does not have that rustc.
 
-The tag is what makes this safe by construction. It covers exactly what
-the handshake covers, so an archive published under a whisker's tag passes
-that whisker's handshake, and a whisker nobody built for finds no file
-rather than downloading one and being refused. A library that arrives
-prebuilt and then fails the handshake is therefore not a reason to fall
-back — it means the archive was published under a tag that does not
-describe it, and compiling the source instead would hide that from
-everyone else who trusts the tag. It ends the run and names the directory
-to delete.
+The tag covers what the handshake covers. An archive published under a
+whisker's tag passes that whisker's handshake, and a whisker nobody built
+for finds no file. A prebuilt library that fails the handshake ends the
+run and names the directory to delete. The publisher named the archive
+with a tag that does not describe it, and a source build would hide that
+from everyone who trusts the tag.
 
-The archive is checked against a `.sha256` published beside it, then
-unpacked into
-`<cache>/prebuilt/<remote>/<rev>/<tag>/`, staged and renamed the way a
-checkout is. `<remote>` is spelled exactly as it is under `<cache>/git/`,
-because both layouts derive it from the same function. Only regular files
-at the archive's root are unpacked, which is one rule doing three jobs: it
-skips what whisker has no use for, and an entry cannot climb out of the
-directory or plant a symbolic link without failing it.
+Whisker checks the archive against the `.sha256` published beside it,
+then unpacks it into `<cache>/prebuilt/<remote>/<rev>/<tag>/`, staged
+and renamed the way a checkout is. Both layouts derive `<remote>` from
+the same function, so it is spelled the same under `<cache>/git/`.
+Whisker unpacks only regular files at the archive's root. That one rule
+skips what whisker has no use for, keeps every entry inside the
+directory, and refuses a symbolic link.
 
-The digest guards against a truncated or corrupted download. It is
-published by the same party as the archive, so it establishes nothing
-about trust; the handshake does that, and configuring a repository of
-lints is already a decision to run its code.
+The digest catches a truncated or corrupted download. The same publisher
+writes the archive and the digest, so it establishes nothing about trust.
+The handshake does that, and a configured repository of lints already
+runs its code in whisker's process.
 
-Everything past the cache is best effort, because compiling the source is
-always available and always correct. What varies is whether the reader
-hears about it. A remote the API does not serve, a repository it will not
-list, and a release with nothing named for this whisker are all the
-ordinary case for a project nobody publishes lints for, so whisker is
-silent; warning there would greet most projects on every check. An API
-that answers with a fault, a digest that does not match, and an archive
-that will not unpack each earn one line on stderr.
+A missing archive never fails a check, because the source build is always
+available. Whisker is silent when the remote is not on GitHub, when the
+API answers 404, and when no release names an archive for this whisker.
+That is the ordinary case for a project whose rules nobody publishes
+prebuilt, and a warning there would appear on most projects on every
+check. Three failures print one line on stderr before whisker compiles
+the source: an API it cannot reach or that answers with an error, a
+digest that does not match, and an archive that will not unpack.
 
-The exchange runs on a thread of its own, because the HTTP client owns an
-asynchronous runtime and dropping one inside another panics.
+The exchange with the API runs on a thread of its own. The HTTP client
+owns an asynchronous runtime, and a runtime dropped inside another
+panics.
 
 A directory may hold one package or a workspace of them, and every dynamic
 library the build produces is loaded and handshaken separately. That is

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,8 +16,22 @@ and this project adheres to
   directory, and whisker fetches that commit into a cache before building it.
   A configured directory may also hold a cargo workspace, in which case every
   plugin it builds is loaded.
+- Whisker looks for prebuilt lints before it compiles a git entry. It asks the
+  repository's releases for an archive named after the commit and after this
+  binary's tag, checks it against the digest published beside it, and loads
+  what it unpacks. Every library still completes the plugin handshake. A
+  repository that publishes nothing for this whisker is compiled from source
+  as before, and whisker says nothing about it.
+- `whisker abi` prints the tag that names which prebuilt lints this binary can
+  load. Whoever publishes lints writes it into the name of each archive.
+- Every release carries an archive of the whisker binary for Linux on x86-64
+  and arm64, and for macOS on Apple silicon, with a SHA-256 digest beside it.
 
 ### Changed
+
+- Whisker lists its subcommands in a stable order. The order used to come from
+  however the linker laid out the command registry, so two builds could print
+  two different orders.
 
 - Whisker's own rules moved to [whisker-aonyx-rules][rules]. A project that
   ran them from `lints/` now names that repository and a commit.
@@ -27,6 +41,9 @@ and this project adheres to
 
 ### Removed
 
+- The workflow that published to crates.io is gone. It called a recipe this
+  repository never had, and every crate here sets `publish = false`, so it
+  could not have worked. Releases carry binaries instead.
 - Whisker no longer reads `.whisker.toml`. The configuration file is
   `.config/whisker.toml`, and a project that keeps the old name has to move
   it. Whisker does not report the old file, so a project that misses this

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,21 +17,20 @@ and this project adheres to
   A configured directory may also hold a cargo workspace, in which case every
   plugin it builds is loaded.
 - Whisker looks for prebuilt lints before it compiles a git entry. It asks the
-  repository's releases for an archive named after the commit and after this
-  binary's tag, checks it against the digest published beside it, and loads
-  what it unpacks. Every library still completes the plugin handshake. A
-  repository that publishes nothing for this whisker is compiled from source
-  as before, and whisker says nothing about it.
-- `whisker abi` prints the tag that names which prebuilt lints this binary can
-  load. Whoever publishes lints writes it into the name of each archive.
+  repository's releases for an archive named after the commit and this
+  binary's tag. It checks the digest published beside the archive and loads
+  the libraries it unpacks. Every library still completes the plugin
+  handshake. A repository that publishes nothing for this whisker compiles
+  from source as before, and whisker says nothing about it.
+- `whisker abi` prints the tag that names which prebuilt lints this binary
+  loads. A publisher writes it into the name of each archive.
 - Every release carries an archive of the whisker binary for Linux on x86-64
   and arm64, and for macOS on Apple silicon, with a SHA-256 digest beside it.
 
 ### Changed
 
-- Whisker lists its subcommands in a stable order. The order used to come from
-  however the linker laid out the command registry, so two builds could print
-  two different orders.
+- Whisker lists its subcommands in a stable order. The linker used to decide
+  the order, so two builds could print two different orders.
 
 - Whisker's own rules moved to [whisker-aonyx-rules][rules]. A project that
   ran them from `lints/` now names that repository and a commit.
@@ -41,9 +40,8 @@ and this project adheres to
 
 ### Removed
 
-- The workflow that published to crates.io is gone. It called a recipe this
-  repository never had, and every crate here sets `publish = false`, so it
-  could not have worked. Releases carry binaries instead.
+- The workflow that published to crates.io is gone. Every crate here sets
+  `publish = false`, so it never worked. Releases carry binaries.
 - Whisker no longer reads `.whisker.toml`. The configuration file is
   `.config/whisker.toml`, and a project that keeps the old name has to move
   it. Whisker does not report the old file, so a project that misses this

--- a/README.md
+++ b/README.md
@@ -30,14 +30,14 @@ tar -xzf whisker-0.1.0-aarch64-apple-darwin.tar.gz
 The archive holds the binary, both licenses, and this README. Move
 `whisker` to a directory on your `PATH`, such as `~/.local/bin`.
 
-Whisker also builds from source. It pins a nightly toolchain in
-`rust-toolchain.toml`, which rustup installs for you:
+Whisker also builds from source. `rust-toolchain.toml` pins a nightly
+toolchain, and rustup installs it during the build:
 
 ```bash
 cargo install --git https://github.com/aonyx-ai/whisker --locked whisker
 ```
 
-Which of the two you use decides how your custom lints are obtained. See
+The choice decides how whisker obtains your custom lints. See
 [custom lints](#custom-lints).
 
 ## Usage
@@ -126,47 +126,39 @@ as long as any Rust compilation; afterwards cargo's cache makes it cheap.
 
 #### Prebuilt lints
 
-A repository can publish its rules already compiled, and whisker prefers
-those to compiling them itself. Before it builds a git entry, whisker asks
-that repository's releases for an archive named after the pinned commit
-and after this binary's own tag, which `whisker abi` prints:
+A repository can publish its rules already compiled, and whisker loads
+those before it compiles anything. Before it builds a git entry, whisker
+asks that repository's releases for an archive. The archive is named
+after the pinned commit and after the tag that `whisker abi` prints. If a
+release carries that archive and the `.sha256` beside it, whisker
+downloads it and checks the digest. It then unpacks the archive into the
+cache and loads the libraries. Each library still completes the handshake
+described below, and one that fails it ends the run.
 
-```bash
-whisker abi
-```
+Whisker asks a release only when the cache holds nothing for the entry.
+Libraries it unpacked before come first, then a checkout it compiled
+before. A project with a cached checkout therefore keeps compiling it
+after its rules start to publish archives. Move the pin or clear the
+cache to pick the archives up.
 
-If a release carries that archive and the `.sha256` beside it, whisker
-downloads it, checks the digest, unpacks it into its cache, and loads the
-libraries. The cache is `WHISKER_CACHE_DIR` when you set it, and
-`~/.cache/whisker` otherwise. A library that arrives this way still
-completes the same handshake described below, and one that fails it ends
-the run.
-
-Whisker asks only when it holds nothing better. Libraries it already
-unpacked come first, and a checkout already in the cache comes next.
-Cargo compiled that checkout before, and a run that needs no network
-should not make one. A project with a warm checkout therefore keeps
-compiling it, even after its rules start to publish archives. Move the
-pin or clear the cache to pick those up.
-
-Everything else falls back to a source build, which is what whisker did
-before any of this existed. A repository that publishes nothing for your
-tag is the ordinary case and whisker says nothing about it; a download
-that fails or a digest that does not match earns one line on stderr.
+A repository that publishes nothing for your tag is the ordinary case,
+and whisker compiles the source and says nothing. A download that fails
+or a digest that does not match prints one line on stderr, and whisker
+compiles the source.
 
 Set `GH_TOKEN` or `GITHUB_TOKEN` to reach a private repository, and
 `WHISKER_GITHUB_API_URL` to point whisker at a GitHub Enterprise
-installation. Whisker sends a token only to the API it was pointed at.
+installation. Whisker sends the token only to that API.
 
-The digest guards against a download that arrived truncated or corrupted.
-It is published by whoever publishes the archive, so it says nothing about
-whether that archive deserves your trust. Configuring a repository of
-lints is already a decision to run its code.
+The digest proves that the download arrived intact. The same publisher
+writes the archive and the digest, so the digest establishes no trust in
+the publisher. A repository you configure runs its code in whisker's
+process, prebuilt or compiled.
 
-This is also why a whisker you downloaded and a lint crate you compile
-yourself rarely fit. The handshake below accepts a plugin only from the
-rustc that built whisker, and a released binary was built with the pinned
-nightly. Either install that toolchain, or build whisker from source.
+A released whisker accepts only a library built by the nightly that
+built it. To compile a lint crate for one yourself, install the toolchain
+that `rust-toolchain.toml` names at the release's commit. Otherwise build
+whisker from source and compile the lint crate with the same toolchain.
 
 A custom lint crate is a `cdylib` that implements `RustLintPass` and hands
 its rules to `export_lints!`. The complete crate in

--- a/README.md
+++ b/README.md
@@ -15,6 +15,31 @@ from tree-sitter's Rust grammar. Type-dependent rules use
 
 Whisker is in early development. Check back soon.
 
+## Installation
+
+Every release carries an archive for Linux on x86-64 and arm64, and for
+macOS on Apple silicon. Download the one for your platform from the
+[releases page][releases], check it against the `.sha256` beside it, and
+unpack it:
+
+```bash
+shasum -a 256 -c whisker-0.1.0-aarch64-apple-darwin.tar.gz.sha256
+tar -xzf whisker-0.1.0-aarch64-apple-darwin.tar.gz
+```
+
+The archive holds the binary, both licenses, and this README. Move
+`whisker` to a directory on your `PATH`, such as `~/.local/bin`.
+
+Whisker also builds from source. It pins a nightly toolchain in
+`rust-toolchain.toml`, which rustup installs for you:
+
+```bash
+cargo install --git https://github.com/aonyx-ai/whisker --locked whisker
+```
+
+Which of the two you use decides how your custom lints are obtained. See
+[custom lints](#custom-lints).
+
 ## Usage
 
 ```bash
@@ -99,6 +124,50 @@ libraries, and runs their lints. Whisker ships no rules of its own, so the
 rules a project configures are exactly the rules it runs. The first build takes
 as long as any Rust compilation; afterwards cargo's cache makes it cheap.
 
+#### Prebuilt lints
+
+A repository can publish its rules already compiled, and whisker prefers
+those to compiling them itself. Before it builds a git entry, whisker asks
+that repository's releases for an archive named after the pinned commit
+and after this binary's own tag, which `whisker abi` prints:
+
+```bash
+whisker abi
+```
+
+If a release carries that archive and the `.sha256` beside it, whisker
+downloads it, checks the digest, unpacks it into its cache, and loads the
+libraries. The cache is `WHISKER_CACHE_DIR` when you set it, and
+`~/.cache/whisker` otherwise. A library that arrives this way still
+completes the same handshake described below, and one that fails it ends
+the run.
+
+Whisker asks only when it holds nothing better. Libraries it already
+unpacked come first, and a checkout already in the cache comes next.
+Cargo compiled that checkout before, and a run that needs no network
+should not make one. A project with a warm checkout therefore keeps
+compiling it, even after its rules start to publish archives. Move the
+pin or clear the cache to pick those up.
+
+Everything else falls back to a source build, which is what whisker did
+before any of this existed. A repository that publishes nothing for your
+tag is the ordinary case and whisker says nothing about it; a download
+that fails or a digest that does not match earns one line on stderr.
+
+Set `GH_TOKEN` or `GITHUB_TOKEN` to reach a private repository, and
+`WHISKER_GITHUB_API_URL` to point whisker at a GitHub Enterprise
+installation. Whisker sends a token only to the API it was pointed at.
+
+The digest guards against a download that arrived truncated or corrupted.
+It is published by whoever publishes the archive, so it says nothing about
+whether that archive deserves your trust. Configuring a repository of
+lints is already a decision to run its code.
+
+This is also why a whisker you downloaded and a lint crate you compile
+yourself rarely fit. The handshake below accepts a plugin only from the
+rustc that built whisker, and a released binary was built with the pinned
+nightly. Either install that toolchain, or build whisker from source.
+
 A custom lint crate is a `cdylib` that implements `RustLintPass` and hands
 its rules to `export_lints!`. The complete crate in
 [`examples/custom_lint`][example] is the template: a `Cargo.toml` declaring
@@ -119,6 +188,7 @@ in step with the whisker you build against, the way
 [`examples/custom_lint`][example] does.
 
 [example]: examples/custom_lint
+[releases]: https://github.com/aonyx-ai/whisker/releases
 
 ## License
 


### PR DESCRIPTION
Whisker now ships binaries, and it loads lints that a publisher built. Neither fact appears anywhere a user reads.

The README gains an installation section, and the custom lints section gains the prebuilt path. It states what whisker asks a release for, what it does with the answer, which variables reach a private repository, and what the digest beside an archive proves. It also states that a released whisker accepts only a library built by the nightly that built it, and what to do about that.

ARCHITECTURE derives the tag from what the handshake compares, so a whisker nobody built for finds no file. It also explains why a prebuilt library that fails the handshake ends the run, and which failures print a warning.

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>
