### PR TITLE
Build release archives for a prerelease too

### DIFF
--- a/.github/workflows/release-binaries.yml
+++ b/.github/workflows/release-binaries.yml
@@ -3,7 +3,12 @@ name: Release binaries
 
 "on":
   release:
-    types: [released]
+    # `published` fires once, for a release and for a prerelease alike.
+    # `released` would skip a prerelease entirely, which is the one kind
+    # of release worth building binaries for before anyone depends on
+    # them. It also fires a second time when a prerelease is promoted,
+    # and the archives from the first run are still the right ones.
+    types: [published]
 
 permissions: {}
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,8 @@ and this project adheres to
   loads. A publisher writes it into the name of each archive.
 - Every release carries an archive of the whisker binary for Linux on x86-64
   and arm64, and for macOS on Apple silicon, with a SHA-256 digest beside it.
+  A prerelease carries them too, so a release can be tried before anyone
+  depends on it.
 
 ### Changed
 

--- a/justfile
+++ b/justfile
@@ -85,11 +85,17 @@ package-whisker version target:
     # The tag names the version, and `Cargo.toml` names it too. A tag that
     # disagrees would ship an archive whose name promises a version the
     # binary does not report, so the disagreement stops the release here.
+    #
+    # A prerelease tag such as `v0.1.0-rc.1` carries a suffix that the
+    # crate version never holds, and the binary reports `0.1.0` whatever
+    # the suffix says. The comparison therefore drops the suffix, while
+    # the archive keeps the whole tag in its name.
+    release="${version%%-*}"
     pinned="$(cargo pkgid -p whisker)"
     pinned="${pinned##*#}"
     pinned="${pinned##*@}"
-    if [ "${version}" != "${pinned}" ]; then
-        echo "the tag names version ${version}, but Cargo.toml holds ${pinned}" >&2
+    if [ "${release}" != "${pinned}" ]; then
+        echo "the tag names version ${release}, but Cargo.toml holds ${pinned}" >&2
         exit 1
     fi
 


### PR DESCRIPTION
The release workflow listened for the `released` event, which GitHub does not fire for a prerelease. Publishing `v0.1.0-rc.1` would have created the release, attached no archives, and left no failed run to explain why.

This change listens for `published` instead. That event fires once for a release, and once for a prerelease. A release can therefore run on all three runners before anyone depends on it. A promotion from prerelease to release fires nothing further, and the archives from the first run stay correct, because neither the tag nor the commit moves.

The packaging recipe also refused such a tag. It compares the tag against the version in `Cargo.toml`, and a prerelease tag carries a suffix that a crate version never holds. The comparison now drops that suffix, and the archive keeps the whole tag in its name. A tag that names another version still stops the release.
