### PR TITLE
Let the cargo cache outlive one pull request

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,6 +3,13 @@ name: Continuous Integration
 
 "on":
   pull_request:
+  # A cache is scoped to the ref that wrote it, and a pull request can read
+  # only its own ref and the default branch. With pull requests alone,
+  # nothing ever wrote a cache on main, so every pull request started cold
+  # and saved a copy that only it would ever read. Running on main is what
+  # gives every pull request something to restore.
+  push:
+    branches: [main]
   workflow_dispatch:
 
 permissions: {}
@@ -66,8 +73,8 @@ jobs:
       - name: Remove Flox installer (if it exists)
         run: rm -f flox.x86_64-linux.deb
 
-      - name: Cache Cargo downloads and build output
-        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+      - name: Restore Cargo downloads and build output
+        uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: |
             ~/.cargo/registry/index
@@ -81,6 +88,24 @@ jobs:
         uses: flox/activate-action@7065dcbe5583b7b015f07a8ebd49d7266e3053e8 # v1.1.1
         with:
           command: just ${{ matrix.target }}
+
+      # One job writes the cache, on one branch. Every job in this matrix
+      # shares one key, and a key cannot be overwritten once it exists, so
+      # whichever job finished first used to claim it. `lint-markdown` won
+      # that race often enough to leave a 3 MB archive holding no build
+      # output at all, which every Rust job then restored and ignored.
+      # `test-rust` builds every target and its test binaries, so its
+      # directory is the one worth keeping.
+      - name: Save Cargo downloads and build output
+        if: github.event_name == 'push' && matrix.target == 'test-rust'
+        uses: actions/cache/save@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: |
+            ~/.cargo/registry/index
+            ~/.cargo/registry/cache
+            ~/.cargo/git/db
+            target
+          key: cargo-${{ runner.os }}-${{ hashFiles('Cargo.lock', 'rust-toolchain.toml') }}
 
   success:
     name: All checks succeeded


### PR DESCRIPTION
Every CI run has been reporting `Cache not found for input keys: cargo-Linux-<hash>, cargo-Linux-` and rebuilding from nothing. Two faults cause it, and both are about who may write a cache.

A cache belongs to the ref that wrote it. A run restores from its own ref and from the default branch, never from another pull request's ref. `restore-keys` widens which *keys* match, not which *scopes* are visible, which is why both entries in that message miss.

This workflow ran on `pull_request` alone. Nothing ever ran on main, so nothing ever wrote a cache main could hold, so every pull request started cold and saved a copy only it would ever read. The repository holds twenty-six caches under the same key `cargo-Linux-819771b8...`, one per pull request ref, and none on `refs/heads/main`. Twenty-six pull requests each paid full price for the same build. Running on main is what gives every pull request something to restore.

The second fault explains a stranger number. All sixteen matrix jobs run the cache step with one identical key, and a key cannot be overwritten once it exists, so whichever job finished first claimed it for that pull request. `lint-markdown` and `format-json` compile nothing, and when one of them won the race it saved an archive holding no build output. That is the 3 MB entries: pull requests 307, 308, 310, 316, 321, 327, 330, and 332 each restored 3 MB of nothing into their Rust jobs. The other pull requests got 74 MB.

So saving now happens in one job on one branch. `test-rust` is that job, because it builds every target and its test binaries, so its directory is the one worth keeping. Restoring stays on every job, so a pull request warms from main and writes nothing at all. That also ends the duplicate copies.

The cost is that CI now runs on merges to main. That run is what fills the cache, so it pays for itself on the next pull request.

Checks: `just lint-github-actions` (zizmor), `lint-yaml`, and `format-yaml` pass. Whether the cache is actually warm cannot be seen until this merges and one main run populates it, so the first pull request after this is the real test.