### PR TITLE
Deploy the documentation site by hand

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -52,7 +52,14 @@ jobs:
 
     needs: build
 
-    if: github.event_name == 'release' && github.event.action == 'released'
+    # A release deploys the site, and a prerelease does not: the pages
+    # name the version a reader downloads, and a release candidate is not
+    # it. Running this workflow by hand deploys too, which is how the site
+    # goes up between releases.
+    if: >-
+      (github.event_name == 'release' && github.event.action == 'released')
+      || (github.event_name == 'workflow_dispatch'
+      && github.ref == 'refs/heads/main')
 
     environment:
       name: github-pages


### PR DESCRIPTION
The documentation site deploys when a release is published, and no release published one yet. Whisker ships release candidates today, and a candidate does not deploy the site. The pages name the version a reader downloads, and a candidate is not that version. This behaviour stays as it is.

The result is that no run can put the site up. This pull request lets the deploy job run when someone starts the `Docs` workflow by hand on `main`. The branch matters. A manual run from another branch would publish that branch's pages as the site.

After a merge, start the `Docs` workflow from the Actions tab to publish the site at https://aonyx-ai.github.io/whisker/.

https://claude.ai/code/session_01SEr8TFrhFBbiE9uRtYVzWU
