### PR TITLE
Lay out the diagnostic and option types with stabby

### DIFF
--- a/.config/whisker.toml
+++ b/.config/whisker.toml
@@ -9,4 +9,4 @@ ignore = ["/examples/", "crates/whisker-rust/tests/fixtures/"]
 # check here runs exactly the rules it ran yesterday.
 [[lints]]
 git = "https://github.com/aonyx-ai/whisker-aonyx-rules"
-rev = "1f8d02571e8b83eb20e0751835fd1c29f1f00655"
+rev = "dcada3d08d8610562381ca68db9a2e6c3b67a862"

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -286,12 +286,11 @@ The fingerprints hash layout. Each names a list of types that cross the
 boundary. A type that stabby lays out contributes the identity stabby
 derives from its report, which covers the name and type of every field,
 so a field that moved or changed type is refused. A type not yet laid out
-that way contributes its size and alignment, and `Diagnostic`,
-`Suggestion`, `Location`, and `DecoratedNode` their field offsets. The
-whisker-rust fingerprint also hashes the generated lint pass trait as
-text, because a trait has no layout a const can read. Doc comments and
-private helpers move nothing, so a plugin stays loadable across most of
-whisker's own churn.
+that way contributes its size and alignment, and `DecoratedNode` its field
+offsets. The whisker-rust fingerprint also hashes the generated lint pass
+trait as text, because a trait has no layout a const can read. Doc
+comments and private helpers move nothing, so a plugin stays loadable
+across most of whisker's own churn.
 
 Layout cannot see the method order of `LintPass` and `LintRegistrar`,
 because a vtable orders its methods by declaration. Those belong to the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,10 +44,13 @@ and this project adheres to
 
 ### Changed
 
-- A span names its file through `FilePath`, a path that [stabby][stabby] lays
-  out, so that its layout no longer depends on the compiler. This is the
-  first step toward loading a plugin that another rustc built.
-  `Span::file_arc` is now `Span::file_path`.
+- The values a plugin exchanges with whisker are laid out by [stabby][stabby]:
+  `Diagnostic`, `Span`, `FilePath`, `Location`, `Suggestion`, `RuleId`,
+  `Severity`, `RuleOptions`, and `RuleOption`. Their layout no longer depends
+  on the compiler, which is the first step toward loading a plugin that
+  another rustc built. A span names its file through `FilePath`, and
+  `Span::file_arc` is now `Span::file_path`. `RuleOptions::names` returns
+  owned names.
 - A plugin declares the rules it reports, which is what a `[rules]` name is
   checked against. The protocol is 3, and whisker reads every protocol from
   2 upward, so a plugin built before this still loads and its rules still

--- a/crates/whisker-types/src/diagnostic.rs
+++ b/crates/whisker-types/src/diagnostic.rs
@@ -1,4 +1,4 @@
-use std::mem::offset_of;
+use stabby::{string, vec};
 
 use crate::{Location, RuleId, Severity, Span, Suggestion};
 
@@ -8,15 +8,25 @@ use crate::{Location, RuleId, Severity, Span, Suggestion};
 /// identifies a specific issue found in source code, with a severity, a
 /// primary span, and optional supplementary information like origin
 /// locations, related locations, and suggested fixes.
+///
+/// A diagnostic is what a plugin hands back across the plugin boundary.
+/// Stabby lays it out, and its strings and lists are stabby's `String` and
+/// `Vec`. The message is copied in from what a caller passes, because
+/// stabby's `String` cannot adopt an allocation std made.
+/// A plugin allocates each diagnostic and whisker frees it, which is sound
+/// because every allocation stabby makes carries its own release function.
+/// The severity is one byte and sits last, so it puts no padding between
+/// the pointer-sized fields before it.
+#[stabby::stabby]
 #[derive(Clone, Debug)]
 pub struct Diagnostic {
     rule_id: RuleId,
-    severity: Severity,
-    message: String,
+    message: string::String,
     span: Span,
-    origins: Vec<Location>,
-    related: Vec<Location>,
-    suggestions: Vec<Suggestion>,
+    origins: vec::Vec<Location>,
+    related: vec::Vec<Location>,
+    suggestions: vec::Vec<Suggestion>,
+    severity: Severity,
 }
 
 impl Diagnostic {
@@ -24,12 +34,12 @@ impl Diagnostic {
     pub fn new(rule_id: RuleId, severity: Severity, message: String, span: Span) -> Self {
         Self {
             rule_id,
-            severity,
-            message,
+            message: string::String::from(message.as_str()),
             span,
-            origins: Vec::new(),
-            related: Vec::new(),
-            suggestions: Vec::new(),
+            origins: vec::Vec::new(),
+            related: vec::Vec::new(),
+            suggestions: vec::Vec::new(),
+            severity,
         }
     }
 
@@ -115,21 +125,6 @@ impl Diagnostic {
     }
 }
 
-/// The offsets of every field, in declaration order
-///
-/// The plugin handshake hashes these so a plugin that places a field
-/// somewhere else is refused rather than trusted. They live beside the
-/// struct, because a field added there has to be added here too.
-pub(crate) const FIELD_OFFSETS: &[usize] = &[
-    offset_of!(Diagnostic, rule_id),
-    offset_of!(Diagnostic, severity),
-    offset_of!(Diagnostic, message),
-    offset_of!(Diagnostic, span),
-    offset_of!(Diagnostic, origins),
-    offset_of!(Diagnostic, related),
-    offset_of!(Diagnostic, suggestions),
-];
-
 #[cfg(test)]
 mod tests {
     use std::path::PathBuf;
@@ -172,6 +167,22 @@ mod tests {
         assert_eq!(diag.message(), "test message");
         assert_eq!(diag.span().start(), 0);
         assert_eq!(diag.span().end(), 10);
+    }
+
+    #[test]
+    fn clone_copies_every_field() {
+        let origin = Location::new(
+            Span::new(PathBuf::from("other.rs"), 5, 15),
+            "defined here".into(),
+        );
+        let diag = test_diagnostic().with_origin(origin);
+
+        let copy = diag.clone();
+
+        assert_eq!(copy.rule_id(), diag.rule_id());
+        assert_eq!(copy.message(), diag.message());
+        assert_eq!(copy.span(), diag.span());
+        assert_eq!(copy.origins(), diag.origins());
     }
 
     #[test]

--- a/crates/whisker-types/src/location.rs
+++ b/crates/whisker-types/src/location.rs
@@ -1,4 +1,4 @@
-use std::mem::offset_of;
+use stabby::string;
 
 use crate::Span;
 
@@ -7,16 +7,25 @@ use crate::Span;
 /// Used for origin and related annotations on diagnostics. The message
 /// describes the role this location plays in the diagnostic (e.g. "defined
 /// here" or "first occurrence").
+///
+/// A location crosses the plugin boundary inside a [`Diagnostic`], so
+/// stabby lays it out and the message is stabby's `String`.
+///
+/// [`Diagnostic`]: crate::Diagnostic
+#[stabby::stabby]
 #[derive(Clone, Eq, PartialEq, Hash, Debug)]
 pub struct Location {
     span: Span,
-    message: String,
+    message: string::String,
 }
 
 impl Location {
     /// Creates a location with the given span and descriptive message
     pub fn new(span: Span, message: String) -> Self {
-        Self { span, message }
+        Self {
+            span,
+            message: string::String::from(message.as_str()),
+        }
     }
 
     /// Returns the span of this location
@@ -29,14 +38,6 @@ impl Location {
         &self.message
     }
 }
-
-/// The offsets of every field, in declaration order
-///
-/// The plugin handshake hashes these so a plugin that places a field
-/// somewhere else is refused rather than trusted. They live beside the
-/// struct, because a field added there has to be added here too.
-pub(crate) const FIELD_OFFSETS: &[usize] =
-    &[offset_of!(Location, span), offset_of!(Location, message)];
 
 #[cfg(test)]
 mod tests {

--- a/crates/whisker-types/src/plugin.rs
+++ b/crates/whisker-types/src/plugin.rs
@@ -152,22 +152,15 @@ pub const RUSTC_VERSION: &CStr = c_str(concat!(env!("WHISKER_RUSTC_VERSION"), "\
 pub const TYPES_FINGERPRINT: u64 = seeded_fingerprint(
     STABLE_TYPES_FINGERPRINT,
     &[
-        Shape::of_fields::<Diagnostic>(crate::diagnostic::FIELD_OFFSETS),
-        Shape::of_fields::<Suggestion>(crate::suggestion::FIELD_OFFSETS),
-        Shape::of_fields::<Location>(crate::location::FIELD_OFFSETS),
         Shape::of_fields::<DecoratedNode<'static>>(crate::decorated_node::FIELD_OFFSETS),
         Shape::of::<DecoratedTree>(),
         Shape::of::<DecorationKey>(),
         Shape::of::<DecorationMap>(),
-        Shape::of::<RuleId>(),
-        Shape::of::<Severity>(),
         Shape::of::<Language>(),
         Shape::of::<ProviderName>(),
         Shape::of::<Coverage>(),
         Shape::of::<CoverageGap>(),
         Shape::of::<UncoveredFile>(),
-        Shape::of_fields::<RuleOptions>(crate::rule_options::FIELD_OFFSETS),
-        Shape::of_fields::<RuleOption>(crate::rule_options::OPTION_FIELD_OFFSETS),
         Shape::of::<LintPassFactory>(),
     ],
 );
@@ -177,8 +170,17 @@ pub const TYPES_FINGERPRINT: u64 = seeded_fingerprint(
 /// Each is the hash stabby computes over a type's report. The list names
 /// every such type, including one that another already reaches through a
 /// field.
-const STABLE_TYPES_FINGERPRINT: u64 =
-    stable_fingerprint(&[<Span as IStable>::ID, <FilePath as IStable>::ID]);
+const STABLE_TYPES_FINGERPRINT: u64 = stable_fingerprint(&[
+    <Diagnostic as IStable>::ID,
+    <Span as IStable>::ID,
+    <FilePath as IStable>::ID,
+    <Suggestion as IStable>::ID,
+    <Location as IStable>::ID,
+    <RuleId as IStable>::ID,
+    <Severity as IStable>::ID,
+    <RuleOptions as IStable>::ID,
+    <RuleOption as IStable>::ID,
+]);
 
 /// Converts a NUL-terminated string literal into a [`&CStr`] at compile time
 ///
@@ -269,7 +271,7 @@ mod tests {
 
     #[test]
     fn types_fingerprint_covers_every_boundary_type() {
-        let one = stable_fingerprint(&[<FilePath as IStable>::ID]);
+        let one = stable_fingerprint(&[<Diagnostic as IStable>::ID]);
 
         let all = TYPES_FINGERPRINT;
 

--- a/crates/whisker-types/src/rule_id.rs
+++ b/crates/whisker-types/src/rule_id.rs
@@ -1,3 +1,7 @@
+use std::cmp::Ordering;
+
+use stabby::str::Str;
+
 /// Identifies a lint rule
 ///
 /// Each rule has a unique static string identifier following the convention
@@ -8,6 +12,11 @@
 /// therefore still declares its identifier as an associated constant, while
 /// nothing can build one out of a string assembled at runtime.
 ///
+/// The string is held as a [`Str`], stabby's string slice, because the
+/// identifier crosses the plugin boundary. A plugin returns the rules
+/// it declares and stamps one on every diagnostic. Std promises no layout
+/// for a string slice that holds from one compiler to the next.
+///
 /// # Examples
 ///
 /// ```
@@ -17,8 +26,11 @@
 ///
 /// assert_eq!(RULE_ID.as_str(), "lint.wildcard-match-arm");
 /// ```
-#[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug)]
-pub struct RuleId(&'static str);
+///
+/// [`Str`]: stabby::str::Str
+#[stabby::stabby]
+#[derive(Copy, Clone, Eq, PartialEq, Hash, Debug)]
+pub struct RuleId(Str<'static>);
 
 impl RuleId {
     /// Returns the identifier for a static rule name
@@ -33,7 +45,7 @@ impl RuleId {
     /// assert_eq!(id.to_string(), "lint.bool-param");
     /// ```
     pub const fn new(id: &'static str) -> Self {
-        Self(id)
+        Self(Str::new(id))
     }
 
     /// Returns the string representation of this rule identifier
@@ -46,13 +58,25 @@ impl RuleId {
     /// assert_eq!(RuleId::new("lint.derive-order").as_str(), "lint.derive-order");
     /// ```
     pub fn as_str(&self) -> &'static str {
-        self.0
+        self.0.as_str()
+    }
+}
+
+impl Ord for RuleId {
+    fn cmp(&self, other: &Self) -> Ordering {
+        self.as_str().cmp(other.as_str())
+    }
+}
+
+impl PartialOrd for RuleId {
+    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+        Some(self.cmp(other))
     }
 }
 
 impl std::fmt::Display for RuleId {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        f.write_str(self.0)
+        f.write_str(self.as_str())
     }
 }
 
@@ -68,6 +92,15 @@ mod tests {
     }
 
     #[test]
+    fn debug_shows_the_name() {
+        let id = RuleId::new("lint.test");
+
+        let text = format!("{id:?}");
+
+        assert_eq!(text, "RuleId(\"lint.test\")");
+    }
+
+    #[test]
     fn display_matches_inner() {
         let id = RuleId::new("lint.test");
 
@@ -79,6 +112,16 @@ mod tests {
         const RULE_ID: RuleId = RuleId::new("lint.const");
 
         assert_eq!(RULE_ID.as_str(), "lint.const");
+    }
+
+    #[test]
+    fn ordering_follows_the_name() {
+        let first = RuleId::new("lint.a");
+        let second = RuleId::new("lint.b");
+
+        assert!(first < second);
+        assert_eq!(first.partial_cmp(&second), Some(Ordering::Less));
+        assert_eq!(first.cmp(&first), Ordering::Equal);
     }
 
     #[test]

--- a/crates/whisker-types/src/rule_options.rs
+++ b/crates/whisker-types/src/rule_options.rs
@@ -1,5 +1,7 @@
 use std::collections::BTreeSet;
-use std::mem::offset_of;
+use std::hash::{Hash, Hasher};
+
+use stabby::vec;
 
 use crate::RuleId;
 
@@ -18,7 +20,8 @@ pub use rule_option::RuleOption;
 /// would read. Whisker knows which rules a plugin declares but not which
 /// pass reports which, so it cannot cut the table down before it hands it
 /// over. A pass therefore names its own rule in the lookup, which it
-/// already holds as a constant.
+/// already holds as a constant. Because the table crosses, stabby lays it
+/// out and its list is stabby's rather than std's.
 ///
 /// A table that names a rule no loaded plugin declares is refused by
 /// [`RuleOptions::validate`]. An option name is not checked, because
@@ -38,11 +41,12 @@ pub use rule_option::RuleOption;
 ///
 /// let names = options.names(RuleId::new("lint.bool-param"), "boundary-attributes");
 ///
-/// assert_eq!(names, Some(&["shard".to_owned()][..]));
+/// assert_eq!(names, Some(vec!["shard".to_owned()]));
 /// ```
-#[derive(Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug, Default)]
+#[stabby::stabby]
+#[derive(Clone, Eq, PartialEq, Ord, PartialOrd, Debug, Default)]
 pub struct RuleOptions {
-    options: Vec<RuleOption>,
+    options: vec::Vec<RuleOption>,
 }
 
 impl RuleOptions {
@@ -63,7 +67,9 @@ impl RuleOptions {
     /// assert!(options.options().is_empty());
     /// ```
     pub fn new(options: Vec<RuleOption>) -> Self {
-        Self { options }
+        Self {
+            options: options.into_iter().collect(),
+        }
     }
 
     /// Returns the names `rule` was given for the option `option`
@@ -74,6 +80,11 @@ impl RuleOptions {
     /// two differ, so a rule with a non-empty default can tell an empty
     /// list from silence.
     ///
+    /// The names come back owned. The table keeps them in stabby's
+    /// `String`, and a rule keeps what it reads for the whole file. A copy
+    /// at this one call therefore costs less than a type every rule would
+    /// have to name.
+    ///
     /// # Examples
     ///
     /// ```
@@ -83,11 +94,11 @@ impl RuleOptions {
     ///
     /// assert_eq!(options.names(RuleId::new("lint.bool-param"), "unset"), None);
     /// ```
-    pub fn names(&self, rule: RuleId, option: &str) -> Option<&[String]> {
+    pub fn names(&self, rule: RuleId, option: &str) -> Option<Vec<String>> {
         self.options
             .iter()
             .find(|candidate| candidate.rule() == rule.as_str() && candidate.name() == option)
-            .map(RuleOption::values)
+            .map(|candidate| candidate.values().map(str::to_owned).collect())
     }
 
     /// Returns every option in the table
@@ -152,21 +163,16 @@ impl RuleOptions {
     }
 }
 
-/// The offsets of every field, in declaration order
-///
-/// The plugin handshake hashes these so a plugin that places a field
-/// somewhere else is refused rather than trusted. They live beside the
-/// struct, because a field added there has to be added here too.
-pub(crate) const FIELD_OFFSETS: &[usize] = &[offset_of!(RuleOptions, options)];
-
-/// The offsets of every field of [`RuleOption`], in declaration order
-///
-/// [`RuleOptions`] holds them behind a [`Vec`], so the handshake has to
-/// hash the element's layout as well as the table's own.
-pub(crate) const OPTION_FIELD_OFFSETS: &[usize] = rule_option::FIELD_OFFSETS;
+impl Hash for RuleOptions {
+    fn hash<H: Hasher>(&self, state: &mut H) {
+        self.options.as_slice().hash(state);
+    }
+}
 
 #[cfg(test)]
 mod tests {
+    use std::collections::HashSet;
+
     use super::*;
 
     fn declared(names: &[&str]) -> BTreeSet<String> {
@@ -189,10 +195,13 @@ mod tests {
     }
 
     #[test]
-    fn field_offsets_covers_every_field() {
-        let offsets = FIELD_OFFSETS;
+    fn hash_agrees_with_eq() {
+        let mut tables = HashSet::new();
+        tables.insert(options());
 
-        assert_eq!(offsets.len(), 1);
+        let found = tables.contains(&options());
+
+        assert!(found);
     }
 
     #[test]
@@ -201,7 +210,7 @@ mod tests {
 
         let empty = options.names(RuleId::new("lint.bool-param"), "boundary-attributes");
 
-        assert_eq!(empty, Some(&[][..]));
+        assert_eq!(empty, Some(Vec::new()));
         assert_eq!(
             options.names(RuleId::new("lint.bool-param"), "absent"),
             None
@@ -219,7 +228,7 @@ mod tests {
 
         assert_eq!(
             names,
-            Some(&["shard".to_owned(), "procedure".to_owned()][..])
+            Some(vec!["shard".to_owned(), "procedure".to_owned()])
         );
     }
 
@@ -233,10 +242,12 @@ mod tests {
     }
 
     #[test]
-    fn option_field_offsets_covers_every_field() {
-        let offsets = OPTION_FIELD_OFFSETS;
+    fn options_returns_every_option_in_order() {
+        let options = options();
 
-        assert_eq!(offsets.len(), 3);
+        let rules: Vec<&str> = options.options().iter().map(RuleOption::rule).collect();
+
+        assert_eq!(rules, ["lint.repeated-primitive-params", "lint.bool-param"]);
     }
 
     #[test]

--- a/crates/whisker-types/src/rule_options/rule_option.rs
+++ b/crates/whisker-types/src/rule_options/rule_option.rs
@@ -1,12 +1,14 @@
-use std::mem::offset_of;
+use std::hash::{Hash, Hasher};
+
+use stabby::{string, vec};
 
 /// One option a project set for one rule
 ///
 /// A rule reads the values through [`RuleOptions::names`] rather than
 /// reaching for an option directly, so this is what a host builds and a
-/// rule rarely names. The rule it belongs to is a [`String`] and not a
-/// [`RuleId`], because the name comes from a configuration file and
-/// [`RuleId`] admits only a `&'static str`. A name that no loaded rule
+/// rule rarely names. The rule it belongs to is an owned string, because
+/// the name comes from a configuration file and [`RuleId`] admits only a
+/// `&'static str`. A name that no loaded rule
 /// declares is refused by [`RuleOptions::validate`] before any pass runs.
 ///
 /// A value is a list of names. Every option the rules ask for today names
@@ -14,7 +16,13 @@ use std::mem::offset_of;
 /// module may import. A number and a flag have no form here, so a project
 /// that writes one is told at load rather than having it read as nothing.
 ///
+/// The option crosses the plugin boundary inside [`RuleOptions`]. Stabby
+/// lays it out, and its strings and list are stabby's `String` and `Vec`.
+/// The constructor copies what it is given, and the accessors hand
+/// out borrowed `str`s, so nothing outside this crate names those types.
+///
 /// [`RuleId`]: crate::RuleId
+/// [`RuleOptions`]: crate::RuleOptions
 /// [`RuleOptions::names`]: crate::RuleOptions::names
 /// [`RuleOptions::validate`]: crate::RuleOptions::validate
 ///
@@ -31,11 +39,12 @@ use std::mem::offset_of;
 ///
 /// assert_eq!(option.name(), "boundary-attributes");
 /// ```
-#[derive(Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug)]
+#[stabby::stabby]
+#[derive(Clone, Eq, PartialEq, Ord, PartialOrd, Debug)]
 pub struct RuleOption {
-    rule: String,
-    name: String,
-    values: Vec<String>,
+    rule: string::String,
+    name: string::String,
+    values: vec::Vec<string::String>,
 }
 
 impl RuleOption {
@@ -52,10 +61,17 @@ impl RuleOption {
     ///     vec!["shard".to_owned()],
     /// );
     ///
-    /// assert_eq!(option.values(), ["shard"]);
+    /// assert_eq!(option.values().collect::<Vec<_>>(), ["shard"]);
     /// ```
     pub fn new(rule: String, name: String, values: Vec<String>) -> Self {
-        Self { rule, name, values }
+        Self {
+            rule: string::String::from(rule.as_str()),
+            name: string::String::from(name.as_str()),
+            values: values
+                .iter()
+                .map(|value| string::String::from(value.as_str()))
+                .collect(),
+        }
     }
 
     /// Returns the rule that reads this option
@@ -96,7 +112,7 @@ impl RuleOption {
         &self.name
     }
 
-    /// Returns the names this option holds
+    /// Returns the names this option holds, in the order they were written
     ///
     /// # Examples
     ///
@@ -109,26 +125,25 @@ impl RuleOption {
     ///     vec!["shard".to_owned()],
     /// );
     ///
-    /// assert_eq!(option.values().len(), 1);
+    /// assert_eq!(option.values().count(), 1);
     /// ```
-    pub fn values(&self) -> &[String] {
-        &self.values
+    pub fn values(&self) -> impl Iterator<Item = &str> {
+        self.values.iter().map(string::String::as_str)
     }
 }
 
-/// The offsets of every field, in declaration order
-///
-/// The plugin handshake hashes these so a plugin that places a field
-/// somewhere else is refused rather than trusted. They live beside the
-/// struct, because a field added there has to be added here too.
-pub(crate) const FIELD_OFFSETS: &[usize] = &[
-    offset_of!(RuleOption, rule),
-    offset_of!(RuleOption, name),
-    offset_of!(RuleOption, values),
-];
+impl Hash for RuleOption {
+    fn hash<H: Hasher>(&self, state: &mut H) {
+        self.rule.hash(state);
+        self.name.hash(state);
+        self.values.as_slice().hash(state);
+    }
+}
 
 #[cfg(test)]
 mod tests {
+    use std::collections::HashSet;
+
     use super::*;
 
     fn option() -> RuleOption {
@@ -140,10 +155,13 @@ mod tests {
     }
 
     #[test]
-    fn field_offsets_covers_every_field() {
-        let offsets = FIELD_OFFSETS;
+    fn hash_agrees_with_eq() {
+        let mut options = HashSet::new();
+        options.insert(option());
 
-        assert_eq!(offsets.len(), 3);
+        let found = options.contains(&option());
+
+        assert!(found);
     }
 
     #[test]
@@ -186,7 +204,7 @@ mod tests {
     fn values_returns_every_name() {
         let option = option();
 
-        let values = option.values();
+        let values: Vec<&str> = option.values().collect();
 
         assert_eq!(values, ["shard", "procedure"]);
     }

--- a/crates/whisker-types/src/severity.rs
+++ b/crates/whisker-types/src/severity.rs
@@ -1,4 +1,12 @@
 /// Severity level for a diagnostic
+///
+/// The discriminant is a byte. A severity crosses the plugin boundary
+/// inside every [`Diagnostic`], and an undeclared representation has no
+/// layout that holds from one compiler to the next.
+///
+/// [`Diagnostic`]: crate::Diagnostic
+#[stabby::stabby]
+#[repr(u8)]
 #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug)]
 pub enum Severity {
     /// A help message

--- a/crates/whisker-types/src/suggestion.rs
+++ b/crates/whisker-types/src/suggestion.rs
@@ -1,4 +1,4 @@
-use std::mem::offset_of;
+use stabby::string;
 
 use crate::Span;
 
@@ -6,11 +6,17 @@ use crate::Span;
 ///
 /// Represents a machine-applicable fix: replace the text at `span` with
 /// `replacement`. An empty replacement means "delete this span".
+///
+/// A suggestion crosses the plugin boundary inside a [`Diagnostic`], so
+/// stabby lays it out and its strings are stabby's `String`.
+///
+/// [`Diagnostic`]: crate::Diagnostic
+#[stabby::stabby]
 #[derive(Clone, Eq, PartialEq, Hash, Debug)]
 pub struct Suggestion {
     span: Span,
-    replacement: String,
-    message: String,
+    replacement: string::String,
+    message: string::String,
 }
 
 impl Suggestion {
@@ -18,8 +24,8 @@ impl Suggestion {
     pub fn new(span: Span, replacement: String, message: String) -> Self {
         Self {
             span,
-            replacement,
-            message,
+            replacement: string::String::from(replacement.as_str()),
+            message: string::String::from(message.as_str()),
         }
     }
 
@@ -38,17 +44,6 @@ impl Suggestion {
         &self.message
     }
 }
-
-/// The offsets of every field, in declaration order
-///
-/// The plugin handshake hashes these so a plugin that places a field
-/// somewhere else is refused rather than trusted. They live beside the
-/// struct, because a field added there has to be added here too.
-pub(crate) const FIELD_OFFSETS: &[usize] = &[
-    offset_of!(Suggestion, span),
-    offset_of!(Suggestion, replacement),
-    offset_of!(Suggestion, message),
-];
 
 #[cfg(test)]
 mod tests {

--- a/crates/whisker/src/config.rs
+++ b/crates/whisker/src/config.rs
@@ -772,11 +772,11 @@ mod tests {
                 RuleId::new("lint.repeated-primitive-params"),
                 "boundary-attributes"
             ),
-            Some(&["shard".to_owned(), "procedure".to_owned()][..])
+            Some(vec!["shard".to_owned(), "procedure".to_owned()])
         );
         assert_eq!(
             options.names(RuleId::new("lint.bool-param"), "boundary-attributes"),
-            Some(&[][..])
+            Some(Vec::new())
         );
     }
 

--- a/crates/whisker/tests/support/configurable_plugin.rs
+++ b/crates/whisker/tests/support/configurable_plugin.rs
@@ -52,8 +52,7 @@ impl RustLintPass for {pass} {{
     fn configure(&mut self, options: &RuleOptions) {{
         self.macros = options
             .names(RULE_ID, "macros")
-            .unwrap_or_default()
-            .to_vec();
+            .unwrap_or_default();
     }}
 
     fn check_macro_invocation(&mut self, node: &DecoratedNode<'_>) -> Vec<Diagnostic> {{

--- a/docs/docs/custom-lints.md
+++ b/docs/docs/custom-lints.md
@@ -82,8 +82,7 @@ impl RustLintPass for RepeatedPrimitiveParams {
     fn configure(&mut self, options: &RuleOptions) {
         self.boundary_attributes = options
             .names(RULE_ID, "boundary-attributes")
-            .unwrap_or_default()
-            .to_vec();
+            .unwrap_or_default();
     }
 }
 ```


### PR DESCRIPTION
stabby now lays out the values that a pass returns and the options that it reads: `Diagnostic`, `Location`, `Suggestion`, `RuleId`, `Severity`, `RuleOptions`, and `RuleOption`. Stabby's `String` and `Vec` keep one layout under every compiler. They free memory through the allocator that made them, so whisker can drop a diagnostic that the plugin built. `RuleOptions::names` returns owned names. Before, it borrowed a slice type that a rule had to name in its own field.

With this change, every value type in the fingerprint contributes the identity that stabby derives from its report. The shapes that remain in the fingerprint belong to the node, the tree, and the types that never leave the host.

The rules repository is pinned to a commit that builds against this change, so that whisker's check of itself loads its rules. That commit pins the `abi/diagnostic-types-pin` branch. Both pins move to the release that carries the change.

Part of https://github.com/aonyx-ai/whisker/issues/343.
