### PR TITLE
Let a project run a subset of a source's rules

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -283,6 +283,21 @@ declaration's `ABI_VERSION`. A test scans both traits' source and fails
 when either method list moves, so the test reminds a contributor to bump
 it.
 
+Two kinds of change reach that declaration, and they cost differently. A
+field appended to it is readable by version, because the struct is
+`#[repr(C)]` and whisker knows where each version's fields end. A plugin
+that stops sooner offers less rather than being refused. A method added
+to either trait is not readable that way, because whisker cannot measure
+a vtable. So an optional capability belongs in the declaration, and
+`MIN_ABI_VERSION` names the oldest layout whisker still reads. Raising
+`ABI_VERSION` alone keeps older plugins loading; raising the floor is what
+stops them, and only a vtable change needs that.
+
+The tag a publisher names an archive with carries the floor rather than
+the version, for the same reason. Two whiskers that read the same
+protocols accept each other's archives, so a protocol that only appends a
+field does not strand what a publisher already built.
+
 The fingerprints stop at whisker's own layout. A contributor maintains
 each list of types by hand. A fieldless enum keeps its size and alignment
 when its variants reorder, so the fingerprint does not see that change. A

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,9 @@ and this project adheres to
 
 ### Added
 
+- A `[rules]` table names the rules a project runs. `enable` runs only those
+  named, `disable` runs everything else, and a name that no configured lint
+  reports is an error rather than a filter that quietly admits everything.
 - Whisker asks a git source's releases for prebuilt lints before it compiles
   anything. It verifies the published SHA-256, and every library still
   completes the plugin handshake.
@@ -26,6 +29,11 @@ and this project adheres to
   A directory may also hold a cargo workspace.
 
 ### Changed
+
+- A plugin declares the rules it reports, which is what a `[rules]` name is
+  checked against. The protocol is 3, and whisker reads every protocol from
+  2 upward, so a plugin built before this still loads and its rules still
+  run. They only cannot be named.
 
 - The Linux binaries are built on Ubuntu 22.04, so they need glibc 2.35 rather
   than 2.39. The 2.39 floor refused Ubuntu 22.04 LTS and Debian 12.

--- a/README.md
+++ b/README.md
@@ -184,6 +184,20 @@ built it. To compile a lint crate for one yourself, install the toolchain
 that `rust-toolchain.toml` names at the release's commit. Otherwise build
 whisker from source and compile the lint crate with the same toolchain.
 
+A `[[lints]]` entry brings every rule its source provides. Name the ones
+you want, or the ones you do not:
+
+```toml
+[rules]
+disable = ["lint.no-inline-comments"]
+```
+
+`enable` is the other half: name it and only those rules run, which is how
+a project adopts a rule at a time. Naming both is refused. So is naming a
+rule that no configured lint reports, because a misspelling would
+otherwise disable nothing and read exactly like a rule that found no
+fault.
+
 A custom lint crate is a `cdylib` that implements `RustLintPass` and hands
 its rules to `export_lints!`. The complete crate in
 [`examples/custom_lint`][example] is the template: a `Cargo.toml` declaring

--- a/crates/whisker-rust/src/declares_rules.rs
+++ b/crates/whisker-rust/src/declares_rules.rs
@@ -1,0 +1,29 @@
+use whisker_types::RuleId;
+
+/// Declares the rules a lint pass can report
+///
+/// Whisker refuses a configured rule name that no loaded plugin declares,
+/// and this is where a plugin says which names are its own.
+///
+/// The trait never crosses the plugin boundary. [`export_lints!`] calls it
+/// inside the plugin's own compilation and puts the result behind a
+/// function pointer in the declaration, so nothing here depends on the
+/// layout of a vtable. That is what lets whisker read the rules of a
+/// plugin built against a newer protocol than an older one without
+/// refusing either.
+///
+/// [`export_lints!`]: crate::export_lints
+///
+/// # Examples
+///
+/// ```ignore
+/// impl DeclaresRules for NoTodo {
+///     fn rules(&self) -> Vec<RuleId> {
+///         vec![RuleId::new("custom.no-todo")]
+///     }
+/// }
+/// ```
+pub trait DeclaresRules {
+    /// Returns every rule this pass can report
+    fn rules(&self) -> Vec<RuleId>;
+}

--- a/crates/whisker-rust/src/export_lints.rs
+++ b/crates/whisker-rust/src/export_lints.rs
@@ -29,7 +29,17 @@ macro_rules! export_lints {
                 types_fingerprint: $crate::plugin::TYPES_FINGERPRINT,
                 language_fingerprint: $crate::plugin::LANGUAGE_FINGERPRINT,
                 register: __whisker_register,
+                rules: __whisker_rules,
             };
+
+        #[doc(hidden)]
+        fn __whisker_rules() -> ::std::vec::Vec<$crate::RuleId> {
+            let mut rules = ::std::vec::Vec::new();
+            $(
+                rules.extend($crate::DeclaresRules::rules(&$lint));
+            )+
+            rules
+        }
 
         #[doc(hidden)]
         fn __whisker_register(registrar: &mut dyn $crate::plugin::LintRegistrar) {
@@ -55,6 +65,12 @@ mod tests {
 
     struct FlagEveryFunction;
 
+    impl crate::DeclaresRules for FlagEveryFunction {
+        fn rules(&self) -> Vec<whisker_types::RuleId> {
+            vec![whisker_types::RuleId::new("test.flag-every-function")]
+        }
+    }
+
     impl RustLintPass for FlagEveryFunction {
         fn check_function_item(&mut self, node: &DecoratedNode<'_>) -> Vec<Diagnostic> {
             vec![Diagnostic::new(
@@ -67,6 +83,12 @@ mod tests {
     }
 
     struct QuietLint;
+
+    impl crate::DeclaresRules for QuietLint {
+        fn rules(&self) -> Vec<whisker_types::RuleId> {
+            vec![whisker_types::RuleId::new("test.quiet")]
+        }
+    }
 
     impl RustLintPass for QuietLint {}
 

--- a/crates/whisker-rust/src/lib.rs
+++ b/crates/whisker-rust/src/lib.rs
@@ -1,4 +1,5 @@
 mod adapter;
+mod declares_rules;
 pub mod decorations;
 mod export_lints;
 pub mod plugin;
@@ -6,8 +7,10 @@ pub mod plugin;
 mod provider;
 
 pub use adapter::RustLintPassAdapter;
+pub use declares_rules::DeclaresRules;
 #[cfg(feature = "provider")]
 pub use provider::RustDecorationProvider;
+pub use whisker_types::RuleId;
 
 include!(concat!(env!("OUT_DIR"), "/rust_lint_pass.rs"));
 

--- a/crates/whisker-rust/src/plugin.rs
+++ b/crates/whisker-rust/src/plugin.rs
@@ -11,7 +11,7 @@
 //! [`export_lints!`]: crate::export_lints
 
 pub use whisker_types::plugin::{
-    ABI_VERSION, LintPassFactory, LintRegistrar, PluginDeclaration, RUSTC_VERSION,
+    ABI_VERSION, LintPassFactory, LintRegistrar, MIN_ABI_VERSION, PluginDeclaration, RUSTC_VERSION,
     TYPES_FINGERPRINT, c_str,
 };
 use whisker_types::plugin::{Shape, seeded_fingerprint};

--- a/crates/whisker-rust/tests/fixtures/lints/decoration_probes/src/anyhow_bare_try.rs
+++ b/crates/whisker-rust/tests/fixtures/lints/decoration_probes/src/anyhow_bare_try.rs
@@ -35,6 +35,12 @@ impl AnyhowBareTry {
     }
 }
 
+impl whisker_rust::DeclaresRules for AnyhowBareTry {
+    fn rules(&self) -> Vec<RuleId> {
+        vec![RuleId::new("fixture.anyhow-bare-try")]
+    }
+}
+
 impl RustLintPass for AnyhowBareTry {
     fn check_try_expression(&mut self, node: &DecoratedNode<'_>) -> Vec<Diagnostic> {
         let Some(operand) = node.named_child(0) else {

--- a/crates/whisker-rust/tests/fixtures/lints/decoration_probes/src/function_scoped_import.rs
+++ b/crates/whisker-rust/tests/fixtures/lints/decoration_probes/src/function_scoped_import.rs
@@ -27,6 +27,12 @@ impl FunctionScopedImport {
     }
 }
 
+impl whisker_rust::DeclaresRules for FunctionScopedImport {
+    fn rules(&self) -> Vec<RuleId> {
+        vec![RuleId::new("fixture.function-scoped-import")]
+    }
+}
+
 impl RustLintPass for FunctionScopedImport {
     fn check_use_declaration(&mut self, node: &DecoratedNode<'_>) -> Vec<Diagnostic> {
         if !is_inside_block(node) {

--- a/crates/whisker-rust/tests/fixtures/lints/decoration_probes/src/wildcard_match_arm.rs
+++ b/crates/whisker-rust/tests/fixtures/lints/decoration_probes/src/wildcard_match_arm.rs
@@ -26,6 +26,12 @@ impl WildcardMatchArm {
     }
 }
 
+impl whisker_rust::DeclaresRules for WildcardMatchArm {
+    fn rules(&self) -> Vec<RuleId> {
+        vec![RuleId::new("fixture.wildcard-match-arm")]
+    }
+}
+
 impl RustLintPass for WildcardMatchArm {
     fn check_match_expression(&mut self, node: &DecoratedNode<'_>) -> Vec<Diagnostic> {
         let Some(scrutinee) = node.child_by_field_name("value") else {

--- a/crates/whisker-types/src/plugin.rs
+++ b/crates/whisker-types/src/plugin.rs
@@ -67,9 +67,32 @@ pub use registrar::{LintPassFactory, LintRegistrar};
 /// ```
 /// use whisker_types::plugin::ABI_VERSION;
 ///
-/// assert_eq!(ABI_VERSION, 2);
+/// assert_eq!(ABI_VERSION, 3);
 /// ```
-pub const ABI_VERSION: u32 = 2;
+pub const ABI_VERSION: u32 = 3;
+
+/// The oldest protocol whisker still loads
+///
+/// A protocol is raised when the declaration gains a field, and a plugin
+/// written before it simply ends sooner. Whisker knows the layout of
+/// every version in this range, so it reads what such a plugin has and
+/// treats the rest as absent.
+///
+/// This range covers the declaration alone. A change to the method list
+/// of [`LintPass`] or [`LintRegistrar`] reorders a vtable, which no
+/// version can make readable, so such a change raises this floor to meet
+/// [`ABI_VERSION`] and refuses everything older.
+///
+/// [`LintPass`]: crate::LintPass
+///
+/// # Examples
+///
+/// ```
+/// use whisker_types::plugin::{ABI_VERSION, MIN_ABI_VERSION};
+///
+/// assert!(MIN_ABI_VERSION <= ABI_VERSION);
+/// ```
+pub const MIN_ABI_VERSION: u32 = 2;
 
 /// The full identity of the rustc that compiled this crate
 ///

--- a/crates/whisker-types/src/plugin/declaration.rs
+++ b/crates/whisker-types/src/plugin/declaration.rs
@@ -1,5 +1,6 @@
 use std::ffi::c_char;
 
+use crate::RuleId;
 use crate::plugin::LintRegistrar;
 
 /// The entry point a custom lint plugin exports
@@ -63,6 +64,24 @@ pub struct PluginDeclaration {
     /// The host calls this once, after the handshake, with a registrar
     /// that collects one factory per lint.
     pub register: fn(&mut dyn LintRegistrar),
+
+    /// Returns every rule this plugin can report
+    ///
+    /// A project names the rules it runs, and whisker refuses a name that
+    /// no loaded plugin declares. Without this, a misspelled name would
+    /// disable nothing and say nothing, which reads exactly like a rule
+    /// that found no fault.
+    ///
+    /// This is the first field a plugin may lack. A plugin built against
+    /// protocol 2 ends after `register`, so whisker reads this only once
+    /// [`PluginDeclaration::abi_version`] says it is there. Anything
+    /// added later goes on the end for the same reason: a `#[repr(C)]`
+    /// struct has offsets whisker can reason about, and a vtable does
+    /// not, so a capability that some plugins lack belongs here rather
+    /// than on [`LintPass`].
+    ///
+    /// [`LintPass`]: crate::LintPass
+    pub rules: fn() -> Vec<RuleId>,
 }
 
 unsafe impl Send for PluginDeclaration {}

--- a/crates/whisker-types/src/plugin/declaration.rs
+++ b/crates/whisker-types/src/plugin/declaration.rs
@@ -98,6 +98,26 @@ mod tests {
         assert_eq!(offset_of!(PluginDeclaration, abi_version), 0);
     }
 
+    /// Pins that protocol 3's field was appended rather than inserted
+    ///
+    /// A plugin built against protocol 2 exported everything up to
+    /// `register` and nothing after it. Whisker reads those fields at the
+    /// offsets this struct gives, so a field inserted among them would
+    /// move the rest and whisker would read one plugin's data as another
+    /// field. That is silent: the fields are integers and pointers, and a
+    /// wrong one is a wrong answer rather than a crash. A new field goes
+    /// last, and this test fails if one does not.
+    #[test]
+    fn rules_sits_after_every_field_protocol_two_exported() {
+        let rules = offset_of!(PluginDeclaration, rules);
+
+        assert!(offset_of!(PluginDeclaration, abi_version) < rules);
+        assert!(offset_of!(PluginDeclaration, rustc_version) < rules);
+        assert!(offset_of!(PluginDeclaration, types_fingerprint) < rules);
+        assert!(offset_of!(PluginDeclaration, language_fingerprint) < rules);
+        assert!(offset_of!(PluginDeclaration, register) < rules);
+    }
+
     #[test]
     fn trait_send() {
         fn assert_send<T: Send>() {}

--- a/crates/whisker/src/commands/check.rs
+++ b/crates/whisker/src/commands/check.rs
@@ -115,6 +115,11 @@ pub async fn check(args: CheckArgs, _context: Context) -> CommandResult {
     let custom_lints =
         CustomLints::load(&config).context("failed to load the project's custom lints")?;
 
+    config
+        .rules()
+        .validate(&custom_lints.declared())
+        .context("failed to read the project's [rules]")?;
+
     let on_error = match keep_going {
         true => WalkErrorPolicy::ReportAndContinue,
         false => WalkErrorPolicy::Fail,
@@ -164,6 +169,11 @@ pub async fn check(args: CheckArgs, _context: Context) -> CommandResult {
 
         match pipeline.run_on_source(&source, file, &providers, &mut passes) {
             Ok(diagnostics) => {
+                let diagnostics: Vec<_> = diagnostics
+                    .into_iter()
+                    .filter(|diagnostic| config.rules().admits(&diagnostic.rule_id()))
+                    .collect();
+
                 if !diagnostics.is_empty() {
                     let arc_path: Arc<Path> = file.clone().into();
                     sources.insert(arc_path, source);

--- a/crates/whisker/src/config.rs
+++ b/crates/whisker/src/config.rs
@@ -11,12 +11,14 @@ mod git_url;
 mod ignore_pattern;
 mod lint_path;
 mod lint_source;
+mod rule_filter;
 
 pub use git_rev::GitRev;
 pub use git_url::GitUrl;
 pub use ignore_pattern::IgnorePattern;
 pub use lint_path::LintPath;
 pub use lint_source::{GitLintSource, LintSource};
+pub use rule_filter::RuleFilter;
 
 /// The name whisker's configuration file carries
 ///
@@ -44,6 +46,7 @@ pub struct WhiskerConfig {
     root: ProjectRoot,
     ignore: Vec<IgnorePattern>,
     lints: Vec<LintSource>,
+    rules: RuleFilter,
 }
 
 impl WhiskerConfig {
@@ -59,11 +62,39 @@ impl WhiskerConfig {
     /// );
     /// ```
     pub fn new(root: ProjectRoot, ignore: Vec<IgnorePattern>, lints: Vec<LintSource>) -> Self {
+        Self::with_rules(root, ignore, lints, RuleFilter::All)
+    }
+
+    /// Creates a configuration that runs only the rules `rules` admits
+    ///
+    /// # Examples
+    ///
+    /// ```ignore
+    /// let config = WhiskerConfig::with_rules(root, ignore, lints, filter);
+    /// ```
+    pub fn with_rules(
+        root: ProjectRoot,
+        ignore: Vec<IgnorePattern>,
+        lints: Vec<LintSource>,
+        rules: RuleFilter,
+    ) -> Self {
         Self {
             root,
             ignore,
             lints,
+            rules,
         }
+    }
+
+    /// Returns which of the loaded rules this project runs
+    ///
+    /// # Examples
+    ///
+    /// ```ignore
+    /// let admitted = config.rules().admits(diagnostic.rule());
+    /// ```
+    pub fn rules(&self) -> &RuleFilter {
+        &self.rules
     }
 
     /// Loads the configuration that governs `path`
@@ -105,9 +136,18 @@ impl WhiskerConfig {
 
         let root = project.root().clone();
 
-        let Some(ConfigTable { ignore, lints }) = project.configuration() else {
+        let Some(ConfigTable {
+            ignore,
+            lints,
+            rules,
+        }) = project.configuration()
+        else {
             return Ok(Self::new(root, Vec::new(), Vec::new()));
         };
+
+        let RulesTable { enable, disable } = rules.clone();
+        let rules = RuleFilter::new(enable, disable)
+            .with_context(|| format!("failed to read {}", project.configuration_path()))?;
 
         let ignore = ignore
             .iter()
@@ -125,7 +165,7 @@ impl WhiskerConfig {
             .collect::<anyhow::Result<Vec<_>>>()
             .with_context(|| format!("failed to read {}", project.configuration_path()))?;
 
-        Ok(Self::new(root, ignore, lints))
+        Ok(Self::with_rules(root, ignore, lints, rules))
     }
 
     /// Returns the project directory that anchors the ignore patterns
@@ -202,6 +242,23 @@ struct ConfigTable {
 
     #[serde(default)]
     lints: Vec<LintEntry>,
+
+    #[serde(default)]
+    rules: RulesTable,
+}
+
+/// The `[rules]` table as written on disk
+///
+/// Both lists are read, and [`RuleFilter::new`] refuses a file that fills
+/// in both, so the contradiction is reported rather than resolved.
+#[derive(Clone, Eq, PartialEq, Debug, Default, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct RulesTable {
+    #[serde(default)]
+    enable: Vec<String>,
+
+    #[serde(default)]
+    disable: Vec<String>,
 }
 
 /// One `[[lints]]` entry as written on disk

--- a/crates/whisker/src/config/rule_filter.rs
+++ b/crates/whisker/src/config/rule_filter.rs
@@ -1,0 +1,207 @@
+use std::collections::BTreeSet;
+
+use whisker_types::RuleId;
+
+/// Which of a source's rules a project runs
+///
+/// A `[[lints]]` entry loads every rule its source provides, because the
+/// libraries arrive as one unit and whisker cannot ask a plugin what it
+/// reports. A project that wants some of them says so here, and whisker
+/// drops the diagnostics of the rest.
+///
+/// A project adopting whisker names the rules it is ready for, and adds
+/// to the list as it fixes what they find. A project that wants all but
+/// a few names those few instead. Naming both is a contradiction rather
+/// than a combination, and the configuration is refused.
+#[derive(Clone, Eq, PartialEq, Debug, Default)]
+pub enum RuleFilter {
+    /// Every rule a source provides
+    #[default]
+    All,
+
+    /// Only the rules named
+    Only(BTreeSet<String>),
+
+    /// Every rule except those named
+    Except(BTreeSet<String>),
+}
+
+impl RuleFilter {
+    /// Builds the filter that `enable` and `disable` describe
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if both name something, because a project that
+    /// says which rules run has already said which do not.
+    pub fn new(enable: Vec<String>, disable: Vec<String>) -> anyhow::Result<Self> {
+        match (enable.is_empty(), disable.is_empty()) {
+            (true, true) => Ok(Self::All),
+            (false, true) => Ok(Self::Only(enable.into_iter().collect())),
+            (true, false) => Ok(Self::Except(disable.into_iter().collect())),
+            (false, false) => Err(anyhow::anyhow!(
+                "[rules] names both enable and disable; naming the rules that run already \
+                 says which do not"
+            )),
+        }
+    }
+
+    /// Reports whether a diagnostic from `rule` reaches the report
+    pub fn admits(&self, rule: &RuleId) -> bool {
+        match self {
+            Self::All => true,
+            Self::Only(named) => named.contains(rule.as_str()),
+            Self::Except(named) => !named.contains(rule.as_str()),
+        }
+    }
+
+    /// Reports the names this filter uses that no loaded rule declares
+    ///
+    /// # Errors
+    ///
+    /// Returns an error naming every one of them. A misspelled rule
+    /// disables nothing and reads exactly like a rule that found no
+    /// fault, so whisker refuses the file rather than the reader having
+    /// to notice.
+    pub fn validate(&self, declared: &BTreeSet<String>) -> anyhow::Result<()> {
+        let unknown: Vec<&str> = self
+            .named()
+            .iter()
+            .filter(|name| !declared.contains(*name))
+            .map(String::as_str)
+            .collect();
+
+        anyhow::ensure!(
+            unknown.is_empty(),
+            "[rules] names {}, which no configured lint reports; the lints loaded here report {}",
+            unknown.join(", "),
+            match declared.is_empty() {
+                true => "nothing".to_owned(),
+                false => declared
+                    .iter()
+                    .map(String::as_str)
+                    .collect::<Vec<_>>()
+                    .join(", "),
+            }
+        );
+
+        Ok(())
+    }
+
+    /// Returns the rules this filter names, which a run may never see
+    ///
+    /// A name that no loaded rule reports is worth saying out loud. It is
+    /// a typo, or a rule that reports nothing here, and whisker cannot
+    /// tell those apart: a plugin declares no rule ids, so the only ones
+    /// whisker learns are the ones it is handed in a diagnostic.
+    pub fn named(&self) -> &BTreeSet<String> {
+        static NONE: BTreeSet<String> = BTreeSet::new();
+
+        match self {
+            Self::All => &NONE,
+            Self::Only(named) | Self::Except(named) => named,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn rule(id: &'static str) -> RuleId {
+        RuleId::new(id)
+    }
+
+    fn names(values: &[&str]) -> Vec<String> {
+        values.iter().map(|value| (*value).to_owned()).collect()
+    }
+
+    #[test]
+    fn admits_everything_when_nothing_is_named() {
+        let filter = RuleFilter::new(Vec::new(), Vec::new()).expect("should build");
+
+        assert!(filter.admits(&rule("lint.anything")));
+    }
+
+    #[test]
+    fn admits_only_an_enabled_rule() {
+        let filter = RuleFilter::new(names(&["lint.wanted"]), Vec::new()).expect("should build");
+
+        assert!(filter.admits(&rule("lint.wanted")));
+        assert!(!filter.admits(&rule("lint.other")));
+    }
+
+    #[test]
+    fn admits_everything_but_a_disabled_rule() {
+        let filter = RuleFilter::new(Vec::new(), names(&["lint.noisy"])).expect("should build");
+
+        assert!(!filter.admits(&rule("lint.noisy")));
+        assert!(filter.admits(&rule("lint.other")));
+    }
+
+    #[test]
+    fn named_returns_nothing_for_an_unfiltered_project() {
+        let filter = RuleFilter::new(Vec::new(), Vec::new()).expect("should build");
+
+        assert!(filter.named().is_empty());
+    }
+
+    #[test]
+    fn named_returns_the_rules_a_project_wrote() {
+        let filter = RuleFilter::new(Vec::new(), names(&["lint.noisy"])).expect("should build");
+
+        assert_eq!(filter.named().len(), 1);
+        assert!(filter.named().contains("lint.noisy"));
+    }
+
+    #[test]
+    fn validate_accepts_a_name_a_lint_declares() {
+        let filter = RuleFilter::new(Vec::new(), names(&["lint.known"])).expect("should build");
+        let declared = BTreeSet::from(["lint.known".to_owned()]);
+
+        filter.validate(&declared).expect("should accept");
+    }
+
+    #[test]
+    fn validate_refuses_a_name_no_lint_declares() {
+        let filter = RuleFilter::new(Vec::new(), names(&["lint.typo"])).expect("should build");
+        let declared = BTreeSet::from(["lint.known".to_owned()]);
+
+        let error = filter.validate(&declared).expect_err("should fail");
+
+        assert!(format!("{error:#}").contains("lint.typo"), "{error:#}");
+        assert!(format!("{error:#}").contains("lint.known"), "{error:#}");
+    }
+
+    #[test]
+    fn validate_accepts_an_unfiltered_project() {
+        let filter = RuleFilter::new(Vec::new(), Vec::new()).expect("should build");
+
+        filter.validate(&BTreeSet::new()).expect("should accept");
+    }
+
+    #[test]
+    fn new_with_both_lists_returns_error() {
+        let error =
+            RuleFilter::new(names(&["lint.a"]), names(&["lint.b"])).expect_err("should fail");
+
+        assert!(format!("{error:#}").contains("both"), "{error:#}");
+    }
+
+    #[test]
+    fn trait_send() {
+        fn assert_send<T: Send>() {}
+        assert_send::<RuleFilter>();
+    }
+
+    #[test]
+    fn trait_sync() {
+        fn assert_sync<T: Sync>() {}
+        assert_sync::<RuleFilter>();
+    }
+
+    #[test]
+    fn trait_unpin() {
+        fn assert_unpin<T: Unpin>() {}
+        assert_unpin::<RuleFilter>();
+    }
+}

--- a/crates/whisker/src/custom_lints.rs
+++ b/crates/whisker/src/custom_lints.rs
@@ -1,12 +1,12 @@
-use std::collections::HashSet;
+use std::collections::{BTreeSet, HashSet};
 use std::ffi::{CStr, OsString, c_char};
 use std::path::{Path, PathBuf};
 use std::process::{Command, Stdio};
 
 use anyhow::Context as _;
 use libloading::Library;
-use whisker_types::LintPass;
 use whisker_types::plugin::{LintPassFactory, LintRegistrar, PluginDeclaration};
+use whisker_types::{LintPass, RuleId};
 
 use self::handshake::AbiIdentity;
 use crate::config::{GitLintSource, LintSource, WhiskerConfig};
@@ -35,6 +35,7 @@ pub use abi_tag::AbiTag;
 /// `--keep-going` governs per-file walk errors, not a broken setup.
 pub struct CustomLints {
     factories: Vec<LintPassFactory>,
+    declared: Vec<RuleId>,
 }
 
 impl CustomLints {
@@ -48,6 +49,7 @@ impl CustomLints {
     pub fn load(config: &WhiskerConfig) -> anyhow::Result<Self> {
         let host = AbiIdentity::host();
         let mut factories = Vec::new();
+        let mut declared = Vec::new();
 
         for Resolved {
             directory,
@@ -67,15 +69,40 @@ impl CustomLints {
                 }),
             }?;
 
-            factories.extend(loaded);
+            factories.extend(loaded.factories);
+            declared.extend(loaded.rules);
         }
 
-        Ok(Self { factories })
+        Ok(Self {
+            factories,
+            declared,
+        })
     }
 
     /// Constructs one fresh pass per loaded custom lint
+    ///
+    /// Every pass runs. A plugin declares the rules it can report, not
+    /// which pass reports which, so a rule a project turned off is
+    /// dropped from the report rather than never looked for.
     pub fn instantiate(&self) -> Vec<Box<dyn LintPass>> {
         self.factories.iter().map(|factory| factory()).collect()
+    }
+
+    /// Returns every rule the loaded plugins declare
+    ///
+    /// This is what a configured rule name is checked against. A plugin
+    /// declares its rules, so whisker knows them all before it walks a
+    /// single file, and a name matching none of them is a mistake it can
+    /// report rather than a filter that quietly admits everything.
+    ///
+    /// A plugin built against protocol 2 declares none, because its
+    /// declaration ends before the field that would say. Its rules still
+    /// run; they just cannot be named.
+    pub fn declared(&self) -> BTreeSet<String> {
+        self.declared
+            .iter()
+            .map(|rule| rule.as_str().to_owned())
+            .collect()
     }
 }
 
@@ -226,11 +253,7 @@ fn resolve_git(source: &GitLintSource, tag: &AbiTag) -> anyhow::Result<(PathBuf,
 /// A directory may hold one package or a workspace of them, so every
 /// dynamic library the build produced is loaded, each with its own
 /// handshake.
-fn load_sources(
-    directory: &Path,
-    locking: Locking,
-    host: &AbiIdentity,
-) -> anyhow::Result<Vec<LintPassFactory>> {
+fn load_sources(directory: &Path, locking: Locking, host: &AbiIdentity) -> anyhow::Result<Loaded> {
     let libraries = build(directory, locking)?;
 
     load_libraries(&libraries, host)
@@ -248,7 +271,7 @@ fn load_sources(
 ///
 /// Returns an error if the directory cannot be read, if it holds no
 /// library, or if any library fails to load.
-fn load_prebuilt(directory: &Path, host: &AbiIdentity) -> anyhow::Result<Vec<LintPassFactory>> {
+fn load_prebuilt(directory: &Path, host: &AbiIdentity) -> anyhow::Result<Loaded> {
     let libraries = prebuilt::libraries(directory)?;
 
     anyhow::ensure!(
@@ -260,19 +283,24 @@ fn load_prebuilt(directory: &Path, host: &AbiIdentity) -> anyhow::Result<Vec<Lin
 }
 
 /// Completes the handshake with each library and collects what registers
-fn load_libraries(
-    libraries: &[PathBuf],
-    host: &AbiIdentity,
-) -> anyhow::Result<Vec<LintPassFactory>> {
-    let mut factories = Vec::new();
+fn load_libraries(libraries: &[PathBuf], host: &AbiIdentity) -> anyhow::Result<Loaded> {
+    let mut all = Loaded::default();
 
     for library in libraries {
         let loaded = load_library(library, host)
             .with_context(|| format!("failed to load {}", library.display()))?;
-        factories.extend(loaded);
+        all.factories.extend(loaded.factories);
+        all.rules.extend(loaded.rules);
     }
 
-    Ok(factories)
+    Ok(all)
+}
+
+/// What one library, or a directory of them, contributed
+#[derive(Default)]
+struct Loaded {
+    factories: Vec<LintPassFactory>,
+    rules: Vec<RuleId>,
 }
 
 /// Compiles the packages at `directory` and returns every library built
@@ -317,6 +345,12 @@ fn build(directory: &Path, locking: Locking) -> anyhow::Result<Vec<PathBuf>> {
     artifact::cdylib_artifacts(&stdout, directory)
 }
 
+/// The first protocol version whose declaration names the plugin's rules
+///
+/// Whisker still loads a plugin older than this. It declares no rules, so
+/// a project cannot name them in `[rules]`, and every one of them runs.
+const RULES_FROM: u32 = 3;
+
 /// Opens the built library, performs the handshake, and collects factories
 ///
 /// The loader reads the declaration's leading protocol version through a
@@ -337,7 +371,7 @@ fn build(directory: &Path, locking: Locking) -> anyhow::Result<Vec<PathBuf>> {
 /// declaration, fails the ABI handshake, or registers no lints.
 ///
 /// [`RuleId`]: whisker_types::RuleId
-fn load_library(library: &Path, host: &AbiIdentity) -> anyhow::Result<Vec<LintPassFactory>> {
+fn load_library(library: &Path, host: &AbiIdentity) -> anyhow::Result<Loaded> {
     let library = unsafe { Library::new(library) }
         .with_context(|| format!("failed to open {}", library.display()))?;
 
@@ -350,10 +384,11 @@ fn load_library(library: &Path, host: &AbiIdentity) -> anyhow::Result<Vec<LintPa
     let declaration: *const PluginDeclaration = *declaration;
 
     let plugin_abi_version = unsafe { abi_version(declaration) };
-    if plugin_abi_version != host.abi_version {
+    if !handshake::supported(plugin_abi_version) {
         return Err(handshake::HandshakeMismatch::AbiVersion {
-            host: host.abi_version,
             plugin: plugin_abi_version,
+            oldest: whisker_rust::plugin::MIN_ABI_VERSION,
+            newest: whisker_rust::plugin::ABI_VERSION,
         }
         .into());
     }
@@ -373,6 +408,16 @@ fn load_library(library: &Path, host: &AbiIdentity) -> anyhow::Result<Vec<LintPa
     };
     (declaration.register)(&mut registrar);
 
+    // A plugin built against protocol 2 has no `rules` field: its
+    // declaration ends after `register`. Reading one would read past the
+    // static it exported, so the version decides whether to look. This is
+    // why an optional capability belongs in this `#[repr(C)]` struct and
+    // not on a trait, whose vtable whisker cannot measure.
+    let rules = match plugin_abi_version >= RULES_FROM {
+        true => (declaration.rules)(),
+        false => Vec::new(),
+    };
+
     anyhow::ensure!(
         !registrar.factories.is_empty(),
         "the plugin registered no lints; a plugin that does nothing looks exactly like one that \
@@ -381,7 +426,10 @@ fn load_library(library: &Path, host: &AbiIdentity) -> anyhow::Result<Vec<LintPa
 
     std::mem::forget(library);
 
-    Ok(registrar.factories)
+    Ok(Loaded {
+        factories: registrar.factories,
+        rules,
+    })
 }
 
 /// Reads the protocol version at the head of a plugin declaration

--- a/crates/whisker/src/custom_lints.rs
+++ b/crates/whisker/src/custom_lints.rs
@@ -353,11 +353,19 @@ const RULES_FROM: u32 = 3;
 
 /// Opens the built library, performs the handshake, and collects factories
 ///
-/// The loader reads the declaration's leading protocol version through a
-/// raw pointer, and only a matching version licenses a reference to the
-/// whole struct: a plugin of another protocol may export a shorter or
-/// differently shaped declaration, and a reference to that is already
-/// undefined behavior.
+/// The loader never forms a `&PluginDeclaration`. A plugin built against
+/// an older protocol exports a shorter static, and a reference asserts
+/// that the whole of the current struct is there and holds a valid value
+/// of every field. Both claims are false for such a plugin, and `rules`
+/// is a function pointer, so the compiler may assume it is not null. That
+/// is undefined behavior whether or not the field is ever read.
+///
+/// So each field is read through a raw pointer at its own offset, and a
+/// field is only projected once [`PluginDeclaration::abi_version`] says
+/// the plugin exported it. This is what makes an appended field cheap:
+/// the offsets of a `#[repr(C)]` struct are knowable per version, and no
+/// step of the read depends on the plugin agreeing about the struct's
+/// size.
 ///
 /// The loader deliberately leaks the library. The registered factories and
 /// the `&'static str` inside every [`RuleId`] a plugin lint mints point into
@@ -393,28 +401,28 @@ fn load_library(library: &Path, host: &AbiIdentity) -> anyhow::Result<Loaded> {
         .into());
     }
 
-    let declaration = unsafe { &*declaration };
-
     let plugin = AbiIdentity {
         abi_version: plugin_abi_version,
-        rustc_version: read_declaration_string(declaration.rustc_version)?,
-        types_fingerprint: declaration.types_fingerprint,
-        language_fingerprint: declaration.language_fingerprint,
+        rustc_version: read_declaration_string(unsafe {
+            (&raw const (*declaration).rustc_version).read()
+        })?,
+        types_fingerprint: unsafe { (&raw const (*declaration).types_fingerprint).read() },
+        language_fingerprint: unsafe { (&raw const (*declaration).language_fingerprint).read() },
     };
     handshake::validate(host, &plugin)?;
 
     let mut registrar = Collecting {
         factories: Vec::new(),
     };
-    (declaration.register)(&mut registrar);
+    let register = unsafe { (&raw const (*declaration).register).read() };
+    register(&mut registrar);
 
-    // A plugin built against protocol 2 has no `rules` field: its
-    // declaration ends after `register`. Reading one would read past the
-    // static it exported, so the version decides whether to look. This is
-    // why an optional capability belongs in this `#[repr(C)]` struct and
-    // not on a trait, whose vtable whisker cannot measure.
     let rules = match plugin_abi_version >= RULES_FROM {
-        true => (declaration.rules)(),
+        true => {
+            let rules = unsafe { (&raw const (*declaration).rules).read() };
+
+            rules()
+        }
         false => Vec::new(),
     };
 

--- a/crates/whisker/src/custom_lints/abi_tag.rs
+++ b/crates/whisker/src/custom_lints/abi_tag.rs
@@ -1,5 +1,7 @@
 use std::fmt;
 
+use whisker_rust::plugin;
+
 use super::digest::digest;
 use super::handshake::AbiIdentity;
 
@@ -47,14 +49,22 @@ impl AbiTag {
     /// input to the digest.
     pub(super) fn new(identity: &AbiIdentity, target: &str) -> Self {
         let AbiIdentity {
-            abi_version,
+            abi_version: _,
             rustc_version,
             types_fingerprint,
             language_fingerprint,
         } = identity;
 
+        // The floor rather than the version whisker writes. Whisker loads
+        // every protocol from the floor upward, so two whiskers sharing
+        // one accept each other's archives, and raising the version alone
+        // does not strand what a publisher already built. Raising the
+        // floor does, which is the point: that is when older plugins stop
+        // loading.
+        let floor = plugin::MIN_ABI_VERSION;
+
         let key = digest(&format!(
-            "{abi_version}\n{rustc_version}\n{types_fingerprint:016x}\n{language_fingerprint:016x}"
+            "{floor}\n{rustc_version}\n{types_fingerprint:016x}\n{language_fingerprint:016x}"
         ));
 
         Self(format!("{key}-{target}"))
@@ -92,14 +102,21 @@ mod tests {
         assert_eq!(tag.to_string(), "4d1b722e64837210-aarch64-apple-darwin");
     }
 
+    /// A protocol version is not part of the tag
+    ///
+    /// Whisker loads every protocol from the floor upward, so two
+    /// whiskers that share a floor accept each other's archives. Raising
+    /// the version alone must therefore not strand what a publisher has
+    /// already built; raising the floor does, which is what the floor is
+    /// for.
     #[test]
-    fn new_separates_identities_that_differ_in_the_abi_version() {
+    fn new_ignores_the_protocol_a_whisker_writes() {
         let other = AbiIdentity {
-            abi_version: 3,
+            abi_version: identity().abi_version + 1,
             ..identity()
         };
 
-        assert_ne!(
+        assert_eq!(
             AbiTag::new(&identity(), "x86_64-unknown-linux-gnu"),
             AbiTag::new(&other, "x86_64-unknown-linux-gnu")
         );

--- a/crates/whisker/src/custom_lints/handshake.rs
+++ b/crates/whisker/src/custom_lints/handshake.rs
@@ -28,7 +28,15 @@ impl AbiIdentity {
     }
 }
 
-/// Accepts a plugin only when its identity matches the host's exactly
+/// Reports whether whisker knows the layout of a plugin's declaration
+///
+/// Whisker reads every version in this range, so a plugin older than the
+/// current protocol loads and offers less rather than being refused.
+pub fn supported(version: u32) -> bool {
+    (plugin::MIN_ABI_VERSION..=plugin::ABI_VERSION).contains(&version)
+}
+
+/// Accepts a plugin only when its identity matches the host's
 ///
 /// The checks run in the order the declaration's fields become
 /// trustworthy, and the first mismatch wins, so the reported error is the
@@ -38,10 +46,11 @@ impl AbiIdentity {
 ///
 /// Returns the first [`HandshakeMismatch`] between the two identities.
 pub fn validate(host: &AbiIdentity, plugin: &AbiIdentity) -> Result<(), HandshakeMismatch> {
-    if host.abi_version != plugin.abi_version {
+    if !supported(plugin.abi_version) {
         return Err(HandshakeMismatch::AbiVersion {
-            host: host.abi_version,
             plugin: plugin.abi_version,
+            oldest: plugin::MIN_ABI_VERSION,
+            newest: plugin::ABI_VERSION,
         });
     }
 
@@ -73,8 +82,15 @@ pub fn validate(host: &AbiIdentity, plugin: &AbiIdentity) -> Result<(), Handshak
 /// what to install.
 #[derive(Clone, Eq, PartialEq, Hash, Debug)]
 pub enum HandshakeMismatch {
-    AbiVersion { host: u32, plugin: u32 },
-    RustcVersion { host: String, plugin: String },
+    AbiVersion {
+        plugin: u32,
+        oldest: u32,
+        newest: u32,
+    },
+    RustcVersion {
+        host: String,
+        plugin: String,
+    },
     TypesFingerprint,
     LanguageFingerprint,
 }
@@ -82,10 +98,21 @@ pub enum HandshakeMismatch {
 impl fmt::Display for HandshakeMismatch {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
-            HandshakeMismatch::AbiVersion { host, plugin } => write!(
-                f,
-                "plugin speaks protocol {plugin}, whisker speaks {host}; rebuild the plugin"
-            ),
+            HandshakeMismatch::AbiVersion {
+                plugin,
+                oldest,
+                newest,
+            } => {
+                let host = match oldest == newest {
+                    true => format!("{newest}"),
+                    false => format!("{oldest}-{newest}"),
+                };
+
+                write!(
+                    f,
+                    "plugin (ABI {plugin}) incompatible with whisker (ABI {host})"
+                )
+            }
             HandshakeMismatch::RustcVersion { host, plugin } => write!(
                 f,
                 "plugin built by `{plugin}`, whisker by `{host}`; use one toolchain"
@@ -110,7 +137,7 @@ mod tests {
 
     fn identity() -> AbiIdentity {
         AbiIdentity {
-            abi_version: 1,
+            abi_version: plugin::ABI_VERSION,
             rustc_version: "rustc 1.92.0-nightly (0000000 2026-08-11)".into(),
             types_fingerprint: 0xaa,
             language_fingerprint: 0xbb,
@@ -151,16 +178,75 @@ mod tests {
         validate(&identity(), &identity()).expect("should match");
     }
 
+    /// A version outside the supported range is reported before anything
+    /// else, because the fields the rest reads are only readable once the
+    /// declaration's shape is known.
     #[test]
-    fn validate_reports_a_differing_abi_version_first() {
+    fn validate_reports_an_unsupported_abi_version_first() {
         let mut plugin = identity();
-        plugin.abi_version = 2;
+        plugin.abi_version = plugin::ABI_VERSION + 1;
         plugin.rustc_version = "rustc 2.0.0".into();
 
         let error = validate(&identity(), &plugin).expect_err("should mismatch");
 
-        assert_eq!(error, HandshakeMismatch::AbiVersion { host: 1, plugin: 2 });
-        assert!(error.to_string().contains("rebuild the plugin"));
+        assert_eq!(
+            error,
+            HandshakeMismatch::AbiVersion {
+                plugin: plugin::ABI_VERSION + 1,
+                oldest: plugin::MIN_ABI_VERSION,
+                newest: plugin::ABI_VERSION,
+            }
+        );
+    }
+
+    /// A plugin from an older protocol is loaded rather than refused. Its
+    /// declaration ends sooner, and whisker knows that shape.
+    #[test]
+    fn validate_accepts_the_oldest_supported_abi_version() {
+        let mut plugin = identity();
+        plugin.abi_version = plugin::MIN_ABI_VERSION;
+
+        validate(&identity(), &plugin).expect("should accept");
+    }
+
+    #[test]
+    fn supported_spans_the_versions_whisker_can_read() {
+        assert!(!supported(plugin::MIN_ABI_VERSION - 1));
+        assert!(supported(plugin::MIN_ABI_VERSION));
+        assert!(supported(plugin::ABI_VERSION));
+        assert!(!supported(plugin::ABI_VERSION + 1));
+    }
+
+    /// The host side names every protocol whisker reads, not just the
+    /// newest, because a plugin between the two is accepted and a reader
+    /// who saw only the newest would rebuild for no reason.
+    #[test]
+    fn an_abi_mismatch_names_the_range_whisker_reads() {
+        let error = HandshakeMismatch::AbiVersion {
+            plugin: 7,
+            oldest: 2,
+            newest: 3,
+        };
+
+        assert_eq!(
+            error.to_string(),
+            "plugin (ABI 7) incompatible with whisker (ABI 2-3)"
+        );
+    }
+
+    /// A whisker that reads one protocol names one, not a range of one.
+    #[test]
+    fn an_abi_mismatch_names_one_version_when_that_is_all_whisker_reads() {
+        let error = HandshakeMismatch::AbiVersion {
+            plugin: 7,
+            oldest: 3,
+            newest: 3,
+        };
+
+        assert_eq!(
+            error.to_string(),
+            "plugin (ABI 7) incompatible with whisker (ABI 3)"
+        );
     }
 
     #[test]

--- a/crates/whisker/tests/custom_lints.rs
+++ b/crates/whisker/tests/custom_lints.rs
@@ -5,6 +5,11 @@ use assert_cmd::prelude::*;
 use predicates::prelude::*;
 use tempfile::TempDir;
 
+#[path = "support/protocol_two_plugin.rs"]
+mod protocol_two_plugin;
+
+use protocol_two_plugin::write_protocol_two_lint_package;
+
 /// Source that trips the example lint and none of the built-ins
 const TODO_SOURCE: &str = "pub fn later() {\n    todo!()\n}\n";
 
@@ -141,6 +146,11 @@ fn workspace_of_lints() -> TempDir {
                 "use whisker_rust::RustLintPass;\n\
                  use whisker_types::{{DecoratedNode, Diagnostic, RuleId, Severity}};\n\n\
                  pub struct Flag;\n\n\
+                 impl whisker_rust::DeclaresRules for Flag {{\n\
+                 \x20   fn rules(&self) -> Vec<RuleId> {{\n\
+                 \x20       vec![RuleId::new(\"{rule}\")]\n\
+                 \x20   }}\n\
+                 }}\n\n\
                  impl RustLintPass for Flag {{\n\
                  \x20   fn {method}(&mut self, node: &DecoratedNode<'_>) -> Vec<Diagnostic> {{\n\
                  \x20       vec![Diagnostic::new(\n\
@@ -158,6 +168,140 @@ fn workspace_of_lints() -> TempDir {
     }
 
     directory
+}
+
+/// Pins that a project runs only the rules it names
+#[test]
+fn check_with_an_enabled_rule_runs_only_that_rule() {
+    let target = package(TODO_SOURCE);
+    let lints = workspace_of_lints();
+    let lint_path = toml::Value::from(lints.path().to_str().expect("the path should be UTF-8"));
+    write_config(
+        target.path(),
+        &format!("[rules]\nenable = [\"workspace.second\"]\n\n[[lints]]\npath = {lint_path}\n"),
+    );
+
+    whisker()
+        .env("CARGO_TARGET_DIR", shared_build_directory())
+        .arg("check")
+        .arg(target.path())
+        .assert()
+        .success()
+        .stderr(predicate::str::contains("warning[workspace.second]"))
+        .stderr(predicate::str::contains("workspace.first").not());
+}
+
+/// Pins that a disabled rule reports nothing and the others still do
+#[test]
+fn check_with_a_disabled_rule_runs_the_rest() {
+    let target = package(TODO_SOURCE);
+    let lints = workspace_of_lints();
+    let lint_path = toml::Value::from(lints.path().to_str().expect("the path should be UTF-8"));
+    write_config(
+        target.path(),
+        &format!("[rules]\ndisable = [\"workspace.first\"]\n\n[[lints]]\npath = {lint_path}\n"),
+    );
+
+    whisker()
+        .env("CARGO_TARGET_DIR", shared_build_directory())
+        .arg("check")
+        .arg(target.path())
+        .assert()
+        .success()
+        .stderr(predicate::str::contains("warning[workspace.second]"))
+        .stderr(predicate::str::contains("workspace.first").not());
+}
+
+/// Pins that a name no lint reports is refused
+///
+/// A misspelled rule would otherwise disable nothing and say nothing,
+/// which reads exactly like a rule that found no fault. The error names
+/// what the loaded lints do report, so the fix is in front of the reader.
+#[test]
+fn check_with_a_rule_no_lint_reports_fails() {
+    let target = package(TODO_SOURCE);
+    let lints = workspace_of_lints();
+    let lint_path = toml::Value::from(lints.path().to_str().expect("the path should be UTF-8"));
+    write_config(
+        target.path(),
+        &format!("[rules]\ndisable = [\"workspace.frist\"]\n\n[[lints]]\npath = {lint_path}\n"),
+    );
+
+    whisker()
+        .env("CARGO_TARGET_DIR", shared_build_directory())
+        .arg("check")
+        .arg(target.path())
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains("workspace.frist"))
+        .stderr(predicate::str::contains("workspace.first"));
+}
+
+/// Pins that naming both lists is refused rather than resolved
+#[test]
+fn check_with_both_rule_lists_fails() {
+    let target = package(TODO_SOURCE);
+    write_config(
+        target.path(),
+        "[rules]\nenable = [\"a.b\"]\ndisable = [\"c.d\"]\n",
+    );
+
+    whisker()
+        .arg("check")
+        .arg(target.path())
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains("both"));
+}
+
+/// Pins that a plugin from an older protocol still loads
+///
+/// A protocol is raised when the declaration gains a field, and such a
+/// plugin ends before it. Whisker knows the older layout, so it reads
+/// what the plugin has and treats the rest as absent, and the rules of an
+/// older plugin still run.
+///
+/// This is why an optional capability belongs in the declaration and not
+/// on a trait: a `#[repr(C)]` struct has offsets whisker can reason
+/// about, and a vtable has none it can measure.
+#[test]
+fn check_with_a_plugin_from_an_older_protocol_loads_it() {
+    let target = package(TODO_SOURCE);
+    let lints = tempfile::tempdir().expect("temporary directory should be created");
+    write_protocol_two_lint_package(lints.path(), "older_lint", "older.fired");
+    configure_lint(target.path(), lints.path());
+
+    whisker()
+        .env("CARGO_TARGET_DIR", shared_build_directory())
+        .arg("check")
+        .arg(target.path())
+        .assert()
+        .success()
+        .stderr(predicate::str::contains("warning[older.fired]"));
+}
+
+/// Pins that an older plugin's rules cannot be named
+///
+/// It declares none, so whisker has nothing to check a name against and
+/// says so, rather than accepting a name it cannot honour.
+#[test]
+fn check_naming_a_rule_of_an_older_plugin_fails() {
+    let target = package(TODO_SOURCE);
+    let lints = tempfile::tempdir().expect("temporary directory should be created");
+    write_protocol_two_lint_package(lints.path(), "older_named", "older.fired");
+    let lint_path = toml::Value::from(lints.path().to_str().expect("the path should be UTF-8"));
+    write_config(
+        target.path(),
+        &format!("[rules]\ndisable = [\"older.fired\"]\n\n[[lints]]\npath = {lint_path}\n"),
+    );
+
+    whisker()
+        .env("CARGO_TARGET_DIR", shared_build_directory())
+        .arg("check")
+        .arg(target.path())
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains("older.fired"));
 }
 
 /// Pins the error for a repository that cannot be reached

--- a/crates/whisker/tests/prebuilt_lints.rs
+++ b/crates/whisker/tests/prebuilt_lints.rs
@@ -326,7 +326,7 @@ fn check_with_a_prebuilt_that_fails_the_handshake_fails() {
         .arg(target.path())
         .assert()
         .failure()
-        .stderr(predicate::str::contains("speaks protocol"))
+        .stderr(predicate::str::contains("incompatible with whisker"))
         .stderr(predicate::str::contains(
             destination.to_string_lossy().into_owned(),
         ));

--- a/crates/whisker/tests/support/fixture_repository.rs
+++ b/crates/whisker/tests/support/fixture_repository.rs
@@ -205,6 +205,12 @@ impl RustLintPass for {pass} {{
     }}
 }}
 
+impl whisker_rust::DeclaresRules for {pass} {{
+    fn rules(&self) -> Vec<RuleId> {{
+        vec![RuleId::new("{rule}")]
+    }}
+}}
+
 whisker_rust::export_lints![{pass}];
 "#
     )

--- a/crates/whisker/tests/support/mismatched_plugin.rs
+++ b/crates/whisker/tests/support/mismatched_plugin.rs
@@ -36,6 +36,11 @@ pub fn write_mismatched_lint_package(directory: &Path, name: &str) {
 /// Registers no lint, because the handshake refuses this library first
 fn register(_registrar: &mut dyn LintRegistrar) {}
 
+/// Declares no rule, for the same reason
+fn rules() -> Vec<whisker_types::RuleId> {
+    Vec::new()
+}
+
 #[unsafe(no_mangle)]
 #[allow(non_upper_case_globals)]
 pub static whisker_plugin_declaration: PluginDeclaration = PluginDeclaration {
@@ -44,6 +49,7 @@ pub static whisker_plugin_declaration: PluginDeclaration = PluginDeclaration {
     types_fingerprint: whisker_types::plugin::TYPES_FINGERPRINT,
     language_fingerprint: 0,
     register,
+    rules,
 };
 "#,
     )

--- a/crates/whisker/tests/support/protocol_two_plugin.rs
+++ b/crates/whisker/tests/support/protocol_two_plugin.rs
@@ -1,0 +1,86 @@
+use std::path::Path;
+
+/// Writes a lint package whose declaration is the one protocol 2 defined
+///
+/// The package spells the older declaration out itself, as a `#[repr(C)]`
+/// struct ending after `register`, which is exactly the shape a plugin
+/// built before protocol 3 exports. It cannot use whisker's own
+/// [`PluginDeclaration`], because that one has the field this plugin is
+/// meant to lack.
+///
+/// A test uses this to prove that whisker still loads such a plugin. The
+/// rules of an older plugin run; they only cannot be named in `[rules]`,
+/// because it declares none.
+///
+/// [`PluginDeclaration`]: whisker_types::plugin::PluginDeclaration
+///
+/// # Panics
+///
+/// Panics if the package cannot be written.
+pub fn write_protocol_two_lint_package(directory: &Path, name: &str, rule: &str) {
+    let crates = Path::new(env!("CARGO_MANIFEST_DIR")).join("..");
+    let crates = std::fs::canonicalize(crates).expect("the crates directory should exist");
+    let crates = crates.to_str().expect("the path should be UTF-8");
+
+    std::fs::create_dir_all(directory.join("src")).expect("the package should be created");
+    std::fs::write(
+        directory.join("Cargo.toml"),
+        format!(
+            "[workspace]\n\n[package]\nname = \"{name}\"\nversion = \"0.1.0\"\nedition = \
+             \"2024\"\npublish = false\n\n[lib]\ncrate-type = [\"cdylib\"]\n\n[dependencies]\n\
+             whisker-rust = {{ path = \"{crates}/whisker-rust\", default-features = false \
+             }}\nwhisker-types = {{ path = \"{crates}/whisker-types\" }}\n"
+        ),
+    )
+    .expect("the manifest should be written");
+    std::fs::write(
+        directory.join("src").join("lib.rs"),
+        format!(
+            r#"use whisker_rust::RustLintPass;
+use whisker_types::plugin::{{LintPassFactory, LintRegistrar}};
+use whisker_types::{{DecoratedNode, Diagnostic, RuleId, Severity}};
+
+pub struct Flag;
+
+impl RustLintPass for Flag {{
+    fn check_macro_invocation(&mut self, node: &DecoratedNode<'_>) -> Vec<Diagnostic> {{
+        vec![Diagnostic::new(
+            RuleId::new("{rule}"),
+            Severity::Warn,
+            "the older plugin fired".into(),
+            node.span(),
+        )]
+    }}
+}}
+
+/// The declaration as protocol 2 defined it, ending after `register`
+#[repr(C)]
+pub struct DeclarationV2 {{
+    pub abi_version: u32,
+    pub rustc_version: *const std::ffi::c_char,
+    pub types_fingerprint: u64,
+    pub language_fingerprint: u64,
+    pub register: fn(&mut dyn LintRegistrar),
+}}
+
+unsafe impl Sync for DeclarationV2 {{}}
+
+fn register(registrar: &mut dyn LintRegistrar) {{
+    let factory: LintPassFactory = || Box::new(whisker_rust::RustLintPassAdapter::new(Flag));
+    registrar.register(factory);
+}}
+
+#[unsafe(no_mangle)]
+#[allow(non_upper_case_globals)]
+pub static whisker_plugin_declaration: DeclarationV2 = DeclarationV2 {{
+    abi_version: 2,
+    rustc_version: whisker_types::plugin::RUSTC_VERSION.as_ptr(),
+    types_fingerprint: whisker_types::plugin::TYPES_FINGERPRINT,
+    language_fingerprint: whisker_rust::plugin::LANGUAGE_FINGERPRINT,
+    register,
+}};
+"#
+        ),
+    )
+    .expect("the source should be written");
+}

--- a/examples/custom_lint/src/lib.rs
+++ b/examples/custom_lint/src/lib.rs
@@ -38,6 +38,12 @@ impl RustLintPass for NoTodo {
     }
 }
 
+impl whisker_rust::DeclaresRules for NoTodo {
+    fn rules(&self) -> Vec<RuleId> {
+        vec![RuleId::new("custom.no-todo")]
+    }
+}
+
 whisker_rust::export_lints![NoTodo];
 
 #[cfg(test)]


### PR DESCRIPTION
Closes #331.

A `[[lints]]` entry brings every rule its source provides, and the only other lever was `--deny-warnings`. A project took all of a source's rules or none. That is what stopped raft adopting whisker: of the 2,995 warnings there, 365 come from one rule flagging the `s[impl ...]` markers its own spec-coverage gate reads out of comments, so fixing them would break `just check-specs`.

A `[rules]` table now names what runs:

```toml
[rules]
disable = ["lint.no-inline-comments"]
```

`enable` is the other half and runs only the rules named, which is how a project takes on one rule at a time. Naming both is refused. A name that no loaded plugin declares fails the run, because a misspelling would otherwise disable nothing and say nothing, which reads exactly like a rule that found no fault.

That check needs plugins to declare their rules, and where that goes decides what the upgrade costs.

My first attempt put a `rules` method on `LintPass`. That reorders a vtable, which whisker cannot measure, so every plugin ever built would have been refused and every published archive stranded. Appending a field to `PluginDeclaration` is different: the struct is `#[repr(C)]`, whisker already reads `abi_version` at offset 0 through a raw pointer before forming a reference, and so it knows where each version's fields end. A plugin that stops sooner offers less rather than being turned away.

So the protocol is 3 and whisker reads 2 upward. The consequences, all tested:

- A plugin exporting the protocol-2 declaration loads, and its rules run. There is a fixture that spells that older struct out by hand, because it is the shape a real pre-3 plugin exports.
- Such a plugin declares no rules, so naming one in `[rules]` fails rather than being silently accepted.
- The tag an archive is published under now carries `MIN_ABI_VERSION` rather than `ABI_VERSION`, so two whiskers that read the same protocols accept each other's archives.

The last one is what makes this cheap rather than expensive: **the archives already published for `v0.1.0-rc.1` are still found and still load.** I checked against the live release rather than a fixture — a cold cache downloads `f9fc0bc-2d20b32c659070af-aarch64-apple-darwin.tar.gz`, unpacks it, loads nineteen protocol-2 libraries, and reports. `check-self` passes unchanged, so none of the cross-repo sequence I described earlier is needed.

Follow-up this does not do: per-rule severity, which is the same request from the other side.
