### PR TITLE
Describe the platform as it is built

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -1,246 +1,334 @@
 # Architecture
 
-Whisker is a language-agnostic linting platform built on [tree-sitter][ts].
-It ships no rules of its own; Aonyx's live in
+Whisker is a linting platform built on [tree-sitter][ts]. It lints Rust
+today. Whisker ships no rules of its own. Aonyx's rules live in
 [whisker-aonyx-rules][rules] and cover what Clippy does not, like derive
 ordering and wildcard match arms.
 
-This document describes the shape of the platform. Individual crates
-document their own APIs, and each lint crate documents its own rule.
+This document describes the shape of the platform. Each crate documents
+its own API, and each lint crate documents its own rule.
 
 ## The core idea
 
-Most of what a lint needs to know is syntactic, and syntax is cheap: a
-tree-sitter grammar parses any source file in isolation, without a
-toolchain, a build, or even a valid project. Some lints, however, need
-semantic facts a syntax tree cannot supply — "is this match scrutinee an
-enum?", "does this function return `Result`?" — and semantics is
-expensive, requiring a real toolchain with knowledge of the whole project.
+Most of what a lint needs to know is syntactic, and syntax is cheap. A
+tree-sitter grammar parses a source file in isolation, without a
+toolchain, a build, or a valid project. Some lints need semantic facts a
+syntax tree cannot supply. Is this match scrutinee an enum? Does this
+function return `Result`? Semantics is expensive, because it needs a real
+toolchain with knowledge of the whole project.
 
-Whisker separates the two. The platform parses files with tree-sitter and
-walks the syntax tree through lint rules. Semantic information enters only
-as **decorations**: annotations a language provider computes up front and
-attaches to individual syntax nodes. Rules read decorations off the tree;
-they never talk to a toolchain themselves.
+Whisker keeps the two apart. The platform parses files with tree-sitter
+and walks the syntax tree through lint rules. Semantic information enters
+as **decorations**: typed values that a language provider computes up
+front and attaches to individual syntax nodes. Rules read decorations off
+the tree and never talk to a toolchain themselves.
 
-That split is what keeps rules cheap. A rule is a pure function of a
-decorated tree, so it can be tested against hand-constructed decorations
-rather than a real toolchain, while still making type-aware decisions.
+That split keeps rules cheap. A rule is a function of a decorated tree. A
+test can therefore give it decorations it built itself, and the rule still
+makes type-aware decisions.
 
 ## The pipeline
 
-Every file flows through four stages:
+The check command runs three stages for every file and one for the run:
 
 ```mermaid
 flowchart LR
     src[source file] --> parse[parse<br>tree-sitter]
     parse --> decorate[decorate]
-    lp[language provider] --> decorate
+    lp[decoration provider] --> decorate
     decorate --> execute[execute<br>lint passes]
-    execute --> report[report]
+    execute --> report[report<br>once per run]
 ```
 
-1. **Parse.** The file is parsed with the tree-sitter grammar for its
-   language, detected from the file extension. The tree, its source text,
-   and an empty decoration map together form a decorated tree.
-2. **Decorate.** Each registered provider inspects the tree and records
-   decorations against individual nodes. This is the only stage that
-   touches a language toolchain.
+1. **Parse.** The command builds one parser, fixed to the Rust grammar,
+   before it visits any file. A file's extension decides whether discovery
+   collects it. The tree, its source text, and an empty decoration map
+   together form a decorated tree.
+2. **Decorate.** The pipeline offers the tree to every provider. A provider
+   either covers the file and returns its decorations, or declines it with
+   a reason. This is the only stage that touches a language toolchain.
+   Decorations merge in provider order, and the first decoration of a type
+   on a node is the one rules see.
 3. **Execute.** A depth-first walk over the named nodes offers every node
    to every lint pass and collects the diagnostics they return.
-4. **Report.** Diagnostics render to stderr with spans, supporting
-   annotations, and suggested fixes.
+4. **Report.** After the last file, the command renders every diagnostic to
+   stderr with its span, its supporting annotations, and its suggested
+   fixes.
 
-The pipeline is synchronous and per-file. There is no scheduling, caching,
-or parallelism yet.
+The pipeline is synchronous and handles one file at a time. The command
+loads the provider once per run and constructs a fresh set of lint passes
+for every file, because passes hold state.
+
+### Coverage
+
+A file that no provider covers is an error. Whisker runs no rule on it,
+syntactic rules included, because a clean result would hide code that no
+rule inspected. A provider declines a file for one of four reasons. The
+file sits outside the root the provider loaded, no crate reaches it, the
+toolchain excluded it, or its text differs from the toolchain's copy. The
+command prints one `help:` line per reason across the whole
+run, after the per-file errors. The run then fails. With `--keep-going`,
+the walk continues past the file and still exits non-zero.
+
+Discovery decides which files reach the pipeline. It walks the target the
+way git and ripgrep do, honors every ignore file, and applies the `ignore`
+patterns from the configuration. The README describes those rules.
 
 ## Language support
 
-A language plugs into the platform at two seams.
+A language plugs into the platform at two points: a lint pass trait that
+whisker generates, and a decoration provider that talks to the toolchain.
 
-The first is its **lint pass trait**, which is generated rather than
-written. A tree-sitter grammar ships a machine-readable description of its
-node types, and whisker turns that into a trait with one method per node
-kind, plus the dispatch that routes a node to the right method. Rules
-therefore hook the constructs they care about by name instead of matching
-on kind strings, the trait cannot drift from the grammar, and a grammar
-update that renames a node breaks compilation at the rules that used it.
-Grammars also group node kinds into supertypes, so a rule can hook every
-expression at once rather than each expression kind in turn.
+### The lint pass trait
 
-The second is its **decoration provider**, the bridge to a real toolchain.
-Rust's is backed by [rust-analyzer][ra] used as a library: it loads the
-target workspace once, then resolves the handful of node positions the
-lints ask about — function signatures, match scrutinees, and similar — and
-records what it finds. The provider and the syntax tree keep separate
-representations of the same file, so byte offsets are what tie them
-together.
+A tree-sitter grammar ships a machine-readable description of its node
+types. Whisker keeps a copy of Rust's at
+`crates/whisker-rust/src/node-types.json`. A build script generates from
+it a trait with one method per named node kind, plus the dispatch that
+routes a node to its method. Rules hook the constructs they care
+about by name. Grammars also group node kinds into supertypes, so a rule
+can hook every expression at once.
 
-Decorations are typed values rather than strings, and each decoration type
-declares whether a provider records it at most once per node or
-repeatedly. Because that choice travels with the type, a rule that reads a
-repeated decoration as though it were singular fails to compile.
+The copy tracks the grammar by hand. A grammar update changes the trait
+once someone refreshes the copy, and a renamed node then breaks
+compilation at every rule that hooked it. Until the refresh, the parser
+and the trait describe different grammars, and a rule that hooked the old
+name stops firing.
+
+### The decoration provider
+
+Rust's provider uses [rust-analyzer][ra] as a library. The command loads
+it once per run. The load discovers the Cargo manifest nearest the checked
+path, resolves that workspace, runs its build scripts, and builds the
+analysis database. A `whisker check` therefore needs a Cargo project, and it
+executes that project's build scripts before it lints anything. The load
+enables the `test` cfg, so code under `#[cfg(test)]` resolves like any
+other code. It runs no proc-macro server, so code that a proc macro
+produces receives no decorations.
+
+For every file it covers, the provider resolves a fixed set of node kinds.
+Those are function items, match scrutinees, else branches, the operand of
+`?`, and use declarations. It records what it finds as decorations: function
+signatures, resolved types, ADT flags, and import sources. The set belongs
+to the provider, and a rule that needs a decoration on another node kind
+needs a change to whisker-rust.
+
+The provider and the syntax tree keep separate parses of the same file, so
+byte offsets tie them together. The provider compares the text the
+database holds with the text the pipeline parsed, and declines the file
+when they differ.
+
+The rust-analyzer stack sits behind the crate's default `provider`
+feature. A lint crate switches it off and depends on the generated trait,
+the adapter, and the decoration types alone.
+
+### Decorations
+
+Decorations are typed values. Each type declares whether a provider
+records it at most once per node or repeatedly, and the declaration
+travels with the type. A rule that reads a decoration through `get`
+receives an `Option` or a `Vec` as the type dictates. The plain
+`decoration` accessor stays available and checks nothing.
+
+The decoration map recovers a value by a name-based key: the type's module
+path, its name, and a hash of its definition. `TypeId` cannot serve,
+because it differs between separately compiled crate graphs, and a plugin
+is one.
 
 ## Lint rules
 
-Each rule is its own crate implementing its language's generated trait,
-emitting diagnostics with a stable rule ID and a severity. Rules are
-linked into the CLI explicitly, so a lint runs only when it has been
-deliberately enabled.
+A rule implements the generated trait and emits diagnostics with a stable
+rule ID and a severity. Rules ship in lint crates. `export_lints!` takes a
+list, so one crate can carry several rules, and Aonyx keeps one rule per
+crate. Whisker links no rules itself. A check runs exactly the rules its
+configured sources export, and the configuration has no switch for one
+rule inside a source.
 
-Rules that depend on decorations **fail open**: when a decoration is
-missing — the provider could not resolve the type, or no provider ran —
-the rule stays silent rather than guessing. Whisker would rather miss a
-finding in code it cannot analyze than report one it cannot justify.
+Rules that depend on decorations **fail open**. A decoration is only ever
+evidence. Where a decoration is the reason to report, a missing one keeps
+the rule silent. Where a decoration would exempt the code, a missing one
+leaves the diagnostic standing. Whisker prefers a missed finding to a
+finding it cannot justify.
 
 ## Custom lints
 
-A target project can configure lint crates of its own, and `whisker
-check` compiles each one at check time, loads the built dynamic library,
-and runs the exported rules. There is nothing else to run: whisker links
-no rules, so a rule the configuration omits does not run however complete
-its own tests are, and nothing is enabled by default. Aonyx's own rules are
-plugins on exactly these terms: they live in [whisker-aonyx-rules][rules],
-and `.config/whisker.toml` names that repository and the commit to take it
-from. A rule written anywhere else is written the same way — the same
-generated trait, the same decorations, the same test harness — and enters
-through `export_lints!` rather than a pass list in the binary.
+A project names its lint crates in `.config/whisker.toml`. Whisker finds
+that file by climbing from the checked path to the file or to a `.git`
+directory. The file has two keys: `ignore` and `lints`. Each `lints` entry
+names a directory, or a repository pinned to one commit.
 
-An entry names either a directory or a repository pinned to one commit.
-The two meet immediately: a git entry is fetched into the cache directory
-and from there is a directory like any other. That directory is
-`WHISKER_CACHE_DIR` when it is set, else `XDG_CACHE_HOME/whisker`, else
-`~/.cache/whisker`. The fetch
-asks the remote for that single commit, at depth one, over gitoxide rather
-than the `git` binary, so whisker's behavior does not depend on which git
-a machine has or whether it has one. Because a commit hash names an
-immutable tree, a checkout that exists is never refreshed and never
-revalidated against the remote, which is what keeps the network out of the
-common path. Only a git entry builds with `--locked`: the pin is worth
-what the lockfile behind it is worth.
+`whisker check` resolves every entry before it compiles any of them, so a
+typo in the second entry surfaces before the first entry's build. Every
+network request whisker makes itself happens in that stage. Cargo may
+still reach the network during a build, for a dependency the machine has
+not downloaded before.
 
-Resolving an entry and loading it are separate stages. Every entry is
-resolved before any of them is compiled, so a typo in the second entry
-surfaces before the first one's five-minute build, and everything that
-reaches the network happens there rather than between two compilations.
+A git entry becomes a directory in the cache and is then a directory like
+any other. The cache is `WHISKER_CACHE_DIR` when it is set. Otherwise it is
+the XDG cache directory plus `whisker`, which is `~/.cache/whisker` on
+every platform. A checkout lives at `<cache>/git/<remote>/<rev>/`. Whisker
+assembles it in a sibling directory and renames it into place, so a
+checkout that exists is whole.
+
+The fetch uses gitoxide. It asks the remote for the pinned commit by hash,
+at depth one, and declines tags. Gitoxide replaces only the transport: the
+machine's git configuration still applies, and a private remote fetches
+with the credentials the home directory carries. The fetch ignores the
+`GIT_*` environment, so a run inside a git hook cannot be redirected onto
+the repository being committed. A commit hash names an immutable tree, so
+whisker never refreshes a checkout that exists and never asks the remote
+about it again.
+
+Whisker runs `cargo build --release` in the directory, with the cargo that
+`CARGO` names or the one on `PATH`. Only a git entry builds with
+`--locked`, because the pinned commit fixes the rules only when the
+lockfile fixes their dependencies. Cargo's target directory sits inside
+the checkout, so a second run over the same pin is a warm build.
+
+A directory may hold one package or a workspace of them. Whisker loads
+every dynamic library the build produced, and each one completes its own
+handshake. That is what lets a repository of rules arrive through a single
+entry.
 
 ## Prebuilt lints
 
-A git entry can arrive as libraries that its publisher compiled, and
-whisker looks for those before it compiles the source. It asks the
-remote's releases for an archive named `<rev>-<tag>.tar.gz`, where the
-tag is the one `whisker abi` prints: a digest of every value the
-handshake compares, followed by the target triple the build script baked
-in.
+A git entry can arrive as libraries that its publisher compiled. Whisker
+takes the cheapest answer the machine already holds. Prebuilt libraries it
+unpacked before come first. A checkout it already holds comes next. Only a
+machine with neither asks the remote's releases, and only when that
+answers with nothing does whisker fetch the source. A project with a warm
+checkout therefore keeps compiling it after its rules start to publish
+archives. Someone moves the pin or clears the cache to pick them up.
 
-Compiling costs a toolchain and several minutes, in every project and on
+A compile costs a toolchain and several minutes, on every machine and
 every build agent that pins the same commit. A released whisker binary
 also cannot compile lints on most machines. The handshake accepts a
-library only from the rustc that built whisker, and whoever downloaded
-the binary does not have that rustc.
+library only from the rustc that built whisker, and whoever downloaded the
+binary does not have that rustc.
 
-The tag covers what the handshake covers. An archive published under a
-whisker's tag passes that whisker's handshake, and a whisker nobody built
-for finds no file. A prebuilt library that fails the handshake ends the
-run and names the directory to delete. The publisher named the archive
-with a tag that does not describe it, and a source build would hide that
-from everyone who trusts the tag.
+Whisker asks the remote's releases for an archive named
+`<rev>-<tag>.tar.gz`, where the tag is the one `whisker abi` prints. The
+tag is a digest of every value the handshake compares, followed by the
+target triple the build script baked in. An archive published under a
+whisker's tag passes that whisker's handshake. A prebuilt library that
+fails the handshake ends the run and names the directory to delete. The
+publisher named that archive with a tag that does not describe it.
 
-Whisker checks the archive against the `.sha256` published beside it,
-then unpacks it into `<cache>/prebuilt/<remote>/<rev>/<tag>/`, staged
-and renamed the way a checkout is. Both layouts derive `<remote>` from
-the same function, so it is spelled the same under `<cache>/git/`.
-Whisker unpacks only regular files at the archive's root. That one rule
-skips what whisker has no use for, keeps every entry inside the
-directory, and refuses a symbolic link.
+Whisker checks the archive against the `.sha256` published beside it, then
+unpacks it into `<cache>/prebuilt/<remote>/<rev>/<tag>/`, staged and
+renamed the way a checkout is. Both layouts derive `<remote>` from the
+same function. Whisker unpacks only regular files at the archive's root.
+That one rule keeps every entry inside the directory, and it passes over a
+symbolic link, which is no regular file.
 
-The digest catches a truncated or corrupted download. The same publisher
+The digest proves that the download arrived intact. The same publisher
 writes the archive and the digest, so it establishes nothing about trust.
-The handshake does that, and a configured repository of lints already
-runs its code in whisker's process.
+Neither does the handshake, which proves compatibility. Trust comes from
+the configuration: a configured repository of lints runs its code in
+whisker's process, prebuilt or compiled.
 
-A missing archive never fails a check, because the source build is always
-available. Whisker is silent when the remote is not on GitHub, when the
-API answers 404, and when no release names an archive for this whisker.
-That is the ordinary case for a project whose rules nobody publishes
-prebuilt, and a warning there would appear on most projects on every
-check. Three failures print one line on stderr before whisker compiles
-the source: an API it cannot reach or that answers with an error, a
-digest that does not match, and an archive that will not unpack.
+A missing archive never fails the lookup. Whisker says nothing when the
+remote is not on GitHub, when the API answers 404, and when no release
+names an archive for this whisker. That is the ordinary case for a project
+whose rules nobody publishes prebuilt. Whisker then compiles the source,
+and on a machine without the matching toolchain that build fails. Every
+other failure prints one line on stderr before the source build:
+
+- an API whisker cannot reach, or one that answers with an error
+- a digest that does not match
+- an archive that will not unpack
+- a cache directory whisker cannot write
 
 The exchange with the API runs on a thread of its own. The HTTP client
-owns an asynchronous runtime, and a runtime dropped inside another
-panics.
+owns an asynchronous runtime, the check command is itself asynchronous,
+and a runtime dropped inside another panics.
 
-A directory may hold one package or a workspace of them, and every dynamic
-library the build produces is loaded and handshaken separately. That is
-what lets a repository of rules arrive through a single entry rather than
-one entry per rule.
+Whisker reads `GH_TOKEN`, then `GITHUB_TOKEN`, for a private repository,
+and sends the token only to the API host. `WHISKER_GITHUB_API_URL` points
+it at a GitHub Enterprise installation. Every request has a timeout, and
+every body whisker reads has a size limit.
 
-Rust has no stable ABI, so a loaded library is only coherent with the
-whisker binary when the same rustc compiled both and both lay the
-boundary out the same way. Whisker establishes that before trusting
-anything: the plugin's declaration carries the compiler's identity and a
-fingerprint of each side of the boundary, and the loader refuses the
-library at the first mismatch.
+## The plugin boundary
 
-The failure mode this guards against is not a crash but silence — a
-plugin built against drifted source would mostly _seem_ to work, and
-rules fail open — so the handshake turns an invisible wrong answer into
-a visible refusal. For the same reason, decorations are recovered by a
-name-based key rather than `TypeId`, which is not stable across
-separately compiled crate graphs.
+Rust has no stable ABI. A loaded library is coherent with the whisker
+binary only when the same rustc compiled both and both lay the boundary
+out the same way. The loader establishes that before it calls anything the
+plugin defines. A `dlopen` runs the library's initializers, so the
+handshake is a compatibility gate, and trust comes from the configuration
+as the previous section says.
 
-The fingerprints hash layout, not source text: the size, alignment, and
-field offsets of every type that crosses, plus the lint pass trait
-whisker-rust generates from the grammar. An earlier revision hashed the
-crates' source directories, which meant a doc comment refused every
-plugin in the tree until each was rebuilt — a cost that scales with the
-number of plugins and buys nothing, since text that moves no field
-threatens nothing. What layout cannot cover is the method order of
-`LintPass` and `LintRegistrar`, because a vtable is ordered by
-declaration and no const reads that back; those belong to the
-declaration's `ABI_VERSION`, and a test fails when either trait's method
-list moves so the bump is not left to memory.
+The plugin exports a declaration. The loader reads its leading protocol
+version through a raw pointer, and only a matching version licenses a
+reference to the whole struct. It then compares, in order, the rustc
+version string and two fingerprints: one for whisker-types and one for
+whisker-rust. The first mismatch refuses the library with an error that
+says what to rebuild. Only then does the loader call the plugin's
+registration function.
 
-The fingerprints reach whisker's own layout, not the graph a plugin's
-lockfile resolves for itself. `tree_sitter::Node` crosses the boundary
-as a `#[repr(transparent)]` wrapper around a `#[repr(C)]` struct of the
-C library, so a version difference there moves no field, but it does
-give each image its own copy of that library. Whisker documents that
-residual risk rather than pinning every version a plugin resolves.
+The handshake guards against silence. A plugin built against drifted
+source would mostly work, and rules fail open, so a wrong answer would
+pass unnoticed. The handshake turns it into a refusal.
 
-Whisker once shipped its rules as compiled plugins through Dylint and
-deliberately retired that (#193). Custom lints re-enter the idea on
-whisker's own terms: the boundary is the narrow `LintPass` trait rather
-than rustc's internals, and compatibility is checked instead of assumed.
+The fingerprints hash layout. Each names a list of types that cross the
+boundary and records the size and alignment of every one. For
+`Diagnostic`, `Span`, `Suggestion`, `Location`, and `DecoratedNode` it
+also records every field offset. The whisker-rust fingerprint also hashes
+the generated lint pass trait as text, because a trait has no layout a
+const can read. Doc comments and private helpers move nothing, so a plugin
+stays loadable across most of whisker's own churn.
+
+Layout cannot see the method order of `LintPass` and `LintRegistrar`,
+because a vtable orders its methods by declaration. Those belong to the
+declaration's `ABI_VERSION`. A test scans both traits' source and fails
+when either method list moves, so the test reminds a contributor to bump
+it.
+
+The fingerprints stop at whisker's own layout. A contributor maintains
+each list of types by hand. A fieldless enum keeps its size and alignment
+when its variants reorder, so the fingerprint does not see that change. A
+decoration's key hashes its definition text, so an edit to that text
+changes the key without changing any fingerprint. The plugin's lockfile
+resolves its own `tree-sitter`. Its `Node` is a `#[repr(transparent)]`
+wrapper around a `#[repr(C)]` struct of the C library, so a version
+difference moves no field. Each image still carries its own copy of that
+library. Nothing on the call path catches a panic, and nothing checks the
+plugin's allocator or panic strategy. A plugin must not set a
+`#[global_allocator]`, because the host frees values the plugin allocated.
+
+The loader keeps every library loaded for the life of the process. The
+registered factories and every `RuleId` a plugin mints point into the
+library's image.
 
 ## Workspace layout
 
-The platform lives in `crates/`, and that is all of it. Rules live in their
-own repository. Two plugin packages stay here for the tests that need one:
-`examples/custom_lint`, which is the template a rule is written from, and
-`crates/whisker-rust/tests/fixtures/lints/decoration_probes`, which reads
-decorations so the provider's output stays under test. Both sit outside the
-workspace, resolving their own dependencies the way a plugin written
-elsewhere does, so the workspace test run does not reach them and
-`just test-example-lint` and `just test-fixture-lint` do.
+The platform lives in `crates/`. Rules live in their own repository. Two
+plugin packages stay here for the tests that need one.
+`examples/custom_lint` is the template a rule is written from.
+`crates/whisker-rust/tests/fixtures/lints/decoration_probes` reads
+decorations, so the provider's output stays under test. Both sit outside
+the workspace and keep their own lockfiles, the way a plugin written
+elsewhere does. The workspace test run builds and loads them through the
+CLI, and `just test-example-lint` and `just test-fixture-lint` run their
+own tests.
 
-| Crate               | Role                                               |
-| ------------------- | -------------------------------------------------- |
-| `whisker-types`     | Shared vocabulary: trees, decorations, diagnostics |
-| `whisker-core`      | The pipeline and tree walker                       |
-| `whisker-codegen`   | Generates per-language lint pass traits            |
-| `whisker-rust`      | The Rust language support                          |
-| `whisker-macros`    | Derive macro for decoration types                  |
-| `whisker-reporting` | Diagnostic rendering                               |
-| `whisker-testing`   | Test harness for lint rules                        |
-| `whisker`           | The CLI                                            |
+| Crate               | Role                                                                                     |
+| ------------------- | ---------------------------------------------------------------------------------------- |
+| `whisker-types`     | Shared vocabulary: trees, decorations, diagnostics, coverage, and the plugin declaration |
+| `whisker-core`      | The pipeline and tree walker                                                             |
+| `whisker-codegen`   | Generates a lint pass trait from `node-types.json`                                       |
+| `whisker-rust`      | Rust support: the generated trait, the decorations, and the provider                     |
+| `whisker-macros`    | The derive macro for decoration types                                                    |
+| `whisker-reporting` | Diagnostic rendering                                                                     |
+| `whisker-testing`   | Test harness for lint rules                                                              |
+| `whisker`           | The CLI, custom lint loading, and the plugin handshake                                   |
 
-Dependencies flow one way: everything rests on `whisker-types`,
-`whisker-core` adds the pipeline, a language crate builds on both, and the
-CLI ties the platform, a language, and the lints together.
+Dependencies flow one way. `whisker-types`, `whisker-codegen`, and
+`whisker-macros` depend on no other whisker crate. `whisker-core` and
+`whisker-reporting` rest on `whisker-types`. `whisker-rust` rests on
+`whisker-types` and `whisker-macros`, and uses `whisker-codegen` at build
+time. `whisker-testing` rests on `whisker-core`. The CLI ties the platform,
+the language, and the loaded lints together.
 
-[rules]: https://github.com/aonyx-ai/whisker-aonyx-rules
 [ra]: https://rust-analyzer.github.io/
+[rules]: https://github.com/aonyx-ai/whisker-aonyx-rules
 [ts]: https://tree-sitter.github.io/tree-sitter/

--- a/README.md
+++ b/README.md
@@ -1,15 +1,16 @@
 # Whisker
 
-Whisker is a language-agnostic linting platform built on [tree-sitter][ts].
-It ships no rules of its own: a project configures the ones it wants, and
-those are exactly the ones it runs. Aonyx's own live in
+Whisker is a linting platform built on [tree-sitter][ts]. It lints Rust
+today. Whisker ships no rules of its own: a project configures the ones it
+wants, and those are exactly the ones it runs. Aonyx's own live in
 [whisker-aonyx-rules][rules] and cover what Clippy does not, like derive
 ordering, wildcard match arms, `matches!` macro usage, and the other style
 rules defined in our `CLAUDE.md` files.
 
-Each rule is a separate crate implementing the `RustLintPass` trait generated
-from tree-sitter's Rust grammar. Type-dependent rules use
-[rust-analyzer][ra] as a library for semantic analysis.
+A rule implements the `RustLintPass` trait, which whisker generates from
+tree-sitter's Rust grammar. A rule that needs type information reads
+decorations that whisker computes with [rust-analyzer][ra] before any rule
+runs.
 
 ## Status
 
@@ -55,12 +56,21 @@ always checks a path you name on the command line, even when an ignore rule
 matches that path. Ignore rules still apply to files below a named
 directory.
 
+`whisker check` needs a Cargo project. Whisker uses rust-analyzer to load
+the workspace nearest the path you name, and it runs that workspace's
+build scripts before it lints anything. A file that no crate in the workspace
+reaches has no type information. Whisker reports it as an error and prints
+what to do about it. The same happens to a file that rust-analyzer
+excludes from the workspace.
+
 A directory that whisker cannot read, or an ignore file that it cannot
 parse, ends the run: each one changes which files whisker inspects. A file
 that whisker cannot read or analyze ends the run too. Pass `--keep-going`
-to report each failure, continue, and still exit non-zero.
+to report each failure, continue, and still exit non-zero. A diagnostic at
+the error severity also fails the run. Pass `--deny-warnings` to fail on
+a warning too.
 
-A run that finds nothing to check is an error, not a success. An empty run
+A run that finds nothing to check is an error. An empty run
 usually means a pattern matched too much, and it would otherwise look like
 a clean project.
 
@@ -89,13 +99,13 @@ the project directory, the one that holds `.config`, and they behave as they
 would in a `.gitignore` written there. `crates/app/generated/` names one
 directory relative to that root, `examples/` matches at any depth, and
 `/examples/` matches only at the root. Whisker rejects keys it does not
-recognize, so a typo is an error and not a silent no-op.
+recognize, so a typo is an error.
 
 ### Custom lints
 
 A project can bring its own rules. Each `lints` entry names a directory
-holding a lint crate; relative paths anchor at the project directory, the
-same way `ignore` patterns do:
+that holds a lint crate. Relative paths anchor at the project directory,
+the same way `ignore` patterns do:
 
 ```toml
 [[lints]]
@@ -113,11 +123,12 @@ rev = "0123456789abcdef0123456789abcdef01234567"
 
 A branch or a tag is whatever the remote points it at today, so the same
 configuration would run different rules on different days. Whisker asks for
-that one commit and nothing else, keeps the checkout under
-`~/.cache/whisker`, and reuses it forever after, because the commit it
-names can never change. Set `WHISKER_CACHE_DIR` to keep those checkouts
-somewhere else. A git source builds with `--locked`, so commit the
-lockfile beside the rules.
+that one commit and nothing else. It keeps the checkout under
+`~/.cache/whisker`, or under `XDG_CACHE_HOME` when that is set. A commit
+hash names one immutable tree, so whisker reuses the checkout on every
+later run. Set `WHISKER_CACHE_DIR` to keep those checkouts somewhere else.
+A git source builds with `--locked`, so commit the lockfile beside the
+rules.
 
 `whisker check` compiles each entry with your `cargo`, loads the built
 libraries, and runs their lints. Whisker ships no rules of its own, so the
@@ -126,9 +137,9 @@ as long as any Rust compilation; afterwards cargo's cache makes it cheap.
 
 #### Prebuilt lints
 
-A repository can publish its rules already compiled, and whisker loads
-those before it compiles anything. Before it builds a git entry, whisker
-asks that repository's releases for an archive. The archive is named
+A repository can publish its rules already compiled. Before whisker
+fetches a git entry, it asks that repository's releases for an archive.
+The archive is named
 after the pinned commit and after the tag that `whisker abi` prints. If a
 release carries that archive and the `.sha256` beside it, whisker
 downloads it and checks the digest. It then unpacks the archive into the
@@ -164,9 +175,9 @@ A custom lint crate is a `cdylib` that implements `RustLintPass` and hands
 its rules to `export_lints!`. The complete crate in
 [`examples/custom_lint`][example] is the template: a `Cargo.toml` declaring
 the crate type and the whisker dependencies, one rule, and its tests. An
-entry may also name a directory holding a cargo workspace, in which case
-every plugin in it loads, which is what lets one entry bring a whole
-repository of rules.
+entry may also name a directory that holds a cargo workspace. Every
+plugin in it loads, which is what lets one entry bring a whole repository
+of rules.
 
 Rust has no stable ABI, so whisker only loads a plugin built by the same
 rustc from the same whisker source as the binary itself, and refuses
@@ -174,9 +185,9 @@ anything else with an error that says what to rebuild. In practice: pin the
 plugin's whisker dependencies to the revision your whisker was built from,
 and build both with the same toolchain.
 
-That check covers whisker's own source and the compiler, not the rest of
-the graph your plugin's lockfile resolves. Commit that lockfile and keep it
-in step with the whisker you build against, the way
+That check covers whisker's own source and the compiler. The rest of the
+graph your plugin's lockfile resolves lies outside it. Commit that
+lockfile and keep it in step with the whisker you build against, the way
 [`examples/custom_lint`][example] does.
 
 [example]: examples/custom_lint


### PR DESCRIPTION
The architecture document did not match the code in four places. It said rules link into the CLI, and thirteen lines later it said whisker links no rules. It said the file extension selects a grammar, but the check command builds one parser for Rust. It said a file without a provider makes rules stay silent, but whisker reports that file as an error. It said the provider resolves the nodes that lints ask for, but the provider resolves a fixed set of five node kinds.

This PR rewrites ARCHITECTURE.md against the code and corrects the README. The new text adds the coverage model, the build scripts a check runs, the resolution order for prebuilt lints, and the limits of the handshake. It also corrects the crate dependency direction. The text follows the comment-judge rubric: short sentences, no em-dash asides, no definition by contrast, and no history.
