### PR TITLE
Install a release with one command

### DIFF
--- a/docs/docs/installation.md
+++ b/docs/docs/installation.md
@@ -5,9 +5,25 @@ sidebar_position: 1
 # Installation
 
 Every release carries an archive for Linux on x86-64 and arm64, and for macOS
-on Apple silicon. Download the one for your platform from the
-[releases page][releases], check it against the `.sha256` beside it, and unpack
-it:
+on Apple silicon. The Linux binaries need glibc 2.35 or newer, which Ubuntu
+22.04 and Debian 12 satisfy. Build from source on anything older.
+
+## With the install script
+
+The script picks the archive for the machine it runs on, checks it against the
+digest published beside it, and puts the binary in `~/.local/bin`:
+
+```bash
+curl -LsSf https://aonyx-ai.github.io/whisker/install.sh | sh
+```
+
+Set `WHISKER_INSTALL_DIR` to install somewhere else. The script installs the
+newest release over whatever whisker that directory already holds.
+
+## By hand
+
+Download the archive for your platform from the [releases page][releases],
+check it against the `.sha256` beside it, and unpack it:
 
 ```bash
 shasum -a 256 -c whisker-0.1.0-rc.3-aarch64-apple-darwin.tar.gz.sha256
@@ -18,13 +34,10 @@ The archive unpacks to a directory named after the release and the platform. It
 holds the binary, both licenses, and the README. Move `whisker` to a directory
 on your `PATH`, such as `~/.local/bin`.
 
-The Linux binaries need glibc 2.35 or newer, which Ubuntu 22.04 and Debian 12
-satisfy. Build from source on anything older.
-
 ## On GitHub Actions
 
-The action in the whisker repository does the same three steps, for the runner
-it finds itself on:
+The action in the whisker repository does the same download, check, and unpack,
+for the runner it finds itself on:
 
 ```yaml
 - uses: aonyx-ai/whisker@v0.1.0-rc.3

--- a/docs/docs/quick-start.md
+++ b/docs/docs/quick-start.md
@@ -9,15 +9,12 @@ Cargo workspace to point whisker at.
 
 ## Install whisker
 
-The install script picks the archive for your platform, checks it against the
-digest published beside it, and puts the binary in `~/.local/bin`:
-
 ```bash
 curl -LsSf https://aonyx-ai.github.io/whisker/install.sh | sh
 ```
 
-Put `~/.local/bin` on your `PATH` if it is not there already. The rest of this
-page calls `whisker` by name.
+The script installs to `~/.local/bin`. Put that on your `PATH` if it is not
+there already.
 
 [Installation](/docs/installation) covers the other ways to install whisker,
 and which one to choose.

--- a/docs/docs/quick-start.md
+++ b/docs/docs/quick-start.md
@@ -9,16 +9,15 @@ Cargo workspace to point whisker at.
 
 ## Install whisker
 
-Download the archive for your platform from the [releases page][releases],
-check it against the digest published beside it, and unpack it:
+The install script picks the archive for your platform, checks it against the
+digest published beside it, and puts the binary in `~/.local/bin`:
 
 ```bash
-shasum -a 256 -c whisker-0.1.0-rc.3-aarch64-apple-darwin.tar.gz.sha256
-tar -xzf whisker-0.1.0-rc.3-aarch64-apple-darwin.tar.gz
+curl -LsSf https://aonyx-ai.github.io/whisker/install.sh | sh
 ```
 
-The archive unpacks to a directory that holds the binary, both licenses, and
-the README. Move `whisker` to a directory on your `PATH`.
+Put `~/.local/bin` on your `PATH` if it is not there already. The rest of this
+page calls `whisker` by name.
 
 [Installation](/docs/installation) covers the other ways to install whisker,
 and which one to choose.
@@ -62,5 +61,3 @@ explains what to rebuild.
 - [Configuration](/docs/configuration) — the rest of `.config/whisker.toml`,
   including how to ignore paths.
 - [Custom lints](/docs/custom-lints) — run a rule at a time, or write your own.
-
-[releases]: https://github.com/aonyx-ai/whisker/releases

--- a/docs/src/pages/index.md
+++ b/docs/src/pages/index.md
@@ -13,6 +13,15 @@ tree-sitter's Rust grammar. A rule that needs type information reads
 decorations that whisker computes with [rust-analyzer][ra] before any rule
 runs.
 
+## Install
+
+```bash
+curl -LsSf https://aonyx-ai.github.io/whisker/install.sh | sh
+```
+
+[Installation](/docs/installation) covers Linux, macOS, GitHub Actions, and a
+build from source.
+
 ## Status
 
 Whisker is in early development. Check back soon.

--- a/docs/static/install.sh
+++ b/docs/static/install.sh
@@ -4,16 +4,32 @@
 #
 #   curl -LsSf https://aonyx-ai.github.io/whisker/install.sh | sh
 #
-# This is POSIX shell rather than bash, because the line above pipes it into
-# whichever /bin/sh the machine has, and on Debian that is dash.
+# The line above runs this in whichever /bin/sh the machine has, and on
+# Debian that is dash, so the script is POSIX shell rather than bash.
 
 set -eu
 
 REPOSITORY="aonyx-ai/whisker"
 
+# Every transfer goes through here. `--proto =https` refuses plain http,
+# also after a redirect, so no hop can move a download onto a channel that
+# someone else can rewrite. The digest needs the same guard as the archive
+# it checks, because a downgrade of both would pass the check.
+download() {
+    curl --proto '=https' --tlsv1.2 --retry 3 \
+        --fail --location --silent --show-error "$@"
+}
+
 main() {
     os="$(uname -s)"
     architecture="$(uname -m)"
+
+    # Under Rosetta, uname reports x86_64 on arm64 hardware that runs the
+    # arm64 binary. The kernel answers for the hardware.
+    if [ "${os}-${architecture}" = "Darwin-x86_64" ] &&
+        (sysctl hw.optional.arm64 2> /dev/null || true) | grep -q ': 1'; then
+        architecture="arm64"
+    fi
 
     case "${os}-${architecture}" in
         Linux-x86_64) target="x86_64-unknown-linux-gnu" ;;
@@ -25,28 +41,34 @@ main() {
             ;;
     esac
 
-    # GitHub reserves `releases/latest` for the newest release that is not a
-    # prerelease, and answers 404 while a repository has published only
-    # prereleases. The `--fail` stops here in that case, rather than at the
-    # download of an archive named after a version that does not exist.
+    # The Linux binary links against glibc. On musl it installs, then fails
+    # with "not found", because the interpreter it names is missing.
+    if [ "${os}" = "Linux" ] && ldd --version 2>&1 | grep -qi musl; then
+        echo "whisker publishes no binary for musl systems such as Alpine" >&2
+        exit 1
+    fi
+
+    # `releases/latest` names the newest release that is not a prerelease,
+    # and answers 404 while a repository has only prereleases. `--fail`
+    # stops here in that case, not at the download of an archive for a
+    # missing version.
     #
-    # The parse is a second statement because a shell reports the status of
-    # the last command in a pipeline. A `curl` that failed inside one would
-    # leave `sed` to report success over an empty version.
-    release="$(curl -fLsS \
-        "https://api.github.com/repos/${REPOSITORY}/releases/latest")"
+    # The parse is a separate statement because a pipeline reports the
+    # status of its last command. A failed `curl` inside one would let `sed`
+    # report success over an empty version.
+    release="$(download "https://api.github.com/repos/${REPOSITORY}/releases/latest")"
     version="$(printf '%s' "${release}" |
         sed -n 's/.*"tag_name"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p')"
 
-    # The archive names carry the version without its leading `v`, because
-    # that is what `Cargo.toml` holds. The same name spells the directory
-    # the archive unpacks to.
+    # Archive names carry the version without its leading `v`, as
+    # `Cargo.toml` holds it. The same name is the directory the archive
+    # unpacks to.
     stem="whisker-${version#v}-${target}"
     name="${stem}.tar.gz"
     base="https://github.com/${REPOSITORY}/releases/download/${version}"
 
-    # The staged copy sits in the destination directory and not beside the
-    # download, so that the rename below stays within one filesystem.
+    # The staged copy sits in the destination directory, not beside the
+    # download, so the rename below stays within one filesystem.
     directory="${WHISKER_INSTALL_DIR:-${HOME}/.local/bin}"
     mkdir -p "${directory}"
     work="$(mktemp -d "${TMPDIR:-/tmp}/whisker-install.XXXXXX")"
@@ -54,11 +76,11 @@ main() {
     trap 'rm -rf "${work}" "${staged}"' EXIT
 
     echo "Downloading whisker ${version} for ${target}"
-    curl -fLsS -o "${work}/${name}" "${base}/${name}"
-    curl -fLsS -o "${work}/${name}.sha256" "${base}/${name}.sha256"
+    download -o "${work}/${name}" "${base}/${name}"
+    download -o "${work}/${name}.sha256" "${base}/${name}.sha256"
 
-    # The digest names the archive without a path, so the check runs from the
-    # directory holding both. Linux carries `sha256sum` and macOS `shasum`.
+    # The digest names the archive without a path, so the check runs in the
+    # directory that holds both. Linux ships `sha256sum` and macOS `shasum`.
     if command -v sha256sum > /dev/null 2>&1; then
         (cd "${work}" && sha256sum -c "${name}.sha256") > /dev/null
     else
@@ -67,8 +89,8 @@ main() {
 
     tar -xzf "${work}/${name}" -C "${work}"
 
-    # A rename replaces a whisker that is running. Copying onto one instead
-    # is what Linux refuses with ETXTBSY.
+    # A rename replaces a running whisker. Linux refuses a copy onto one
+    # with ETXTBSY.
     cp "${work}/${stem}/whisker" "${staged}"
     chmod 755 "${staged}"
     mv "${staged}" "${directory}/whisker"
@@ -76,6 +98,6 @@ main() {
     echo "Installed ${directory}/whisker"
 }
 
-# The body is one function that the last line calls, so that a download this
-# shell has read only half of runs nothing at all.
+# The body is one function that the last line calls, so a half-downloaded
+# script runs nothing at all.
 main

--- a/docs/static/install.sh
+++ b/docs/static/install.sh
@@ -4,20 +4,29 @@
 #
 #   curl -LsSf https://aonyx-ai.github.io/whisker/install.sh | sh
 #
-# The line above runs this in whichever /bin/sh the machine has, and on
-# Debian that is dash, so the script is POSIX shell rather than bash.
+# The line above runs this in whichever /bin/sh the machine has, which is
+# not always bash, so the script is POSIX shell.
 
 set -eu
 
 REPOSITORY="aonyx-ai/whisker"
 
-# Every transfer goes through here. `--proto =https` refuses plain http,
-# also after a redirect, so no hop can move a download onto a channel that
-# someone else can rewrite. The digest needs the same guard as the archive
-# it checks, because a downgrade of both would pass the check.
+# Every transfer goes through here. `--proto =https` covers redirects as
+# well, so no hop can fall back to http and swap the archive and its digest
+# together.
 download() {
     curl --proto '=https' --tlsv1.2 --retry 3 \
         --fail --location --silent --show-error "$@"
+}
+
+# Names every file the script writes, so that nothing has to be removed
+# recursively. `rmdir` refuses a directory holding anything else, so an
+# archive that ever carries more than this leaves a directory behind in
+# `TMPDIR` instead of widening what gets deleted.
+cleanup() {
+    rm -f "${work}/${name}" "${work}/${name}.sha256" \
+        "${work}/${stem}/whisker" "${staged}"
+    rmdir "${work}/${stem}" "${work}" 2> /dev/null || true
 }
 
 main() {
@@ -53,9 +62,9 @@ main() {
     # stops here in that case, not at the download of an archive for a
     # missing version.
     #
-    # The parse is a separate statement because a pipeline reports the
-    # status of its last command. A failed `curl` inside one would let `sed`
-    # report success over an empty version.
+    # The parse is a separate statement because a pipeline reports its last
+    # command's status, which would let `sed` report success over a failed
+    # `curl`.
     release="$(download "https://api.github.com/repos/${REPOSITORY}/releases/latest")"
     version="$(printf '%s' "${release}" |
         sed -n 's/.*"tag_name"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p')"
@@ -81,7 +90,7 @@ main() {
     mkdir -p "${directory}"
     work="$(mktemp -d "${TMPDIR:-/tmp}/whisker-install.XXXXXX")"
     staged="${directory}/whisker.$$.tmp"
-    trap 'rm -rf "${work}" "${staged}"' EXIT
+    trap cleanup EXIT
 
     echo "Downloading whisker ${version} for ${target}"
     download -o "${work}/${name}" "${base}/${name}"
@@ -95,7 +104,7 @@ main() {
         (cd "${work}" && shasum -a 256 -c "${name}.sha256") > /dev/null
     fi
 
-    tar -xzf "${work}/${name}" -C "${work}"
+    tar -xzf "${work}/${name}" -C "${work}" "${stem}/whisker"
 
     # A rename replaces a running whisker. Linux refuses a copy onto one
     # with ETXTBSY.

--- a/docs/static/install.sh
+++ b/docs/static/install.sh
@@ -1,0 +1,81 @@
+#!/bin/sh
+#
+# Installs the latest release of whisker.
+#
+#   curl -LsSf https://aonyx-ai.github.io/whisker/install.sh | sh
+#
+# This is POSIX shell rather than bash, because the line above pipes it into
+# whichever /bin/sh the machine has, and on Debian that is dash.
+
+set -eu
+
+REPOSITORY="aonyx-ai/whisker"
+
+main() {
+    os="$(uname -s)"
+    architecture="$(uname -m)"
+
+    case "${os}-${architecture}" in
+        Linux-x86_64) target="x86_64-unknown-linux-gnu" ;;
+        Linux-aarch64) target="aarch64-unknown-linux-gnu" ;;
+        Darwin-arm64) target="aarch64-apple-darwin" ;;
+        *)
+            echo "whisker publishes no binary for ${os} on ${architecture}" >&2
+            exit 1
+            ;;
+    esac
+
+    # GitHub reserves `releases/latest` for the newest release that is not a
+    # prerelease, and answers 404 while a repository has published only
+    # prereleases. The `--fail` stops here in that case, rather than at the
+    # download of an archive named after a version that does not exist.
+    #
+    # The parse is a second statement because a shell reports the status of
+    # the last command in a pipeline. A `curl` that failed inside one would
+    # leave `sed` to report success over an empty version.
+    release="$(curl -fLsS \
+        "https://api.github.com/repos/${REPOSITORY}/releases/latest")"
+    version="$(printf '%s' "${release}" |
+        sed -n 's/.*"tag_name"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p')"
+
+    # The archive names carry the version without its leading `v`, because
+    # that is what `Cargo.toml` holds. The same name spells the directory
+    # the archive unpacks to.
+    stem="whisker-${version#v}-${target}"
+    name="${stem}.tar.gz"
+    base="https://github.com/${REPOSITORY}/releases/download/${version}"
+
+    # The staged copy sits in the destination directory and not beside the
+    # download, so that the rename below stays within one filesystem.
+    directory="${WHISKER_INSTALL_DIR:-${HOME}/.local/bin}"
+    mkdir -p "${directory}"
+    work="$(mktemp -d "${TMPDIR:-/tmp}/whisker-install.XXXXXX")"
+    staged="${directory}/whisker.$$.tmp"
+    trap 'rm -rf "${work}" "${staged}"' EXIT
+
+    echo "Downloading whisker ${version} for ${target}"
+    curl -fLsS -o "${work}/${name}" "${base}/${name}"
+    curl -fLsS -o "${work}/${name}.sha256" "${base}/${name}.sha256"
+
+    # The digest names the archive without a path, so the check runs from the
+    # directory holding both. Linux carries `sha256sum` and macOS `shasum`.
+    if command -v sha256sum > /dev/null 2>&1; then
+        (cd "${work}" && sha256sum -c "${name}.sha256") > /dev/null
+    else
+        (cd "${work}" && shasum -a 256 -c "${name}.sha256") > /dev/null
+    fi
+
+    tar -xzf "${work}/${name}" -C "${work}"
+
+    # A rename replaces a whisker that is running. Copying onto one instead
+    # is what Linux refuses with ETXTBSY.
+    cp "${work}/${stem}/whisker" "${staged}"
+    chmod 755 "${staged}"
+    mv "${staged}" "${directory}/whisker"
+
+    echo "Installed ${directory}/whisker"
+}
+
+# The body is one function that the last line calls, so that a download this
+# shell has read only half of runs nothing at all.
+main

--- a/docs/static/install.sh
+++ b/docs/static/install.sh
@@ -60,6 +60,14 @@ main() {
     version="$(printf '%s' "${release}" |
         sed -n 's/.*"tag_name"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p')"
 
+    # A network that answers for api.github.com, such as a captive portal or
+    # an inspecting proxy, returns 200 and a page of its own. The parse finds
+    # no name in it, and the download would then ask for version "".
+    if [ -z "${version}" ]; then
+        echo "cannot read a release name from GitHub's answer" >&2
+        exit 1
+    fi
+
     # Archive names carry the version without its leading `v`, as
     # `Cargo.toml` holds it. The same name is the directory the archive
     # unpacks to.


### PR DESCRIPTION
Whisker publishes an archive for each platform. Until now a user downloaded the archive, checked the digest, and unpacked it. This pull request adds a script that does those three steps automatically.

The documentation site serves the script, so one command installs whisker:

```bash
curl -LsSf https://aonyx-ai.github.io/whisker/install.sh | sh
```

The script reads `uname`, selects the archive for the machine, and verifies the digest. It then puts the binary in `~/.local/bin`. The variable `WHISKER_INSTALL_DIR` selects a different directory. The script is POSIX shell and not bash, because the command above pipes it into `/bin/sh`, and on Debian that is dash.

Two details are deliberate. The version lookup and the parse are separate statements, because a shell reports the status of the last command in a pipeline. A `curl` that failed inside one leaves `sed` to report success over an empty version. The binary also arrives through a rename and not a copy, because a rename replaces a whisker that is running.

Note that the script asks GitHub for `releases/latest`. GitHub reserves that name for the newest release that is not a prerelease. Whisker publishes only release candidates today, so the command returns 404 and the script stops. The command starts to work when whisker 0.1.0 ships.

I ran the script on macOS under both `dash` and `sh`, with a pinned version to reach an existing archive. I checked a first install, a second install over it, a corrupt archive, a failed version lookup, both digest tools, and six operating system and architecture pairs. shellcheck reports nothing with `--enable=all`.

This change also edits the quick start and the index page, which conflicts with the docs rewrite in progress.
