### PR TITLE
Say what the handshake refused in one line

### DIFF
--- a/crates/whisker/src/custom_lints/handshake.rs
+++ b/crates/whisker/src/custom_lints/handshake.rs
@@ -84,24 +84,19 @@ impl fmt::Display for HandshakeMismatch {
         match self {
             HandshakeMismatch::AbiVersion { host, plugin } => write!(
                 f,
-                "the plugin speaks declaration protocol version {plugin}, but this whisker \
-                 speaks version {host}; rebuild the plugin against the whisker revision this \
-                 binary was built from"
+                "plugin speaks protocol {plugin}, whisker speaks {host}; rebuild the plugin"
             ),
             HandshakeMismatch::RustcVersion { host, plugin } => write!(
                 f,
-                "the plugin was built by `{plugin}`, but whisker was built by `{host}`; build \
-                 the plugin with the same toolchain"
+                "plugin built by `{plugin}`, whisker by `{host}`; use one toolchain"
             ),
             HandshakeMismatch::TypesFingerprint => write!(
                 f,
-                "the plugin was built against a different revision of whisker-types; update the \
-                 plugin's whisker dependencies to the revision whisker was built from"
+                "plugin built against another whisker-types; match its whisker pin"
             ),
             HandshakeMismatch::LanguageFingerprint => write!(
                 f,
-                "the plugin was built against a different revision of whisker-rust; update the \
-                 plugin's whisker dependencies to the revision whisker was built from"
+                "plugin built against another whisker-rust; match its whisker pin"
             ),
         }
     }
@@ -189,7 +184,7 @@ mod tests {
         let message = error.to_string();
         assert!(message.contains("1.92.0"), "should name both: {message}");
         assert!(message.contains("1.93.0"), "should name both: {message}");
-        assert!(message.contains("same toolchain"), "unexpected: {message}");
+        assert!(message.contains("one toolchain"), "unexpected: {message}");
     }
 
     #[test]

--- a/crates/whisker/tests/prebuilt_lints.rs
+++ b/crates/whisker/tests/prebuilt_lints.rs
@@ -326,7 +326,7 @@ fn check_with_a_prebuilt_that_fails_the_handshake_fails() {
         .arg(target.path())
         .assert()
         .failure()
-        .stderr(predicate::str::contains("protocol version"))
+        .stderr(predicate::str::contains("speaks protocol"))
         .stderr(predicate::str::contains(
             destination.to_string_lossy().into_owned(),
         ));


### PR DESCRIPTION
Each of the four handshake refusals restated where a plugin comes from and what to do about it, in a sentence the reader had already been given by the two contexts wrapping it.

Before, and this is a real one from CI:

```
the plugin speaks declaration protocol version 2, but this whisker speaks version 3;
rebuild the plugin against the whisker revision this binary was built from
```

After:

```
plugin speaks protocol 2, whisker speaks 3; rebuild the plugin
```

The other three shorten the same way. Each still names both sides and the fix:

```
plugin built by `rustc 1.92.0-nightly (…)`, whisker by `rustc 1.93.0-nightly (…)`; use one toolchain
plugin built against another whisker-types; match its whisker pin
plugin built against another whisker-rust; match its whisker pin
```

The tail that said to rebuild against the revision whisker was built from appeared in all four and was most of the words. What the reader learns is unchanged: which side is which, what each holds, and what to change.
