### PR TITLE
Trim the changelog for the first release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,42 +12,30 @@ and this project adheres to
 
 ### Added
 
-- A `[[lints]]` entry can name a repository and a commit rather than a
-  directory, and whisker fetches that commit into a cache before building it.
-  A configured directory may also hold a cargo workspace, in which case every
-  plugin it builds is loaded.
-- Whisker looks for prebuilt lints before it compiles a git entry. It asks the
-  repository's releases for an archive named after the commit and this
-  binary's tag. It checks the digest published beside the archive and loads
-  the libraries it unpacks. Every library still completes the plugin
-  handshake. A repository that publishes nothing for this whisker compiles
-  from source as before, and whisker says nothing about it.
-- `whisker abi` prints the tag that names which prebuilt lints this binary
-  loads. A publisher writes it into the name of each archive.
-- Every release carries an archive of the whisker binary for Linux on x86-64
-  and arm64, and for macOS on Apple silicon, with a SHA-256 digest beside it.
-  A prerelease carries them too, so a release can be tried before anyone
-  depends on it.
+- Whisker asks a git source's releases for prebuilt lints before it compiles
+  anything. It verifies the published SHA-256, and every library still
+  completes the plugin handshake.
+- `whisker abi` prints the tag that says which prebuilt lints this binary
+  loads. Publishers put it in each archive's name.
+- Every release carries whisker binaries for Linux on x86-64 and arm64 and for
+  macOS on Apple silicon, each with a SHA-256 beside it. Prereleases too.
+- A `[[lints]]` entry can name a repository and a commit, which whisker caches.
+  A directory may also hold a cargo workspace.
 
 ### Changed
 
-- Whisker lists its subcommands in a stable order. The linker used to decide
-  the order, so two builds could print two different orders.
-
-- Whisker's own rules moved to [whisker-aonyx-rules][rules]. A project that
-  ran them from `lints/` now names that repository and a commit.
-- Whisker finds its project with [kawauso-project][kawauso], which is how
-  every Aonyx tool finds one. A broken configuration file now reports the
-  line and column, or the field, that has to change.
+- Whisker's own rules moved to [whisker-aonyx-rules][rules]. A project that ran
+  them from `lints/` now names that repository and a commit.
+- Whisker finds its project with [kawauso-project][kawauso], and a broken
+  configuration file reports the line and column to fix.
+- Whisker lists its subcommands in a stable order.
 
 ### Removed
 
-- The workflow that published to crates.io is gone. Every crate here sets
-  `publish = false`, so it never worked. Releases carry binaries.
-- Whisker no longer reads `.whisker.toml`. The configuration file is
-  `.config/whisker.toml`, and a project that keeps the old name has to move
-  it. Whisker does not report the old file, so a project that misses this
-  runs with no patterns and no custom lints.
+- Whisker no longer reads `.whisker.toml`. Move it to `.config/whisker.toml`.
+  Whisker says nothing about the old name, so a project that misses this runs
+  with no patterns and no custom lints.
+- The crates.io publish workflow is gone. Releases carry binaries.
 
 [kawauso]: https://crates.io/crates/kawauso-project
 [rules]: https://github.com/aonyx-ai/whisker-aonyx-rules


### PR DESCRIPTION
The entries carried a paragraph each. Several described what the code used to do, defined a change by what it is not, or kept going after the point. comment-judge's rubric names those `history_essay`, `definition_by_contrast`, and `keeps_going_after_the_point`.

The section loses about a third of its lines and keeps every entry it had. What a reader has to act on stays, so the `.whisker.toml` move still says what happens to a project that misses it.

This lands before the first release, because the release body quotes this section.
