### PR TITLE
Build this repository's rules with this repository's toolchain

### DIFF
--- a/justfile
+++ b/justfile
@@ -157,5 +157,17 @@ test-fixture-lint:
 # once an integration test, but a test that reaches the network belongs in a
 # recipe a person can choose to run, not in `cargo test`.
 check-self:
+    #!/usr/bin/env -S bash -euo pipefail
     cargo build --release -p whisker
-    ./target/release/whisker check .
+
+    # The rules repository pins a toolchain of its own, and whisker's may
+    # move ahead of it. Rustup would then build those rules with their
+    # toolchain, and the handshake would refuse plugins that whisker had
+    # just built. Whisker passes its environment to the cargo it runs, so
+    # naming the toolchain here builds them with this repository's.
+    #
+    # This belongs to the recipe and not to whisker. Whisker has no business
+    # overriding the toolchain a plugin author chose; the two pins are
+    # coupled only because both repositories are ours.
+    RUSTUP_TOOLCHAIN="$(rustup show active-toolchain | cut -d" " -f1)" \
+        ./target/release/whisker check .


### PR DESCRIPTION
The rules repository pins a toolchain of its own, and whisker's can move ahead of it. Rustup honors the `rust-toolchain.toml` beside the package it builds, so `check-self` compiled those rules with their toolchain, and the handshake then refused the plugins it had just built.

Renovate PR #319 fails in exactly this way. It moves whisker to `nightly-2026-09-02`, and `check-self` then reports that the plugin was built by `rustc 1.99.0-nightly (12c36e253 2026-08-10)` while whisker was built by `rustc 1.100.0-nightly (5db7f4be8 2026-09-01)`.

Whisker passes its environment to the cargo it runs, so this recipe names the toolchain, and the rules build with this repository's. No code changes.

The fix belongs to the recipe rather than to whisker. Whisker has no business overriding the toolchain a plugin author chose, because that would make their pin decorative and would compile their code with a toolchain they never tested. The two pins here are coupled only because both repositories are ours, and only `check-self` spans them.

After this lands, #319 needs a rebase. Its CI is the real proof, because it holds the only genuine toolchain mismatch.
