### PR TITLE
Lay out the decoration types with stabby

### DIFF
--- a/.config/whisker.toml
+++ b/.config/whisker.toml
@@ -9,4 +9,4 @@ ignore = ["/examples/", "crates/whisker-rust/tests/fixtures/"]
 # check here runs exactly the rules it ran yesterday.
 [[lints]]
 git = "https://github.com/aonyx-ai/whisker-aonyx-rules"
-rev = "dcada3d08d8610562381ca68db9a2e6c3b67a862"
+rev = "08b979629122d8a522d4cd81c0ef569835a6831e"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,10 @@ and this project adheres to
   another rustc built. A span names its file through `FilePath`, and
   `Span::file_arc` is now `Span::file_path`. `RuleOptions::names` returns
   owned names.
+- The decorations a plugin reads are laid out by stabby too: `ResolvedType`,
+  `FnSignature`, `AdtFlags`, and `ImportSource`, with the types they hold. A
+  `Decoration` must now be `IStable`, so a decoration std would lay out is a
+  compile error rather than a plugin that reads the wrong bytes.
 - A plugin declares the rules it reports, which is what a `[rules]` name is
   checked against. The protocol is 3, and whisker reads every protocol from
   2 upward, so a plugin built before this still loads and its rules still

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5351,6 +5351,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "proptest",
+ "stabby",
  "tree-sitter",
  "tree-sitter-rust",
  "whisker-types",
@@ -5362,6 +5363,7 @@ version = "0.1.0"
 dependencies = [
  "proc-macro2",
  "quote",
+ "stabby",
  "syn 3.0.5",
  "tree-sitter",
  "tree-sitter-rust",
@@ -5391,6 +5393,7 @@ dependencies = [
  "ra_ap_project_model",
  "ra_ap_syntax",
  "ra_ap_vfs",
+ "stabby",
  "tree-sitter",
  "tree-sitter-rust",
  "whisker-codegen",
@@ -5404,6 +5407,7 @@ name = "whisker-testing"
 version = "0.1.0"
 dependencies = [
  "proptest",
+ "stabby",
  "tree-sitter",
  "tree-sitter-rust",
  "whisker-core",

--- a/crates/whisker-core/Cargo.toml
+++ b/crates/whisker-core/Cargo.toml
@@ -12,6 +12,7 @@ whisker-types.workspace = true
 
 [dev-dependencies]
 proptest.workspace = true
+stabby.workspace = true
 tree-sitter-rust.workspace = true
 
 [lints]

--- a/crates/whisker-core/src/pipeline.rs
+++ b/crates/whisker-core/src/pipeline.rs
@@ -121,6 +121,7 @@ pub fn detect_language(path: &Path) -> anyhow::Result<Language> {
 mod tests {
     use std::path::PathBuf;
 
+    use stabby::str::Str;
     use whisker_types::{
         CoverageGap, DecoratedNode, Decoration, DecorationKey, DecorationMap, Diagnostic, Language,
         ProviderName, RuleId, RuleOptions, Severity,
@@ -164,13 +165,14 @@ mod tests {
 
         fn decorate(&self, tree: &DecoratedTree) -> anyhow::Result<Coverage> {
             let mut decorations = DecorationMap::new();
-            decorations.insert(tree.root_node().id(), Marker(self.0));
+            decorations.insert(tree.root_node().id(), Marker(Str::new(self.0)));
             Ok(Coverage::Covered(decorations))
         }
     }
 
+    #[stabby::stabby]
     #[derive(Debug)]
-    struct Marker(&'static str);
+    struct Marker(Str<'static>);
 
     unsafe impl Decoration for Marker {
         const KEY: DecorationKey = DecorationKey::new(concat!(module_path!(), "::Marker"));
@@ -201,7 +203,7 @@ mod tests {
             vec![Diagnostic::new(
                 RuleId::new("test.marker"),
                 Severity::Warn,
-                marker.0.into(),
+                marker.0.as_str().into(),
                 node.span(),
             )]
         }

--- a/crates/whisker-macros/Cargo.toml
+++ b/crates/whisker-macros/Cargo.toml
@@ -14,6 +14,7 @@ quote.workspace = true
 syn.workspace = true
 
 [dev-dependencies]
+stabby.workspace = true
 tree-sitter.workspace = true
 tree-sitter-rust.workspace = true
 whisker-types.workspace = true

--- a/crates/whisker-macros/src/lib.rs
+++ b/crates/whisker-macros/src/lib.rs
@@ -22,15 +22,22 @@ use syn::{DeriveInput, parse_macro_input};
 ///
 /// # Examples
 ///
+/// A plugin reads a decoration out of memory the host allocated, so
+/// `Decoration` requires a layout stabby fixes. Annotate the type with
+/// `#[stabby::stabby]` and give it fields stabby lays out.
+///
 /// ```
+/// use stabby::string::String;
 /// use whisker_macros::Decoration;
 ///
+/// #[stabby::stabby]
 /// #[derive(Decoration)]
 /// #[decoration(cardinality = "one")]
 /// pub struct ResolvedType {
 ///     display: String,
 /// }
 ///
+/// #[stabby::stabby]
 /// #[derive(Decoration)]
 /// #[decoration(cardinality = "many")]
 /// pub struct TraitImpl {

--- a/crates/whisker-macros/tests/decoration.rs
+++ b/crates/whisker-macros/tests/decoration.rs
@@ -6,16 +6,19 @@
 
 use std::path::PathBuf;
 
+use stabby::str::Str;
 use whisker_macros::Decoration;
 use whisker_types::{DecoratedTree, Decoration};
 
+#[stabby::stabby]
 #[derive(Decoration)]
 #[decoration(cardinality = "one")]
-struct ResolvedType(&'static str);
+struct ResolvedType(Str<'static>);
 
+#[stabby::stabby]
 #[derive(Decoration)]
 #[decoration(cardinality = "many")]
-struct TraitImpl(&'static str);
+struct TraitImpl(Str<'static>);
 
 fn parse(source: &str) -> DecoratedTree {
     let mut parser = tree_sitter::Parser::new();
@@ -31,14 +34,16 @@ fn parse(source: &str) -> DecoratedTree {
 fn many_cardinality_reads_back_every_instance_in_order() {
     let mut tree = parse("fn main() {}");
     let id = tree.root_node().id();
-    tree.decorations_mut().insert(id, TraitImpl("Debug"));
-    tree.decorations_mut().insert(id, TraitImpl("Clone"));
+    tree.decorations_mut()
+        .insert(id, TraitImpl(Str::new("Debug")));
+    tree.decorations_mut()
+        .insert(id, TraitImpl(Str::new("Clone")));
 
     let found = tree.root_node().get::<TraitImpl>();
 
     assert_eq!(found.len(), 2);
-    assert_eq!(found[0].0, "Debug");
-    assert_eq!(found[1].0, "Clone");
+    assert_eq!(found[0].0.as_str(), "Debug");
+    assert_eq!(found[1].0.as_str(), "Clone");
 }
 
 #[test]
@@ -54,11 +59,12 @@ fn many_cardinality_when_absent_reads_back_empty() {
 fn one_cardinality_reads_back_a_single_value() {
     let mut tree = parse("fn main() {}");
     let id = tree.root_node().id();
-    tree.decorations_mut().insert(id, ResolvedType("u32"));
+    tree.decorations_mut()
+        .insert(id, ResolvedType(Str::new("u32")));
 
     let found = tree.root_node().get::<ResolvedType>();
 
-    assert_eq!(found.expect("should be present").0, "u32");
+    assert_eq!(found.expect("should be present").0.as_str(), "u32");
 }
 
 #[test]
@@ -75,7 +81,8 @@ fn decorations_are_keyed_per_node() {
     let source = "fn main() {}";
     let mut tree = parse(source);
     let root_id = tree.root_node().id();
-    tree.decorations_mut().insert(root_id, ResolvedType("root"));
+    tree.decorations_mut()
+        .insert(root_id, ResolvedType(Str::new("root")));
 
     let child = tree
         .root_node()
@@ -86,7 +93,8 @@ fn decorations_are_keyed_per_node() {
         tree.root_node()
             .get::<ResolvedType>()
             .expect("root should be decorated")
-            .0,
+            .0
+            .as_str(),
         "root"
     );
     assert!(child.get::<ResolvedType>().is_none());
@@ -96,11 +104,12 @@ fn decorations_are_keyed_per_node() {
 fn lookup_can_be_called_through_the_trait() {
     let mut tree = parse("fn main() {}");
     let id = tree.root_node().id();
-    tree.decorations_mut().insert(id, ResolvedType("u32"));
+    tree.decorations_mut()
+        .insert(id, ResolvedType(Str::new("u32")));
 
     let found = ResolvedType::lookup(&tree.root_node());
 
-    assert_eq!(found.expect("should be present").0, "u32");
+    assert_eq!(found.expect("should be present").0.as_str(), "u32");
 }
 
 /// Two types of one name in two function bodies must stay apart
@@ -111,6 +120,7 @@ fn lookup_can_be_called_through_the_trait() {
 #[test]
 fn same_named_types_in_two_functions_do_not_collide() {
     fn decorate(tree: &mut DecoratedTree) -> u64 {
+        #[stabby::stabby]
         #[derive(Decoration)]
         #[decoration(cardinality = "one")]
         struct Local(u64);
@@ -121,6 +131,7 @@ fn same_named_types_in_two_functions_do_not_collide() {
         tree.root_node().get::<Local>().expect("should read back").0
     }
 
+    #[stabby::stabby]
     #[derive(Decoration)]
     #[decoration(cardinality = "one")]
     struct Local;

--- a/crates/whisker-rust/Cargo.toml
+++ b/crates/whisker-rust/Cargo.toml
@@ -29,6 +29,7 @@ ra_ap_load-cargo = { workspace = true, optional = true }
 ra_ap_project_model = { workspace = true, optional = true }
 ra_ap_syntax = { workspace = true, optional = true }
 ra_ap_vfs = { workspace = true, optional = true }
+stabby.workspace = true
 tree-sitter.workspace = true
 tree-sitter-rust.workspace = true
 whisker-macros.workspace = true

--- a/crates/whisker-rust/src/decorations/adt_flags.rs
+++ b/crates/whisker-rust/src/decorations/adt_flags.rs
@@ -6,7 +6,11 @@ use whisker_macros::Decoration;
 /// Provides additional information about the ADT that rules need for
 /// decisions like whether a wildcard match arm is acceptable.
 ///
+/// A rule reads it out of memory the host allocated, so stabby lays it
+/// out.
+///
 /// [`ResolvedType`]: crate::decorations::ResolvedType
+#[stabby::stabby]
 #[derive(Copy, Clone, Eq, PartialEq, Hash, Debug, Decoration)]
 #[decoration(cardinality = "one")]
 pub struct AdtFlags {

--- a/crates/whisker-rust/src/decorations/error_type.rs
+++ b/crates/whisker-rust/src/decorations/error_type.rs
@@ -8,8 +8,14 @@ use crate::decorations::{TypePath, TypePathRef};
 /// `Box<dyn Error>` is [`ErrorType::Named`] with the path
 /// `alloc::boxed::Box`, because `Box` is the ADT in the `E` slot.
 ///
+/// A rule reads it out of a [`FnSignature`] the host recorded, so the
+/// discriminant is a byte and stabby lays the payload out.
+///
+/// [`FnSignature`]: crate::decorations::FnSignature
 /// [`Result<T, E>`]: std::result::Result
 /// [`TypePath`]: crate::decorations::TypePath
+#[stabby::stabby]
+#[repr(u8)]
 #[derive(Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug)]
 pub enum ErrorType {
     /// The error is an ADT, identified by where it is defined

--- a/crates/whisker-rust/src/decorations/fn_signature.rs
+++ b/crates/whisker-rust/src/decorations/fn_signature.rs
@@ -1,3 +1,4 @@
+use stabby::option;
 use whisker_macros::Decoration;
 
 use crate::decorations::{ErrorType, ResolvedType, ReturnMode};
@@ -8,11 +9,18 @@ use crate::decorations::{ErrorType, ResolvedType, ReturnMode};
 /// without re-querying the semantic model. Every resolved function gets a
 /// signature, even an empty one. An absent decoration would look like a
 /// function the provider never reached, and those are different facts.
+///
+/// A rule reads it out of memory the host allocated, so stabby lays it
+/// out. Its optional parts are stabby's [`Option`], because std promises
+/// no layout for an `Option` of these types.
+///
+/// [`Option`]: stabby::option::Option
+#[stabby::stabby]
 #[derive(Clone, Eq, PartialEq, Hash, Debug, Decoration)]
 #[decoration(cardinality = "one")]
 pub struct FnSignature {
-    return_type: Option<ResolvedType>,
-    error_type: Option<ErrorType>,
+    return_type: option::Option<ResolvedType>,
+    error_type: option::Option<ErrorType>,
     return_mode: ReturnMode,
 }
 
@@ -24,8 +32,8 @@ impl FnSignature {
         return_mode: ReturnMode,
     ) -> Self {
         Self {
-            return_type,
-            error_type,
+            return_type: return_type.into(),
+            error_type: error_type.into(),
             return_mode,
         }
     }

--- a/crates/whisker-rust/src/decorations/import_source.rs
+++ b/crates/whisker-rust/src/decorations/import_source.rs
@@ -7,6 +7,11 @@ use whisker_macros::Decoration;
 ///
 /// The provider attaches it to a `use_declaration` whose path has a
 /// qualifier. `use serde;` has none, so it carries no decoration.
+///
+/// A rule reads it out of memory the host allocated, so the discriminant
+/// is a byte, a layout that holds from one compiler to the next.
+#[stabby::stabby]
+#[repr(u8)]
 #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug, Decoration)]
 #[decoration(cardinality = "one")]
 pub enum ImportSource {

--- a/crates/whisker-rust/src/decorations/resolved_type.rs
+++ b/crates/whisker-rust/src/decorations/resolved_type.rs
@@ -1,3 +1,4 @@
+use stabby::string;
 use whisker_macros::Decoration;
 
 /// Resolved type information attached to a tree-sitter node
@@ -5,6 +6,9 @@ use whisker_macros::Decoration;
 /// Decoration providers populate this on match scrutinees, `else`
 /// clauses, and `?` operands. Rules access it via
 /// `node.decoration::<ResolvedType>()`.
+///
+/// A rule reads it out of memory the host allocated, so stabby lays it
+/// out and the rendered name is stabby's `String`.
 ///
 /// # Examples
 ///
@@ -16,10 +20,11 @@ use whisker_macros::Decoration;
 /// assert_eq!(ty.display(), "MyEnum");
 /// assert!(ty.is_enum());
 /// ```
+#[stabby::stabby]
 #[derive(Clone, Eq, PartialEq, Hash, Debug, Decoration)]
 #[decoration(cardinality = "one")]
 pub struct ResolvedType {
-    display: String,
+    display: string::String,
     is_enum: bool,
     is_never: bool,
     is_result: bool,
@@ -30,7 +35,7 @@ impl ResolvedType {
     /// Creates a new resolved type
     pub fn new(display: String) -> Self {
         Self {
-            display,
+            display: string::String::from(display.as_str()),
             is_enum: false,
             is_never: false,
             is_result: false,

--- a/crates/whisker-rust/src/decorations/return_mode.rs
+++ b/crates/whisker-rust/src/decorations/return_mode.rs
@@ -3,6 +3,14 @@
 /// For a plain function, the declared return type holds the error type. For
 /// an `async fn`, the declared type is an opaque future, and the error type
 /// is in the future's output.
+///
+/// A rule reads it out of a [`FnSignature`] the host recorded, so the
+/// discriminant is a byte. That is a layout that holds from one compiler
+/// to the next.
+///
+/// [`FnSignature`]: crate::decorations::FnSignature
+#[stabby::stabby]
+#[repr(u8)]
 #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug)]
 pub enum ReturnMode {
     /// The error type is in the declared return type

--- a/crates/whisker-rust/src/decorations/type_path.rs
+++ b/crates/whisker-rust/src/decorations/type_path.rs
@@ -1,4 +1,7 @@
 use std::fmt;
+use std::hash::{Hash, Hasher};
+
+use stabby::{string, vec};
 
 use crate::decorations::TypePathRef;
 
@@ -11,6 +14,9 @@ use crate::decorations::TypePathRef;
 /// The path names the item's definition, not a re-export, so `syn::Error`
 /// appears here as `syn::error::Error`.
 ///
+/// A rule reads the path out of a decoration the host recorded, so stabby
+/// lays it out. Its segments are stabby's `String`s.
+///
 /// # Examples
 ///
 /// ```
@@ -20,11 +26,12 @@ use crate::decorations::TypePathRef;
 ///
 /// assert_eq!(path.to_string(), "syn::error::Error");
 /// ```
-#[derive(Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug)]
+#[stabby::stabby]
+#[derive(Clone, Eq, PartialEq, Ord, PartialOrd, Debug)]
 pub struct TypePath {
-    krate: Box<str>,
-    modules: Box<[Box<str>]>,
-    name: Box<str>,
+    krate: string::String,
+    modules: vec::Vec<string::String>,
+    name: string::String,
 }
 
 impl TypePath {
@@ -45,12 +52,12 @@ impl TypePath {
         M::Item: AsRef<str>,
     {
         Self {
-            krate: Box::from(krate),
+            krate: string::String::from(krate),
             modules: modules
                 .into_iter()
-                .map(|segment| Box::from(segment.as_ref()))
+                .map(|segment| string::String::from(segment.as_ref()))
                 .collect(),
-            name: Box::from(name),
+            name: string::String::from(name),
         }
     }
 
@@ -81,7 +88,7 @@ impl TypePath {
     /// assert_eq!(path.modules().collect::<Vec<_>>(), vec!["error"]);
     /// ```
     pub fn modules(&self) -> impl Iterator<Item = &str> {
-        self.modules.iter().map(AsRef::as_ref)
+        self.modules.iter().map(string::String::as_str)
     }
 
     /// Returns the item's own name
@@ -108,32 +115,50 @@ impl TypePath {
 impl fmt::Display for TypePath {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "{}", self.krate)?;
-        for segment in &self.modules {
+        for segment in self.modules() {
             write!(f, "::{segment}")?;
         }
         write!(f, "::{}", self.name)
     }
 }
 
+impl Hash for TypePath {
+    fn hash<H: Hasher>(&self, state: &mut H) {
+        self.krate.hash(state);
+        self.modules.as_slice().hash(state);
+        self.name.hash(state);
+    }
+}
+
 impl PartialEq<TypePathRef<'_>> for TypePath {
     fn eq(&self, other: &TypePathRef<'_>) -> bool {
-        &*self.krate == other.krate()
-            && &*self.name == other.name()
+        self.krate() == other.krate()
+            && self.name() == other.name()
             && self.modules.len() == other.modules().len()
             && self
-                .modules
-                .iter()
+                .modules()
                 .zip(other.modules())
-                .all(|(lhs, rhs)| &**lhs == *rhs)
+                .all(|(lhs, rhs)| lhs == *rhs)
     }
 }
 
 #[cfg(test)]
 mod tests {
+    use std::collections::HashSet;
+
     use super::*;
 
     #[test]
-    fn display_renders_crate_modules_and_name() {
+    fn accessors_return_each_part() {
+        let path = TypePath::new("syn", ["error"], "Error");
+
+        assert_eq!(path.krate(), "syn");
+        assert_eq!(path.modules().collect::<Vec<_>>(), vec!["error"]);
+        assert_eq!(path.name(), "Error");
+    }
+
+    #[test]
+    fn display_joins_segments_with_double_colons() {
         let path = TypePath::new("syn", ["error"], "Error");
 
         let rendered = path.to_string();
@@ -188,6 +213,17 @@ mod tests {
         let matches = path == TypePathRef::new("syn", &["error"], "Error");
 
         assert!(matches);
+    }
+
+    #[test]
+    fn hash_agrees_with_eq() {
+        let mut paths = HashSet::new();
+        paths.insert(TypePath::new("syn", ["error"], "Error"));
+
+        let found = paths.contains(&TypePath::new("syn", ["error"], "Error"));
+
+        assert!(found);
+        assert!(!paths.contains(&TypePath::new("syn", [] as [&str; 0], "Error")));
     }
 
     #[test]

--- a/crates/whisker-rust/src/lib.rs
+++ b/crates/whisker-rust/src/lib.rs
@@ -369,6 +369,7 @@ mod tests {
 
         use super::*;
 
+        #[stabby::stabby]
         #[derive(Eq, PartialEq, Debug, Decoration)]
         #[decoration(cardinality = "one")]
         struct Tag(u32);

--- a/crates/whisker-rust/src/plugin.rs
+++ b/crates/whisker-rust/src/plugin.rs
@@ -10,31 +10,35 @@
 //! [`RustLintPass`]: crate::RustLintPass
 //! [`export_lints!`]: crate::export_lints
 
+use stabby::IStable;
+use whisker_types::plugin::stable_fingerprint;
 pub use whisker_types::plugin::{
     ABI_VERSION, LintPassFactory, LintRegistrar, MIN_ABI_VERSION, PluginDeclaration, RUSTC_VERSION,
     TYPES_FINGERPRINT, c_str,
 };
-use whisker_types::plugin::{Shape, seeded_fingerprint};
 
-use crate::decorations::{
-    AdtFlags, ErrorType, FnSignature, ResolvedType, ReturnMode, TypePath, TypePathRef,
-};
+use crate::decorations::{AdtFlags, FnSignature, ImportSource, ResolvedType};
 
 include!(concat!(env!("OUT_DIR"), "/visitor_fingerprint.rs"));
 
 /// A fingerprint of the Rust language support a plugin was built against
 ///
 /// Two things on this side shape the boundary. The generated lint pass
-/// trait is one: its methods are named after the grammar's node kinds and
-/// a plugin generated from a different grammar would not crash, its checks
-/// would quietly never fire, so [`VISITOR_FINGERPRINT`] hashes the
-/// generated source. The decoration types are the other, because a plugin
+/// trait is one: its methods are named after the grammar's node kinds. A
+/// plugin generated from a different grammar still loads, and its checks
+/// never fire, so [`VISITOR_FINGERPRINT`] hashes the generated source. The decoration types are the other, because a plugin
 /// reads them out of a node the host decorated, and reading them at a
 /// layout the host did not write is unsound rather than merely quiet.
 ///
-/// Everything else in this crate is deliberately absent. Hashing it, as an
-/// earlier revision did, refused every plugin in the tree whenever any
-/// source file here changed at all.
+/// Each decoration contributes the identity stabby derives from its
+/// report, which covers the name and type of every field, recursively. A
+/// type a decoration holds, such as [`TypePath`] inside [`FnSignature`],
+/// is therefore covered without being named here. The list names every
+/// type that implements [`Decoration`], and a new one belongs on it.
+///
+/// Everything else in this crate is deliberately absent. Hashing the
+/// whole crate refuses every plugin in the tree whenever any source file
+/// here changes.
 ///
 /// # Examples
 ///
@@ -43,30 +47,28 @@ include!(concat!(env!("OUT_DIR"), "/visitor_fingerprint.rs"));
 ///
 /// assert_ne!(LANGUAGE_FINGERPRINT, 0);
 /// ```
-pub const LANGUAGE_FINGERPRINT: u64 = seeded_fingerprint(
+///
+/// [`Decoration`]: whisker_types::Decoration
+/// [`TypePath`]: crate::decorations::TypePath
+pub const LANGUAGE_FINGERPRINT: u64 = stable_fingerprint(&[
     VISITOR_FINGERPRINT,
-    &[
-        Shape::of::<AdtFlags>(),
-        Shape::of::<ErrorType>(),
-        Shape::of::<FnSignature>(),
-        Shape::of::<ResolvedType>(),
-        Shape::of::<ReturnMode>(),
-        Shape::of::<TypePath>(),
-        Shape::of::<TypePathRef>(),
-    ],
-);
+    <AdtFlags as IStable>::ID,
+    <FnSignature as IStable>::ID,
+    <ImportSource as IStable>::ID,
+    <ResolvedType as IStable>::ID,
+]);
 
 #[cfg(test)]
 mod tests {
     use super::*;
 
     #[test]
-    fn language_fingerprint_covers_more_than_the_visitor() {
-        let visitor_only = VISITOR_FINGERPRINT;
+    fn language_fingerprint_covers_the_decorations() {
+        let visitor_alone = stable_fingerprint(&[VISITOR_FINGERPRINT]);
 
         let combined = LANGUAGE_FINGERPRINT;
 
-        assert_ne!(combined, visitor_only);
+        assert_ne!(combined, visitor_alone);
         assert_ne!(combined, 0);
     }
 

--- a/crates/whisker-rust/tests/fixtures/lints/decoration_probes/Cargo.lock
+++ b/crates/whisker-rust/tests/fixtures/lints/decoration_probes/Cargo.lock
@@ -366,6 +366,7 @@ dependencies = [
 name = "whisker-rust"
 version = "0.1.0"
 dependencies = [
+ "stabby",
  "tree-sitter",
  "tree-sitter-rust",
  "whisker-codegen",

--- a/crates/whisker-testing/Cargo.toml
+++ b/crates/whisker-testing/Cargo.toml
@@ -13,6 +13,7 @@ whisker-types.workspace = true
 
 [dev-dependencies]
 proptest.workspace = true
+stabby.workspace = true
 whisker-rust.workspace = true
 
 [lints]

--- a/crates/whisker-testing/src/lib.rs
+++ b/crates/whisker-testing/src/lib.rs
@@ -225,6 +225,7 @@ mod tests {
 
     use super::*;
 
+    #[stabby::stabby]
     #[derive(Eq, PartialEq, Debug)]
     struct Tag(u32);
 

--- a/crates/whisker-types/src/decorated_node.rs
+++ b/crates/whisker-types/src/decorated_node.rs
@@ -179,6 +179,7 @@ mod tests {
     use super::*;
     use crate::DecorationKey;
 
+    #[stabby::stabby]
     #[derive(Eq, PartialEq, Debug)]
     struct TestDeco(u32);
 
@@ -192,6 +193,7 @@ mod tests {
         }
     }
 
+    #[stabby::stabby]
     #[derive(Eq, PartialEq, Debug)]
     struct Missing;
 
@@ -205,6 +207,7 @@ mod tests {
         }
     }
 
+    #[stabby::stabby]
     #[derive(Eq, PartialEq, Debug)]
     struct Value(u64);
 

--- a/crates/whisker-types/src/decorated_tree.rs
+++ b/crates/whisker-types/src/decorated_tree.rs
@@ -78,6 +78,7 @@ mod tests {
     use super::*;
     use crate::{Decoration, DecorationKey};
 
+    #[stabby::stabby]
     #[derive(Eq, PartialEq, Debug)]
     struct Tag(u32);
 

--- a/crates/whisker-types/src/decoration.rs
+++ b/crates/whisker-types/src/decoration.rs
@@ -1,3 +1,5 @@
+use stabby::IStable;
+
 use crate::{DecoratedNode, DecorationKey};
 
 /// A semantic annotation that a provider can attach to syntax nodes
@@ -18,10 +20,16 @@ use crate::{DecoratedNode, DecorationKey};
 /// safety obligation mechanically:
 ///
 /// ```ignore
+/// #[stabby::stabby]
 /// #[derive(Decoration)]
 /// #[decoration(cardinality = "one")]
 /// pub struct ResolvedType { /* … */ }
 /// ```
+///
+/// A decoration is [`IStable`]. A plugin reads it out of memory the host
+/// allocated, and only a layout that holds from one compiler to the next
+/// makes that read sound. The bound turns a decoration std would lay out
+/// into a compile error rather than a plugin that reads the wrong bytes.
 ///
 /// # Safety
 ///
@@ -40,7 +48,8 @@ use crate::{DecoratedNode, DecorationKey};
 /// ```
 /// use whisker_types::{DecoratedNode, Decoration, DecorationKey};
 ///
-/// struct Signature(String);
+/// #[stabby::stabby]
+/// struct Signature(stabby::string::String);
 ///
 /// unsafe impl Decoration for Signature {
 ///     const KEY: DecorationKey = DecorationKey::new(concat!(module_path!(), "::Signature"));
@@ -54,9 +63,10 @@ use crate::{DecoratedNode, DecorationKey};
 /// ```
 ///
 /// [`DecorationProvider`]: crate::DecorationProvider
+/// [`IStable`]: stabby::IStable
 /// [`KEY`]: Decoration::KEY
 /// [`Ref`]: Decoration::Ref
-pub unsafe trait Decoration: Send + Sync + Sized + 'static {
+pub unsafe trait Decoration: IStable + Send + Sync + 'static {
     /// The name that identifies this type in the decoration map
     ///
     /// The map compares keys where single-image code would compare
@@ -86,6 +96,7 @@ mod tests {
     use super::*;
     use crate::DecoratedTree;
 
+    #[stabby::stabby]
     struct Single(u32);
 
     unsafe impl Decoration for Single {
@@ -98,6 +109,7 @@ mod tests {
         }
     }
 
+    #[stabby::stabby]
     struct Repeated(u32);
 
     unsafe impl Decoration for Repeated {

--- a/crates/whisker-types/src/decoration_key.rs
+++ b/crates/whisker-types/src/decoration_key.rs
@@ -1,3 +1,5 @@
+use stabby::str::Str;
+
 /// Identifies a decoration type across separately compiled crate graphs
 ///
 /// The decoration map stores type-erased values and must decide, at
@@ -16,6 +18,11 @@
 /// type's module path, its name, and a hash of its definition, so two
 /// types stay apart even where a module path and a name coincide.
 ///
+/// The name is held as a [`Str`], stabby's string slice, because a key
+/// crosses the plugin boundary with every lookup a plugin makes. Std
+/// promises no layout for a string slice that holds from one compiler to
+/// the next.
+///
 /// # Examples
 ///
 /// ```
@@ -27,9 +34,11 @@
 /// ```
 ///
 /// [`Decoration`]: crate::Decoration
+/// [`Str`]: stabby::str::Str
 /// [`TypeId`]: std::any::TypeId
+#[stabby::stabby]
 #[derive(Copy, Clone, Eq, PartialEq, Hash, Debug)]
-pub struct DecorationKey(&'static str);
+pub struct DecorationKey(Str<'static>);
 
 impl DecorationKey {
     /// Creates a key from the name that identifies a decoration type
@@ -42,7 +51,7 @@ impl DecorationKey {
     /// const KEY: DecorationKey = DecorationKey::new("my_crate::Signature");
     /// ```
     pub const fn new(name: &'static str) -> Self {
-        Self(name)
+        Self(Str::new(name))
     }
 
     /// Returns the name this key was created from
@@ -57,7 +66,7 @@ impl DecorationKey {
     /// assert_eq!(key.as_str(), "my_crate::Signature");
     /// ```
     pub const fn as_str(&self) -> &'static str {
-        self.0
+        self.0.as_str()
     }
 }
 

--- a/crates/whisker-types/src/decoration_map.rs
+++ b/crates/whisker-types/src/decoration_map.rs
@@ -158,11 +158,14 @@ impl DecorationMap {
 
 #[cfg(test)]
 mod tests {
+    use stabby::string;
+
     use super::*;
     use crate::DecoratedNode;
 
+    #[stabby::stabby]
     #[derive(Eq, PartialEq, Debug)]
-    struct TypeInfo(String);
+    struct TypeInfo(string::String);
 
     unsafe impl Decoration for TypeInfo {
         const KEY: DecorationKey = DecorationKey::new(concat!(module_path!(), "::TypeInfo"));
@@ -174,6 +177,7 @@ mod tests {
         }
     }
 
+    #[stabby::stabby]
     #[derive(Eq, PartialEq, Debug)]
     struct Scope(u32);
 
@@ -213,6 +217,7 @@ mod tests {
 
     #[test]
     fn get_retrieves_a_zero_sized_decoration() {
+        #[stabby::stabby]
         #[derive(Eq, PartialEq, Debug)]
         struct Present;
 
@@ -345,6 +350,7 @@ mod tests {
 
         use super::*;
 
+        #[stabby::stabby]
         #[derive(Eq, PartialEq, Debug)]
         struct Value(u64);
 
@@ -358,6 +364,7 @@ mod tests {
             }
         }
 
+        #[stabby::stabby]
         #[derive(Eq, PartialEq, Debug)]
         struct Count(u32);
 
@@ -371,6 +378,7 @@ mod tests {
             }
         }
 
+        #[stabby::stabby]
         #[derive(Eq, PartialEq, Debug)]
         struct Signed(i64);
 

--- a/examples/custom_lint/Cargo.lock
+++ b/examples/custom_lint/Cargo.lock
@@ -366,6 +366,7 @@ dependencies = [
 name = "whisker-rust"
 version = "0.1.0"
 dependencies = [
+ "stabby",
  "tree-sitter",
  "tree-sitter-rust",
  "whisker-codegen",


### PR DESCRIPTION
A plugin reads a decoration out of memory that the host allocated. The two sides must agree on its layout, and Rust promises nothing about that from one compiler to the next. stabby now lays out the decoration types: `ResolvedType`, `FnSignature`, `AdtFlags`, and `ImportSource`, together with `ErrorType`, `ReturnMode`, and `TypePath`. The `DecorationKey` that a lookup carries across the boundary follows.

`Decoration` now requires stabby's `IStable`. A decoration that std lays out is a compile error. Before, it was a plugin that read the wrong bytes once the compilers differed. The language fingerprint folds in the identity that stabby derives from each decoration's report, in place of the sizes and alignments that it hashed before.

The rules repository is pinned to a commit that builds against this change, so that whisker's check of itself loads its rules. That commit pins the `abi/decoration-types-pin` branch. Both pins move to the release that carries the change.

Part of https://github.com/aonyx-ai/whisker/issues/343.
