### PR TITLE
Install a released whisker on a runner

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,9 @@ and this project adheres to
 - Whisker asks a git source's releases for prebuilt lints before it compiles
   anything. It verifies the published SHA-256, and every library still
   completes the plugin handshake.
+- An action installs a released whisker on a GitHub Actions runner. It picks
+  the archive for the runner, checks it against the digest published beside
+  it, and puts whisker on the `PATH`.
 - `whisker abi` prints the tag that says which prebuilt lints this binary
   loads. Publishers put it in each archive's name.
 - Every release carries whisker binaries for Linux on x86-64 and arm64 and for

--- a/README.md
+++ b/README.md
@@ -34,6 +34,16 @@ The archive holds the binary, both licenses, and this README. Move
 The Linux binaries need glibc 2.35 or newer, which Ubuntu 22.04 and Debian
 12 satisfy. Build from source on anything older.
 
+On GitHub Actions, the action in this repository does the same three
+steps, for the runner it finds itself on:
+
+```yaml
+- uses: aonyx-ai/whisker@v0.1.0-rc.2
+  with:
+    version: v0.1.0-rc.2
+- run: whisker check .
+```
+
 Whisker also builds from source. `rust-toolchain.toml` pins a nightly
 toolchain, and rustup installs it during the build:
 

--- a/action.yml
+++ b/action.yml
@@ -1,0 +1,59 @@
+---
+name: Set up whisker
+description: Downloads a released whisker and puts it on the PATH
+
+inputs:
+  version:
+    description: The release to install, such as v0.1.0-rc.2
+    required: true
+
+runs:
+  using: composite
+  steps:
+    - name: Download and verify whisker
+      shell: bash
+      env:
+        VERSION: ${{ inputs.version }}
+      run: |
+        set -euo pipefail
+
+        # A caller chooses the version, and this writes a path derived
+        # from it into an environment file. Anything but a release name
+        # is refused, so a caller cannot write a second line of its own.
+        if ! printf '%s' "${VERSION}" | grep -Eq '^v[0-9A-Za-z.+-]+$'; then
+          echo "the version must look like v0.1.0-rc.2" >&2
+          exit 1
+        fi
+
+        # The archive names carry the version without its leading `v`,
+        # because that is what `Cargo.toml` holds.
+        version="${VERSION#v}"
+
+        case "${RUNNER_OS}-${RUNNER_ARCH}" in
+          Linux-X64) target=x86_64-unknown-linux-gnu ;;
+          Linux-ARM64) target=aarch64-unknown-linux-gnu ;;
+          macOS-ARM64) target=aarch64-apple-darwin ;;
+          *)
+            echo "whisker publishes no binary for this runner" >&2
+            exit 1
+            ;;
+        esac
+
+        name="whisker-${version}-${target}.tar.gz"
+        base="https://github.com/aonyx-ai/whisker/releases/download"
+
+        # The download host serves a public repository without a token,
+        # and it spends none of the API rate limit that whisker needs
+        # later to look for prebuilt lints.
+        directory="${RUNNER_TEMP}/whisker"
+        mkdir -p "${directory}"
+        cd "${directory}"
+        curl --fail --location --silent --show-error \
+          --remote-name "${base}/${VERSION}/${name}"
+        curl --fail --location --silent --show-error \
+          --remote-name "${base}/${VERSION}/${name}.sha256"
+        shasum -a 256 -c "${name}.sha256"
+
+        tar -xzf "${name}"
+
+        echo "${directory}/whisker-${version}-${target}" >> "${GITHUB_PATH}"

--- a/zizmor.yml
+++ b/zizmor.yml
@@ -1,5 +1,16 @@
 ---
 rules:
+  # The action writes the directory it unpacked into onto the PATH, which
+  # zizmor reads as a way to run code of a caller's choosing. The only part
+  # of that path a caller decides is the version, and the script refuses a
+  # version that is not a release name, so it cannot carry the newline that
+  # a second entry would need. An inline ignore does not apply inside a
+  # composite action, so the exemption sits here. Reread the check in
+  # `action.yml` before trusting this line.
+  github-env:
+    ignore:
+      - action.yml
+
   anonymous-definition:
     ignore:
       - release.yml


### PR DESCRIPTION
Running whisker in CI meant writing the same download, digest check, and unpack in every repository that wanted it, and getting the archive name right for the runner it landed on. This action does those three steps.

```yaml
- uses: aonyx-ai/whisker@v0.1.0-rc.2
  with:
    version: v0.1.0-rc.2
- run: whisker check .
```

The archive comes from the release download host rather than from the API. That host serves a public repository without a token, and it spends none of the rate limit that whisker needs afterwards to look for prebuilt lints. I checked that the rules archives download unauthenticated: HTTP 200, and the byte count matches the published asset.

A caller chooses the version, and the path built from it is written onto the `PATH`, so the script refuses a version that is not a release name. Without that check a caller could pass a newline and write an entry of its own. zizmor reads any write to `GITHUB_PATH` as dangerous and cannot see the check. An inline ignore has no effect inside a composite action, so the exemption sits in `zizmor.yml` and says which check to reread before trusting it.

This is the first half of linting raft with whisker. The second half is a job in raft, and it will be advisory: whisker reports 2,995 warnings there today, across fifteen rules.
