### PR TITLE
Say when nobody published lints this whisker can load

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,11 @@ and this project adheres to
 
 ### Added
 
+- Whisker says when a git source publishes no prebuilt lints it can load, and
+  names the archive it looked for. The compile that follows costs minutes on
+  every machine, and silence read exactly like a warm cache. A repository
+  whisker cannot see, which is what a private one looks like without a token,
+  stays quiet: nobody reading that can act on it.
 - A `[rules]` table names the rules a project runs. `enable` runs only those
   named, `disable` runs everything else, and a name that no configured lint
   reports is an error rather than a filter that quietly admits everything.

--- a/crates/whisker/src/custom_lints/prebuilt.rs
+++ b/crates/whisker/src/custom_lints/prebuilt.rs
@@ -75,9 +75,11 @@ pub fn cached(source: &GitLintSource, tag: &AbiTag) -> anyhow::Result<Option<Pat
 /// nothing, and the caller then compiles the source. That fallback is
 /// what whisker did before any of this existed, and it is never wrong.
 ///
-/// The cases differ in whether the reader hears about them. Whisker stays
-/// quiet about a failure it cannot tell apart from a repository that
-/// nobody built for.
+/// The cases differ in whether the reader hears about them. A failure is
+/// a warning, and a release that holds no archive for this whisker is a
+/// note, because a publisher can act on it. A repository whisker cannot
+/// see stays quiet: that is what a private one looks like without a
+/// token, and nobody reading it can do anything about it.
 ///
 /// # Errors
 ///
@@ -173,9 +175,13 @@ fn note_absent(source: &GitLintSource, name: &AssetName) {
 
 /// Tells the reader that whisker compiles what it hoped to download
 ///
-/// Whisker says this once per source, and says nothing else about the
-/// prebuilt path. Nothing is broken when it appears. The check goes on
-/// and reports the same diagnostics, more slowly.
+/// Whisker says this at most once per source. Nothing is broken when it
+/// appears. The check goes on and reports the same diagnostics, more
+/// slowly.
+///
+/// This reports a lookup that failed and might succeed on the next run.
+/// [`note_absent`] reports the other outcome, where the lookup worked and
+/// the archive is simply not published.
 fn warn(source: &GitLintSource, error: &anyhow::Error) {
     eprintln!(
         "warning: whisker cannot use the prebuilt lints for {source}: {error:#}; it builds them \

--- a/crates/whisker/src/custom_lints/prebuilt.rs
+++ b/crates/whisker/src/custom_lints/prebuilt.rs
@@ -31,7 +31,7 @@ use anyhow::Context as _;
 
 use self::archive::Sha256Digest;
 use self::asset_name::AssetName;
-use self::github_release::{GitHubApi, PrebuiltAsset};
+use self::github_release::{AssetSearch, GitHubApi, PrebuiltAsset};
 use self::github_repository::GitHubRepository;
 use super::abi_tag::AbiTag;
 use super::cache;
@@ -94,7 +94,11 @@ pub fn fetch(source: &GitLintSource, tag: &AbiTag) -> anyhow::Result<Option<Path
 
     match download(&repository, &name, &directory) {
         Ok(Installed::Yes) => Ok(Some(directory)),
-        Ok(Installed::Absent) => Ok(None),
+        Ok(Installed::Absent) => {
+            note_absent(source, &name);
+            Ok(None)
+        }
+        Ok(Installed::Unlisted) => Ok(None),
         Err(error) => {
             warn(source, &error);
             Ok(None)
@@ -132,8 +136,39 @@ fn download(
 /// Whether a release had prebuilt lints to install
 #[derive(Copy, Clone, Eq, PartialEq, Debug)]
 enum Installed {
+    /// The archive was downloaded, checked, and unpacked
     Yes,
+
+    /// The releases were listed, and nobody published this archive
     Absent,
+
+    /// Whisker could not see the repository, so it asked nothing of it
+    Unlisted,
+}
+
+/// Tells the reader that nobody published lints this whisker can load
+///
+/// Nothing is wrong when this appears, and the check reports exactly what
+/// it would have reported anyway. It costs a compile of every rule in the
+/// source, on every machine and every build agent, which is minutes that
+/// look like whisker being slow rather than like an archive being absent.
+/// Silence there reads the same as a warm cache, so the one case a
+/// publisher can act on says so.
+///
+/// The message names the archive rather than describing it. A publisher
+/// reading it knows the exact file to produce, and the name carries the
+/// commit and this whisker's ABI tag, which are the two things that
+/// decide whether an archive is found.
+///
+/// This is not the same as [`warn`]. That one reports a lookup that
+/// failed and might succeed next time. This one reports a lookup that
+/// worked and found nothing.
+fn note_absent(source: &GitLintSource, name: &AssetName) {
+    eprintln!(
+        "note: no prebuilt lints published for {source} as {}; whisker builds them from source \
+         instead",
+        name.as_str()
+    );
 }
 
 /// Tells the reader that whisker compiles what it hoped to download
@@ -163,8 +198,10 @@ fn install(
     name: &AssetName,
     destination: &Path,
 ) -> anyhow::Result<Installed> {
-    let Some(PrebuiltAsset { archive, sidecar }) = api.find_asset(repository, name)? else {
-        return Ok(Installed::Absent);
+    let PrebuiltAsset { archive, sidecar } = match api.find_asset(repository, name)? {
+        AssetSearch::Found(asset) => asset,
+        AssetSearch::NoMatch => return Ok(Installed::Absent),
+        AssetSearch::Unlisted => return Ok(Installed::Unlisted),
     };
 
     if destination.exists() {

--- a/crates/whisker/src/custom_lints/prebuilt/github_release.rs
+++ b/crates/whisker/src/custom_lints/prebuilt/github_release.rs
@@ -72,6 +72,26 @@ pub fn configured_repository_host() -> Option<String> {
     repository_host(&base_from(std::env::var(API_VARIABLE).ok()))
 }
 
+/// What asking a repository's releases for one archive turned up
+///
+/// The two empty-handed answers are not the same thing, and only one of
+/// them is worth telling the reader about. `NoMatch` means the releases
+/// were listed and nobody published this archive, which a publisher can
+/// act on. `Unlisted` means whisker could not see the repository at all,
+/// which is what a private repository looks like without a token, and
+/// saying so on every check would be noise nobody can fix.
+#[derive(Clone, Eq, PartialEq, Debug)]
+pub enum AssetSearch {
+    /// The archive and its digest are both published
+    Found(PrebuiltAsset),
+
+    /// The releases were listed, and none holds this archive
+    NoMatch,
+
+    /// The API does not know this repository
+    Unlisted,
+}
+
 impl GitHubApi {
     /// Builds the client the environment describes
     ///
@@ -116,7 +136,7 @@ impl GitHubApi {
         &self,
         repository: &GitHubRepository,
         name: &AssetName,
-    ) -> anyhow::Result<Option<PrebuiltAsset>> {
+    ) -> anyhow::Result<AssetSearch> {
         let url = format!("{}/repos/{repository}/releases?per_page=100", self.base);
 
         let response = self
@@ -124,7 +144,7 @@ impl GitHubApi {
             .with_context(|| format!("failed to ask {repository} for its releases"))?;
 
         if response.status() == reqwest::StatusCode::NOT_FOUND {
-            return Ok(None);
+            return Ok(AssetSearch::Unlisted);
         }
 
         let status = response.status();
@@ -141,7 +161,10 @@ impl GitHubApi {
         let releases: Vec<Release> = serde_json::from_str(&body)
             .with_context(|| format!("failed to read the releases of {repository} as JSON"))?;
 
-        Ok(select_asset(&releases, name))
+        match select_asset(&releases, name) {
+            Some(asset) => Ok(AssetSearch::Found(asset)),
+            None => Ok(AssetSearch::NoMatch),
+        }
     }
 
     /// Downloads `asset` to `path` and returns the digest of what arrived

--- a/crates/whisker/tests/prebuilt_lints.rs
+++ b/crates/whisker/tests/prebuilt_lints.rs
@@ -514,13 +514,18 @@ fn check_with_prebuilt_lints_in_the_cache_asks_nothing() {
     );
 }
 
-/// Pins that a repository nobody built for stays quiet
+/// Pins that a release holding no archive for this whisker is said
 ///
-/// Whisker says nothing and compiles the source, as it did before any of
-/// this existed. A warning here would appear on every check of every
-/// project whose lints are not published.
+/// The compile that follows costs minutes on every machine and every
+/// build agent, and silence there reads exactly like a warm cache. The
+/// releases were listed and nobody published this archive, which is the
+/// one empty-handed case a publisher can act on, so it is named rather
+/// than guessed at.
+///
+/// This is a note and not a warning. Nothing is broken, and the check
+/// reports what it would have reported anyway.
 #[test]
-fn check_without_a_matching_asset_says_nothing() {
+fn check_without_a_matching_asset_names_the_archive_nobody_published() {
     let server = FakeGitHub::start();
     let cache = tempfile::tempdir().expect("temporary directory should be created");
     let target = package(TODO_SOURCE);
@@ -535,10 +540,18 @@ fn check_without_a_matching_asset_says_nothing() {
         .arg(target.path())
         .assert()
         .failure()
+        .stderr(predicate::str::contains(
+            "note: no prebuilt lints published",
+        ))
+        .stderr(predicate::str::contains(REV))
         .stderr(predicate::str::contains("warning: whisker cannot use").not());
 }
 
-/// Pins that a repository whisker cannot list is the same quiet case
+/// Pins that a repository whisker cannot see stays quiet
+///
+/// This is what a private repository looks like without a token, and the
+/// reader can do nothing about it. Naming it on every check would be
+/// noise, so the note is kept for the case a publisher can fix.
 #[test]
 fn check_with_a_repository_the_api_does_not_know_says_nothing() {
     let server = FakeGitHub::start();
@@ -551,6 +564,7 @@ fn check_with_a_repository_the_api_does_not_know_says_nothing() {
         .arg(target.path())
         .assert()
         .failure()
+        .stderr(predicate::str::contains("note: no prebuilt lints").not())
         .stderr(predicate::str::contains("warning: whisker cannot use").not());
 }
 


### PR DESCRIPTION
Whisker asks a git source's releases for an archive named for the commit and its own ABI tag. When it finds none it compiles the rules instead, which is right, and it said nothing about it, which was not.

That compile costs minutes on every machine and every build agent that pins the same commit. The silence reads exactly like a warm cache, so nobody can tell a repository that publishes nothing from one whose archives are already unpacked. aonyx-ai/raft#43 compiled nineteen crates on every CI run, and the only clue was the log.

The quiet was deliberate, and this keeps the half that earned it. A repository whisker cannot see answers the lookup the same way as one that published nothing, and a private repository with no token looks like the first. Telling the reader about that on every check is noise they cannot act on. So `find_asset` now answers with which of the three things happened, rather than with an `Option`:

- `Found`, and whisker installs the archive.
- `NoMatch`, meaning the releases were listed and nobody published this archive. Whisker names it.
- `Unlisted`, meaning the API does not know the repository. Whisker stays quiet.

The message names the archive rather than describing the problem:

```text
note: no prebuilt lints published for <url> as <rev>-<tag>-<target>.tar.gz; whisker builds them from source instead
```

A publisher who reads that knows the exact file to produce. The name carries the commit and this whisker's ABI tag, which are the two things that decide whether an archive is found.

It is a note and not a warning, because nothing is broken when it appears and the check reports what it would have reported anyway.

The test that pinned the old silence now pins the new message, and a second test pins that a repository whisker cannot list still says nothing.

This makes the fallback visible. It does not make it rarer: the ABI tag folds in the rustc version, so every toolchain bump invalidates every published archive. #343 is the part that would change that.
