### PR TITLE
Build the Linux binaries for the LTS in use

### DIFF
--- a/.github/workflows/release-binaries.yml
+++ b/.github/workflows/release-binaries.yml
@@ -27,11 +27,15 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
+        # A binary asks its build machine's glibc for a floor, and the
+        # oldest runner sets the oldest distribution that can run it.
+        # Ubuntu 24.04 carries glibc 2.39, which refuses Ubuntu 22.04 LTS
+        # and Debian 12. Ubuntu 22.04 carries 2.35, which both accept.
         include:
           - target: x86_64-unknown-linux-gnu
-            runner: ubuntu-latest
+            runner: ubuntu-22.04
           - target: aarch64-unknown-linux-gnu
-            runner: ubuntu-24.04-arm
+            runner: ubuntu-22.04-arm
           - target: aarch64-apple-darwin
             runner: macos-latest
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,8 @@ and this project adheres to
 
 ### Changed
 
+- The Linux binaries are built on Ubuntu 22.04, so they need glibc 2.35 rather
+  than 2.39. The 2.39 floor refused Ubuntu 22.04 LTS and Debian 12.
 - Whisker's own rules moved to [whisker-aonyx-rules][rules]. A project that ran
   them from `lints/` now names that repository and a commit.
 - Whisker finds its project with [kawauso-project][kawauso], and a broken

--- a/README.md
+++ b/README.md
@@ -31,6 +31,9 @@ tar -xzf whisker-0.1.0-aarch64-apple-darwin.tar.gz
 The archive holds the binary, both licenses, and this README. Move
 `whisker` to a directory on your `PATH`, such as `~/.local/bin`.
 
+The Linux binaries need glibc 2.35 or newer, which Ubuntu 22.04 and Debian
+12 satisfy. Build from source on anything older.
+
 Whisker also builds from source. `rust-toolchain.toml` pins a nightly
 toolchain, and rustup installs it during the build:
 


### PR DESCRIPTION
A binary takes its build machine's glibc as a floor. The workflow built on Ubuntu 24.04, so the archives demanded glibc 2.39, and the two most common Linux targets refused them.

I ran the `v0.1.0-rc.1` archives in containers. Ubuntu 22.04 LTS carries glibc 2.35 and Debian 12 carries 2.36, and both stopped with `GLIBC_2.38 not found` and `GLIBC_2.39 not found`. Ubuntu 24.04 and Debian 13 ran them. RHEL 9 and Amazon Linux 2023 carry 2.34, so the floor refused those too.

Building on Ubuntu 22.04 puts the floor at 2.35, which Ubuntu 22.04 LTS and Debian 12 accept. The README names the floor now, because it promised Linux without one.

I considered musl, which would remove the floor entirely. It also changes DNS resolution, and whisker now makes real requests to a release API, so that is not a variable to introduce in the same change. It is worth measuring separately.

The prerelease is what found this. Nobody had run either Linux archive until one existed, and both failed on a distribution people use.
