### PR TITLE
Cache what check-self builds

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -84,6 +84,17 @@ jobs:
           key: cargo-${{ runner.os }}-${{ hashFiles('Cargo.lock', 'rust-toolchain.toml') }}
           restore-keys: cargo-${{ runner.os }}-
 
+      # `check-self` alone builds in release, so `target/release` is its own
+      # and the entry above never holds one. It restores second, beside the
+      # `target/debug` that entry carries.
+      - name: Restore the release build output
+        if: matrix.target == 'check-self'
+        uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: target/release
+          key: cargo-release-${{ runner.os }}-${{ hashFiles('Cargo.lock', 'rust-toolchain.toml') }}
+          restore-keys: cargo-release-${{ runner.os }}-
+
       - name: Run check with Just
         uses: flox/activate-action@7065dcbe5583b7b015f07a8ebd49d7266e3053e8 # v1.1.1
         with:
@@ -106,6 +117,13 @@ jobs:
             ~/.cargo/git/db
             target
           key: cargo-${{ runner.os }}-${{ hashFiles('Cargo.lock', 'rust-toolchain.toml') }}
+
+      - name: Save the release build output
+        if: github.event_name == 'push' && matrix.target == 'check-self'
+        uses: actions/cache/save@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: target/release
+          key: cargo-release-${{ runner.os }}-${{ hashFiles('Cargo.lock', 'rust-toolchain.toml') }}
 
   success:
     name: All checks succeeded

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -95,6 +95,15 @@ jobs:
           key: cargo-release-${{ runner.os }}-${{ hashFiles('Cargo.lock', 'rust-toolchain.toml') }}
           restore-keys: cargo-release-${{ runner.os }}-
 
+      # Whisker builds the pinned rules once and keeps them here. No stale
+      # revision is worth restoring, so the key has no prefix to fall back to.
+      - name: Restore the built lint sources
+        if: matrix.target == 'check-self'
+        uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: ~/.cache/whisker
+          key: lints-${{ runner.os }}-${{ hashFiles('.config/whisker.toml', 'rust-toolchain.toml') }}
+
       - name: Run check with Just
         uses: flox/activate-action@7065dcbe5583b7b015f07a8ebd49d7266e3053e8 # v1.1.1
         with:
@@ -124,6 +133,13 @@ jobs:
         with:
           path: target/release
           key: cargo-release-${{ runner.os }}-${{ hashFiles('Cargo.lock', 'rust-toolchain.toml') }}
+
+      - name: Save the built lint sources
+        if: github.event_name == 'push' && matrix.target == 'check-self'
+        uses: actions/cache/save@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: ~/.cache/whisker
+          key: lints-${{ runner.os }}-${{ hashFiles('.config/whisker.toml', 'rust-toolchain.toml') }}
 
   success:
     name: All checks succeeded


### PR DESCRIPTION
The check-self job is the slowest job in the matrix. It takes 575 seconds. A cold compile takes 289 of those seconds.

The recipe builds whisker in release. Only test-rust saves a cache, and test-rust never builds in release. So check-self restores 2.6 GB, finds no `target/release` in it, and compiles 451 crates from source on every run.

This change gives the release directory its own cache entry. The check-self job writes the entry on main. No other job builds in release, so the entry duplicates nothing. A release directory holds no debug info. It is about a quarter of the size of the debug directory. The repository stays inside its cache budget.

The check-self job still restores the shared entry. The check runs the build scripts of rust-analyzer, and those compile into `target/debug`.

A second entry keeps the rules that whisker builds. Whisker fetches the pinned rules repository and builds every lint in it. That work takes 32 seconds on every run.

The key hashes the whisker configuration and the toolchain file. The configuration pins the revision. The handshake refuses a library that another rustc built. Neither an older revision nor an older toolchain gives this job anything to load, so the key has no restore-keys prefix.

I expect the job to drop from 575 seconds to about 350 seconds. The first run on main after a change to `Cargo.lock` or `rust-toolchain.toml` stays cold. That run writes the entry.