### PR TITLE
Keep the git fixtures out of the ambient repository

### DIFF
--- a/crates/whisker/tests/git_lints.rs
+++ b/crates/whisker/tests/git_lints.rs
@@ -8,7 +8,7 @@ use tempfile::TempDir;
 #[path = "support/fixture_repository.rs"]
 mod fixture_repository;
 
-use fixture_repository::{FixtureRepository, Standalone, write_lint_package, write_lockfile};
+use fixture_repository::{FixtureRepository, Standalone, git, write_lint_package, write_lockfile};
 
 /// Source that trips the fixture lints and nothing whisker ships
 const TODO_SOURCE: &str = "pub fn later() {\n    todo!()\n}\n";
@@ -101,6 +101,52 @@ fn repository_with_one_lint(rule: &str) -> FixtureRepository {
         write_lint_package(directory, "fixture_lint", rule, Standalone::Yes);
         write_lockfile(directory);
     })
+}
+
+/// Pins that the fixture helper ignores the git environment around the tests
+///
+/// The suite runs from a pre-commit hook, and git exports `GIT_DIR` and
+/// `GIT_INDEX_FILE` to a hook in a linked worktree. A fixture that inherited
+/// them once ran `git init` and `git add --all` against the checkout being
+/// committed. The test sets the process environment, which nextest confines
+/// to this test's own process.
+#[test]
+fn fixture_repository_ignores_an_ambient_git_environment() {
+    let victim = tempfile::tempdir().expect("temporary directory should be created");
+    std::fs::write(victim.path().join("file.txt"), "hello\n").expect("the file should be written");
+    git(victim.path(), &["init", "--quiet", "-b", "main"]);
+    git(victim.path(), &["add", "--all"]);
+    let git_dir = victim.path().join(".git");
+    let index_before = std::fs::read(git_dir.join("index")).expect("the index should be readable");
+    let config_before =
+        std::fs::read(git_dir.join("config")).expect("the config should be readable");
+    unsafe {
+        std::env::set_var("GIT_DIR", &git_dir);
+        std::env::set_var("GIT_INDEX_FILE", git_dir.join("index"));
+    }
+
+    let rules = repository_with_one_lint("fixture.no-todo");
+
+    unsafe {
+        std::env::remove_var("GIT_DIR");
+        std::env::remove_var("GIT_INDEX_FILE");
+    }
+    let index_after = std::fs::read(git_dir.join("index")).expect("the index should be readable");
+    let config_after =
+        std::fs::read(git_dir.join("config")).expect("the config should be readable");
+    assert_eq!(
+        index_after, index_before,
+        "the fixture wrote the victim's index"
+    );
+    assert_eq!(
+        config_after, config_before,
+        "the fixture wrote the victim's config"
+    );
+    assert_eq!(
+        rules.rev().len(),
+        40,
+        "the fixture should hold a commit of its own"
+    );
 }
 
 /// Pins that a git environment around whisker cannot reach its checkout

--- a/crates/whisker/tests/prebuilt_lints.rs
+++ b/crates/whisker/tests/prebuilt_lints.rs
@@ -13,7 +13,7 @@ mod fixture_repository;
 mod mismatched_plugin;
 
 use fake_github::{Answer, FakeGitHub};
-use fixture_repository::{FixtureRepository, Standalone, write_lint_package, write_lockfile};
+use fixture_repository::{FixtureRepository, Standalone, git, write_lint_package, write_lockfile};
 use mismatched_plugin::write_mismatched_lint_package;
 
 /// Source that trips the fixture lint and nothing whisker ships
@@ -652,22 +652,6 @@ fn check_with_a_remote_the_api_does_not_serve_asks_nothing() {
 ///
 /// Panics if git is unavailable or any step fails.
 fn clone_into(rules: &FixtureRepository, destination: &Path) {
-    let run = |arguments: &[&str], directory: &Path| {
-        let output = Command::new("git")
-            .args(arguments)
-            .current_dir(directory)
-            .env("GIT_CONFIG_GLOBAL", "/dev/null")
-            .env("GIT_CONFIG_SYSTEM", "/dev/null")
-            .output()
-            .unwrap_or_else(|error| panic!("git {arguments:?} should run: {error}"));
-
-        assert!(
-            output.status.success(),
-            "git {arguments:?} failed: {}",
-            String::from_utf8_lossy(&output.stderr)
-        );
-    };
-
     let parent = destination.parent().expect("the path should have a parent");
     std::fs::create_dir_all(parent).expect("the parent should be created");
 
@@ -677,10 +661,10 @@ fn clone_into(rules: &FixtureRepository, destination: &Path) {
         .to_string_lossy()
         .into_owned();
 
-    run(&["clone", "--quiet", &rules.url(), &name], parent);
-    run(
-        &["checkout", "--quiet", "--detach", rules.rev()],
+    git(parent, &["clone", "--quiet", &rules.url(), &name]);
+    git(
         destination,
+        &["checkout", "--quiet", "--detach", rules.rev()],
     );
 }
 

--- a/crates/whisker/tests/support/fixture_repository.rs
+++ b/crates/whisker/tests/support/fixture_repository.rs
@@ -80,17 +80,25 @@ impl FixtureRepository {
 
 /// Runs one git command in `directory` and returns its standard output
 ///
-/// The fixture ignores the configuration of whoever runs the tests. A
-/// global `commit.gpgsign`, a `core.hooksPath`, or a commit template would
-/// otherwise decide whether the suite passes.
+/// The command starts from an empty environment, plus the `PATH` that
+/// finds git. The fixture therefore ignores the configuration of whoever
+/// runs the tests, and it ignores the `GIT_DIR` and `GIT_INDEX_FILE` that
+/// git exports to a hook. A global `commit.gpgsign`, a `core.hooksPath`,
+/// or a commit template would otherwise decide whether the suite passes.
+/// A pre-commit hook in a linked worktree once handed the fixture its
+/// repository, and `git init` and `git add --all` then ran against the
+/// checkout being committed.
 ///
 /// # Panics
 ///
 /// Panics if git cannot be run or exits unsuccessfully.
-fn git(directory: &Path, arguments: &[&str]) -> String {
+pub fn git(directory: &Path, arguments: &[&str]) -> String {
+    let path = std::env::var_os("PATH").unwrap_or_default();
     let output = Command::new("git")
         .args(arguments)
         .current_dir(directory)
+        .env_clear()
+        .env("PATH", path)
         .env("GIT_CONFIG_GLOBAL", "/dev/null")
         .env("GIT_CONFIG_SYSTEM", "/dev/null")
         .env("GIT_TERMINAL_PROMPT", "0")


### PR DESCRIPTION
The git fixtures inherited the environment of the test process. Git exports GIT_DIR and GIT_INDEX_FILE to a pre-commit hook in a linked worktree. The fixture's git init, git add, and git commit then ran against the checkout being committed. Today that wrote core.bare = true into the shared .git/config of this repository and replaced a worktree's index with a fixture's files.

Whisker itself already defends against this hazard. The fetch in custom_lints/git_source.rs denies the GIT_* environment so that a hook cannot redirect a checkout. The fixture helper set GIT_CONFIG_GLOBAL, GIT_CONFIG_SYSTEM, and GIT_TERMINAL_PROMPT, and it left GIT_DIR and GIT_INDEX_FILE alone. This PR brings the helper in line with the loader.

The fixture helper now starts git from an empty environment plus PATH. The prebuilt tests' clone helper goes through the same function. A new test sets GIT_DIR and GIT_INDEX_FILE on the process, builds a fixture, and checks that the victim's index and config did not change. The test fails against the old helper.

Until this merges, a commit from a linked worktree with the pre-commit hook active repeats the damage. After it merges, the hook is safe there again, and nobody needs --no-verify for that reason.
