### PR TITLE
Exclude the example packages by name

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,8 @@
 members = ["crates/*"]
 exclude = [
   "crates/whisker-rust/tests/fixtures/lints/decoration_probes",
-  "examples/*",
+  "examples/custom_lint",
+  "examples/sample_project",
 ]
 
 # Opt-in to the new feature resolver introduced in Rust 1.85 and Edition 2024.


### PR DESCRIPTION
`exclude` held `examples/*`, and cargo does not expand a glob there. The line has excluded nothing since #21 added it, when the manifest still globbed `lints/*` into its members and the two lists read as a pair. `lints/*` later moved to its own repository and the exclude survived the move.

Nothing noticed because the lint examples carry an empty `[workspace]` table of their own, and that is what has been keeping them standalone. `examples/sample_project` carries none, so cargo claimed it for the workspace and refused to build it where it sits:

```text
error: current package believes it's in a workspace when it's not
current:   examples/sample_project/Cargo.toml
workspace: Cargo.toml
```

Naming the paths excludes them for real, and the fixture builds in place. I checked each of the three resolves standalone afterwards rather than assuming the list was enough.

`examples/doc_summary_break` is deliberately absent: it does not exist on main yet. #355 adds the package and can add its line with it.