### PR TITLE
Let a rule copy a node instead of cloning one

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ and this project adheres to
 
 ### Added
 
+- `DecoratedNode` is `Copy`. A rule reading a node out of the vector that
+  `named_children` returns no longer clones borrowed data. The
+  plugin ABI tag does not move, so every published archive still loads.
+
 - Whisker says when a git source publishes no prebuilt lints it can load, and
   names the archive it looked for. The compile that follows costs minutes on
   every machine, and silence read exactly like a warm cache. A repository

--- a/crates/whisker-rust/src/provider.rs
+++ b/crates/whisker-rust/src/provider.rs
@@ -437,7 +437,7 @@ fn collect_targets(node: &DecoratedNode<'_>, targets: &mut Vec<Target>) {
         }
         "if_expression" => {
             if let Some(alt) = node.child_by_field_name("alternative") {
-                let block = alt.named_child(0).unwrap_or(alt.clone());
+                let block = alt.named_child(0).unwrap_or(alt);
                 if let Some(branch_range) = text_range_of(&block) {
                     targets.push(Target::IfElse {
                         branch_range,

--- a/crates/whisker-rust/tests/provider_integration.rs
+++ b/crates/whisker-rust/tests/provider_integration.rs
@@ -138,7 +138,7 @@ fn find_function_by_name<'a>(root: &DecoratedNode<'a>, name: &str) -> Option<Dec
 
 fn find_first_node_of_kind<'a>(node: &DecoratedNode<'a>, kind: &str) -> Option<DecoratedNode<'a>> {
     if node.kind() == kind {
-        return Some(node.clone());
+        return Some(*node);
     }
     for child in node.named_children() {
         if let Some(found) = find_first_node_of_kind(&child, kind) {

--- a/crates/whisker-types/src/decorated_node.rs
+++ b/crates/whisker-types/src/decorated_node.rs
@@ -9,7 +9,17 @@ use crate::{Decoration, DecorationMap, Span};
 /// This is the primary type that lint rules interact with. It provides
 /// access to the tree-sitter node's structural information (kind, text,
 /// children) and to semantic decorations attached by providers.
-#[derive(Clone)]
+/// Copying one moves borrowed data and nothing else. Every field is a
+/// reference or a `tree_sitter::Node`, which is itself a
+/// `#[repr(transparent)]` wrapper around a C struct of pointers. The
+/// `Arc<Path>` sits behind a reference, so a copy reaches no allocation
+/// and moves no refcount.
+///
+/// This is `Copy` so that a rule walking siblings and children writes what
+/// it means. Without it, reading a node out of the `Vec` that
+/// [`DecoratedNode::named_children`] returns forces a clone that copies
+/// exactly what a move would and reads as though it costs something.
+#[derive(Copy, Clone)]
 pub struct DecoratedNode<'a> {
     node: tree_sitter::Node<'a>,
     source: &'a str,


### PR DESCRIPTION
`DecoratedNode` is four words of borrowed data: a `tree_sitter::Node`, which is a `#[repr(transparent)]` wrapper around a C struct, and three references. One of those is `&Arc<Path>`, so a copy moves no refcount and touches no allocation.

It derived `Clone` alone, so reading a node out of the vector `named_children` returns forced a `.clone()` that copies exactly those four words while reading as though it costs something. Walking siblings is what a syntax-only rule does most, and the clone was in the way of saying so plainly.

The ABI tag is `ff1d396a4e1f77e0` before this change and after it. A derive moves no field and changes no layout, so `TYPES_FINGERPRINT` is unmoved and every archive published for the current protocol still loads. I measured that with `whisker abi` on both sides rather than assuming it, because this type crosses the plugin boundary and the cost of being wrong there is a refusal for every publisher.

Clippy's `clone_on_copy` found the two call sites the derive made redundant, one of them in a test my own search had skipped.