### PR TITLE
Cover the CLI's exit codes, stdout, and configuration errors

### DIFF
--- a/crates/whisker/tests/check.rs
+++ b/crates/whisker/tests/check.rs
@@ -218,7 +218,7 @@ fn check_directory_without_sources_fails() {
         .arg("check")
         .arg(directory.path())
         .assert()
-        .failure()
+        .code(1)
         .stderr(predicate::str::contains("analyzed no files"));
 }
 
@@ -237,7 +237,7 @@ fn check_non_rust_file_fails() {
         .args(["check", "Cargo.toml"])
         .current_dir(package.path())
         .assert()
-        .failure()
+        .code(1)
         .stderr(predicate::str::contains("no grammar for `.toml` files"));
 }
 
@@ -246,7 +246,7 @@ fn check_nonexistent_path_fails() {
     whisker()
         .args(["check", "does/not/exist"])
         .assert()
-        .failure()
+        .code(1)
         .stderr(predicate::str::contains("does not exist"));
 }
 
@@ -263,7 +263,7 @@ fn check_orphan_directory_reports_no_coverage() {
         .arg("check")
         .arg(package.path())
         .assert()
-        .failure()
+        .code(1)
         .stderr(predicate::str::contains(
             "no decoration provider covers this file",
         ))
@@ -282,7 +282,7 @@ fn check_orphan_file_reports_no_coverage() {
         .args(["check", "src/stray.rs"])
         .current_dir(package.path())
         .assert()
-        .failure()
+        .code(1)
         .stderr(predicate::str::contains(
             "no decoration provider covers this file",
         ))
@@ -313,7 +313,7 @@ fn check_package_whose_sources_a_gitignore_excludes_fails() {
         .arg("check")
         .arg(package.path())
         .assert()
-        .failure()
+        .code(1)
         .stderr(predicate::str::contains("analyzed no files"));
 }
 
@@ -326,7 +326,7 @@ fn check_package_whose_sources_the_configuration_excludes_fails() {
         .arg("check")
         .arg(package.path())
         .assert()
-        .failure()
+        .code(1)
         .stderr(predicate::str::contains("analyzed no files"));
 }
 
@@ -352,7 +352,7 @@ fn check_package_whose_sources_the_global_gitignore_excludes_fails() {
         .arg("check")
         .arg(package.path())
         .assert()
-        .failure()
+        .code(1)
         .stderr(predicate::str::contains("analyzed no files"));
 }
 
@@ -373,7 +373,7 @@ fn check_package_with_an_unparsable_ignore_file_and_keep_going_reports_it_and_fa
         .args(["check", "--keep-going"])
         .arg(package.path())
         .assert()
-        .failure()
+        .code(1)
         .stderr(predicate::str::contains(
             "error: failed to read an ignore file",
         ))
@@ -398,7 +398,7 @@ fn check_package_with_an_unparsable_ignore_file_fails() {
         .arg("check")
         .arg(package.path())
         .assert()
-        .failure()
+        .code(1)
         .stderr(predicate::str::contains("failed to discover source files"))
         .stderr(predicate::str::contains("failed to read an ignore file"))
         .stderr(predicate::str::contains("error parsing glob '{a,b'"));
@@ -417,7 +417,7 @@ fn check_package_with_an_unreadable_directory_and_keep_going_reports_it_and_fail
         .args(["check", "--keep-going"])
         .arg(package.path())
         .assert()
-        .failure()
+        .code(1)
         .stderr(predicate::str::contains(
             "error: failed to read a directory entry",
         ))
@@ -437,7 +437,7 @@ fn check_package_with_an_unreadable_directory_fails() {
         .arg("check")
         .arg(package.path())
         .assert()
-        .failure()
+        .code(1)
         .stderr(predicate::str::contains("failed to discover source files"))
         .stderr(predicate::str::contains("failed to read a directory entry"));
 }
@@ -519,7 +519,7 @@ fn check_with_keep_going_reports_every_orphan_file() {
         .args(["check", "--keep-going"])
         .arg(package.path())
         .assert()
-        .failure()
+        .code(1)
         .stderr(predicate::str::contains("first_stray.rs"))
         .stderr(predicate::str::contains("second_stray.rs"))
         .stderr(predicate::function(|stderr: &str| error_count(stderr) == 2))
@@ -585,7 +585,7 @@ fn check_without_keep_going_keeps_diagnostics_from_earlier_files() {
         .current_dir(&root)
         .args(["check", "src"])
         .assert()
-        .failure()
+        .code(1)
         .stderr(predicate::str::contains("error: src/not_utf8.rs"))
         .stderr(predicate::str::contains(
             "warning[fixture.wildcard-match-arm]",

--- a/crates/whisker/tests/check.rs
+++ b/crates/whisker/tests/check.rs
@@ -222,6 +222,51 @@ fn check_directory_without_sources_fails() {
         .stderr(predicate::str::contains("analyzed no files"));
 }
 
+/// Pins that a run started inside the project reads the ignore patterns
+/// from the project root
+///
+/// The configuration unit tests pin that the search climbs to the project
+/// root. This pins that the CLI gets the benefit, which is what a person
+/// relies on when they check the directory they happen to be standing in.
+///
+/// The pattern names the only file in the package, so the two outcomes
+/// cannot be confused. A run that reads the configuration excludes the
+/// file and reports that it analyzed nothing. A run that misses the
+/// configuration analyzes the file and succeeds.
+#[test]
+fn check_from_a_subdirectory_applies_the_project_ignore_patterns() {
+    let package = package(CLEAN_SOURCE);
+    write_config(package.path(), "ignore = [\"src/lib.rs\"]\n");
+
+    whisker()
+        .args(["check", "."])
+        .current_dir(package.path().join("src"))
+        .assert()
+        .code(1)
+        .stdout(predicate::str::is_empty())
+        .stderr(predicate::str::contains("analyzed no files"));
+}
+
+/// Pins that a run started inside the project loads the lints the project
+/// root configures
+///
+/// A lint that silently stops running is worse than one that fails, since
+/// the check still passes. The source trips `custom.no-todo`, so a run
+/// that misses the configuration loads no lints, reports nothing, and
+/// succeeds.
+#[test]
+fn check_from_a_subdirectory_applies_the_project_lints() {
+    let package = with_no_todo(package(WARNING_SOURCE));
+
+    whisker()
+        .args(["check", "."])
+        .current_dir(package.path().join("src"))
+        .assert()
+        .success()
+        .stdout(predicate::str::is_empty())
+        .stderr(predicate::str::contains("warning[custom.no-todo]"));
+}
+
 /// Pins that whisker refuses a file it has no grammar for
 ///
 /// The target is a fixture rather than this repository's own manifest.
@@ -247,6 +292,7 @@ fn check_nonexistent_path_fails() {
         .args(["check", "does/not/exist"])
         .assert()
         .code(1)
+        .stdout(predicate::str::is_empty())
         .stderr(predicate::str::contains("does not exist"));
 }
 
@@ -264,6 +310,7 @@ fn check_orphan_directory_reports_no_coverage() {
         .arg(package.path())
         .assert()
         .code(1)
+        .stdout(predicate::str::is_empty())
         .stderr(predicate::str::contains(
             "no decoration provider covers this file",
         ))
@@ -300,6 +347,7 @@ fn check_package_directory_succeeds() {
         .arg(package.path())
         .assert()
         .success()
+        .stdout(predicate::str::is_empty())
         .stderr(predicate::str::is_empty());
 }
 
@@ -472,6 +520,104 @@ fn check_single_file_succeeds() {
         .stderr(predicate::str::is_empty());
 }
 
+/// Pins that a key whisker does not recognize ends the run and names itself
+///
+/// The configuration rejects an unknown key rather than dropping it,
+/// because a dropped key looks exactly like one that works. The error has
+/// to name the key, or the author of a typo has nothing to correct.
+#[test]
+fn check_with_a_configuration_naming_an_unknown_key_fails() {
+    let package = package(CLEAN_SOURCE);
+    write_config(package.path(), "nonsense = true\n");
+
+    whisker()
+        .arg("check")
+        .arg(package.path())
+        .assert()
+        .code(1)
+        .stdout(predicate::str::is_empty())
+        .stderr(predicate::str::contains(
+            "failed to load the whisker configuration",
+        ))
+        .stderr(predicate::str::contains("nonsense"));
+}
+
+/// Pins that an entry describing no source ends the run and names its
+/// position
+///
+/// The configuration unit tests pin the message. This pins that the
+/// message survives the trip to the user, along with the entry number that
+/// tells them which of several entries to fix.
+#[test]
+fn check_with_a_lint_entry_that_defines_no_source_fails() {
+    let package = package(CLEAN_SOURCE);
+    write_config(package.path(), "[[lints]]\n");
+
+    whisker()
+        .arg("check")
+        .arg(package.path())
+        .assert()
+        .code(1)
+        .stdout(predicate::str::is_empty())
+        .stderr(predicate::str::contains(
+            "failed to load the whisker configuration",
+        ))
+        .stderr(predicate::str::contains("failed to read [[lints]] entry 1"))
+        .stderr(predicate::str::contains(
+            "must define either path, or git and rev",
+        ));
+}
+
+/// Pins that a branch name where a revision belongs ends the run before
+/// whisker reaches the network
+///
+/// A branch moves, so a lint pinned to one does not describe a
+/// reproducible check. Whisker refuses it while reading the file, which is
+/// why this test names an unreachable host and still finishes.
+#[test]
+fn check_with_a_lint_entry_whose_rev_is_a_branch_fails() {
+    let package = package(CLEAN_SOURCE);
+    write_config(
+        package.path(),
+        "[[lints]]\ngit = \"https://example.invalid/rules.git\"\nrev = \"main\"\n",
+    );
+
+    whisker()
+        .arg("check")
+        .arg(package.path())
+        .assert()
+        .code(1)
+        .stdout(predicate::str::is_empty())
+        .stderr(predicate::str::contains(
+            "failed to load the whisker configuration",
+        ))
+        .stderr(predicate::str::contains(
+            "git revision \"main\" does not have 40 characters",
+        ));
+}
+
+/// Pins that a configuration file whisker cannot parse ends the run and
+/// points at the line
+///
+/// The error carries the parse position from the TOML reader, so a person
+/// with a large configuration file learns where to look.
+#[test]
+fn check_with_an_unparsable_configuration_fails() {
+    let package = package(CLEAN_SOURCE);
+    write_config(package.path(), "ignore = [\n");
+
+    whisker()
+        .arg("check")
+        .arg(package.path())
+        .assert()
+        .code(1)
+        .stdout(predicate::str::is_empty())
+        .stderr(predicate::str::contains(
+            "failed to load the whisker configuration",
+        ))
+        .stderr(predicate::str::contains("TOML parse error at line 1"));
+}
+
 #[test]
 fn check_with_deny_warnings_fails_on_warnings() {
     let package = with_no_todo(package(WARNING_SOURCE));
@@ -481,7 +627,33 @@ fn check_with_deny_warnings_fails_on_warnings() {
         .arg(package.path())
         .assert()
         .code(1)
+        .stdout(predicate::str::is_empty())
         .stderr(predicate::str::contains("error[custom.no-todo]"));
+}
+
+/// Pins that whisker writes its whole report to stderr and leaves stdout
+/// empty
+///
+/// A caller that pipes whisker into another program reads stdout, so a
+/// report that landed there would corrupt the pipe. This run trips both
+/// writers at once: the renderer prints a diagnostic for `src/lib.rs`, and
+/// the walk prints an error for the file it cannot read. The other
+/// assertions in this file cover one writer each, and this one covers the
+/// pair that a single run prints together.
+#[test]
+fn check_with_diagnostics_and_errors_writes_nothing_to_stdout() {
+    let root = mixed_project("check_writes_nothing_to_stdout");
+
+    whisker()
+        .current_dir(&root)
+        .args(["check", "--keep-going", "src"])
+        .assert()
+        .code(1)
+        .stdout(predicate::str::is_empty())
+        .stderr(predicate::str::contains(
+            "warning[fixture.wildcard-match-arm]",
+        ))
+        .stderr(predicate::str::contains("error: src/not_utf8.rs"));
 }
 
 /// Pins the exit code to the failure recorded while walking the files, not
@@ -499,6 +671,7 @@ fn check_with_keep_going_and_unreadable_file_fails() {
         .arg(package.path())
         .assert()
         .code(1)
+        .stdout(predicate::str::is_empty())
         .stderr(predicate::str::contains(
             "stream did not contain valid UTF-8",
         ))
@@ -570,6 +743,7 @@ fn check_without_deny_warnings_reports_warnings_and_succeeds() {
         .arg(package.path())
         .assert()
         .success()
+        .stdout(predicate::str::is_empty())
         .stderr(predicate::str::contains("warning[custom.no-todo]"));
 }
 

--- a/crates/whisker/tests/custom_lints.rs
+++ b/crates/whisker/tests/custom_lints.rs
@@ -235,7 +235,7 @@ fn check_with_a_rule_no_lint_reports_fails() {
         .arg("check")
         .arg(target.path())
         .assert()
-        .failure()
+        .code(1)
         .stderr(predicate::str::contains("workspace.frist"))
         .stderr(predicate::str::contains("workspace.first"));
 }
@@ -253,7 +253,7 @@ fn check_with_both_rule_lists_fails() {
         .arg("check")
         .arg(target.path())
         .assert()
-        .failure()
+        .code(1)
         .stderr(predicate::str::contains("both"));
 }
 
@@ -281,7 +281,7 @@ fn check_with_a_plugin_from_an_older_protocol_refuses_it() {
         .arg("check")
         .arg(target.path())
         .assert()
-        .failure()
+        .code(1)
         .stderr(predicate::str::contains("plugin (ABI 2)"))
         .stderr(predicate::str::contains(format!(
             "whisker (ABI {})",
@@ -362,7 +362,7 @@ fn check_with_an_option_for_a_rule_no_lint_reports_fails() {
         .arg("check")
         .arg(target.path())
         .assert()
-        .failure()
+        .code(1)
         .stderr(predicate::str::contains("custom.misspelled"))
         .stderr(predicate::str::contains("custom.configured"));
 }
@@ -388,7 +388,7 @@ fn check_with_a_git_lint_that_cannot_be_fetched_names_the_source() {
         .arg("check")
         .arg(target.path())
         .assert()
-        .failure()
+        .code(1)
         .stderr(predicate::str::contains("failed to check out"))
         .stderr(predicate::str::contains("https://whisker.invalid/rules"))
         .stderr(predicate::str::contains(
@@ -445,7 +445,7 @@ fn check_with_lint_path_that_does_not_exist_fails() {
         .arg("check")
         .arg(target.path())
         .assert()
-        .failure()
+        .code(1)
         .stderr(predicate::str::contains(
             "failed to load the project's custom lints",
         ))
@@ -466,7 +466,7 @@ fn check_with_lint_that_builds_no_cdylib_fails() {
         .arg("check")
         .arg(target.path())
         .assert()
-        .failure()
+        .code(1)
         .stderr(predicate::str::contains("crate-type = [\"cdylib\"]"));
 }
 
@@ -486,7 +486,7 @@ fn check_with_lint_that_exports_no_declaration_fails() {
         .arg("check")
         .arg(target.path())
         .assert()
-        .failure()
+        .code(1)
         .stderr(predicate::str::contains("not a whisker lint plugin"))
         .stderr(predicate::str::contains("export_lints!"));
 }

--- a/crates/whisker/tests/git_lints.rs
+++ b/crates/whisker/tests/git_lints.rs
@@ -242,7 +242,7 @@ fn check_with_git_lint_source_at_an_unknown_rev_fails() {
         .arg("check")
         .arg(target.path())
         .assert()
-        .failure()
+        .code(1)
         .stderr(predicate::str::contains(ABSENT_REV))
         .stderr(predicate::str::contains(rules.url()));
 }

--- a/crates/whisker/tests/prebuilt_lints.rs
+++ b/crates/whisker/tests/prebuilt_lints.rs
@@ -325,7 +325,7 @@ fn check_with_a_prebuilt_that_fails_the_handshake_fails() {
         .arg("check")
         .arg(target.path())
         .assert()
-        .failure()
+        .code(1)
         .stderr(predicate::str::contains("incompatible with whisker"))
         .stderr(predicate::str::contains(
             destination.to_string_lossy().into_owned(),
@@ -539,7 +539,7 @@ fn check_without_a_matching_asset_names_the_archive_nobody_published() {
         .arg("check")
         .arg(target.path())
         .assert()
-        .failure()
+        .code(1)
         .stderr(predicate::str::contains(
             "note: no prebuilt lints published",
         ))
@@ -563,7 +563,7 @@ fn check_with_a_repository_the_api_does_not_know_says_nothing() {
         .arg("check")
         .arg(target.path())
         .assert()
-        .failure()
+        .code(1)
         .stderr(predicate::str::contains("note: no prebuilt lints").not())
         .stderr(predicate::str::contains("warning: whisker cannot use").not());
 }
@@ -585,7 +585,7 @@ fn check_with_a_wrong_digest_warns() {
         .arg("check")
         .arg(target.path())
         .assert()
-        .failure()
+        .code(1)
         .stderr(predicate::str::contains("warning: whisker cannot use"))
         .stderr(predicate::str::contains("digest"));
 
@@ -608,7 +608,7 @@ fn check_with_a_failing_release_api_warns() {
         .arg("check")
         .arg(target.path())
         .assert()
-        .failure()
+        .code(1)
         .stderr(predicate::str::contains("warning: whisker cannot use"))
         .stderr(predicate::str::contains("500"));
 }
@@ -702,7 +702,7 @@ fn check_with_a_checkout_already_present_asks_nothing() {
         .arg("check")
         .arg(target.path())
         .assert()
-        .failure();
+        .code(1);
     let remote = fetched_remote(&cache);
     clone_into(
         &rules,


### PR DESCRIPTION
The CLI tests asserted only that a run exited with a non-zero code. That assertion also holds when the binary panics, which exits 101. It also holds when clap rejects the command line, which exits 2. A test that means to observe a lint failure passed while whisker crashed on the way there.

Whisker exits 1 for every failure that these tests describe. The first commit changes 29 assertions across the four CLI test files. Each assertion now names the exact code.

The second commit adds seven tests. The CLI tests read stderr and never looked at stdout. Whisker sends its whole report to stderr, so a caller can pipe a run into another program. Nothing pinned that arrangement. A stray print to stdout corrupted the pipe and still passed every test.

Six tests now assert that stdout stays empty. Each of the six covers a different writer: the silent success, the warning renderer, the error renderer, the coverage remedies, the per-file walk errors, and the path from `anyhow` to `Termination`. One more test covers the diagnostic renderer and the walk errors in a single run.

Four new tests read a broken configuration through the binary. They cover an unknown key, a lint entry with no source, a lint entry that names a branch instead of a revision, and a file that the TOML reader cannot parse. The configuration module has thorough unit tests, but only two of its failures ever reached the binary. Each new test confirms that the message and the position reach the user.

Two new tests run whisker from inside the project instead of at its root. The search for the configuration file climbs to the project root, and the unit tests pin that behavior. These two tests pin that the CLI gets the benefit. A project can lose its lints without a sign, because the check still passes.

Three defects came up during this work. This pull request adds no test for them, because such a test holds the current behavior in place. The `--json` flag renders the same text as a plain run. The `--quiet` flag suppresses nothing. The `check` command binds its `Context` to `_context` and never reads it. The same command accepts trailing arguments and then drops them, so `whisker check src --total-nonsense` exits 0.
