### PR TITLE
Retire the shape fingerprint

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -283,14 +283,13 @@ source would mostly work, and rules fail open, so a wrong answer would
 pass unnoticed. The handshake turns it into a refusal.
 
 The fingerprints hash layout. Each names a list of types that cross the
-boundary. A type that stabby lays out contributes the identity stabby
-derives from its report, which covers the name and type of every field,
-so a field that moved or changed type is refused. The factory function
-pointer, which stabby does not lay out yet, contributes its size and
-alignment. The whisker-rust fingerprint also hashes the generated lint
-pass trait as text, because a trait has no layout a const can read. Doc
-comments and private helpers move nothing, so a plugin stays loadable
-across most of whisker's own churn.
+boundary, and every one of them is laid out by stabby. Each contributes
+the identity stabby derives from its report, which covers the name and
+type of every field, so a field that moved or changed type is refused.
+The whisker-rust fingerprint also hashes the generated lint pass trait as
+text, because a trait has no layout a const can read. Doc comments and
+private helpers move nothing, so a plugin stays loadable across most of
+whisker's own churn.
 
 A node reaches the host's decorations through a call rather than a
 reference to the map, so no std collection crosses the boundary. The host

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -70,6 +70,8 @@ and this project adheres to
   registrar is gone. Every allocation that crosses now carries the function
   that frees it, so a plugin may set its own `#[global_allocator]`. The
   protocol is 6.
+- `TYPES_FINGERPRINT` is built from stabby's identities alone. The hash of
+  sizes, alignments, and field offsets that preceded it is gone.
 - A plugin declares the rules it reports, which is what a `[rules]` name is
   checked against.
 

--- a/crates/whisker-types/src/plugin.rs
+++ b/crates/whisker-types/src/plugin.rs
@@ -53,7 +53,7 @@ mod fingerprint;
 
 pub use declaration::PluginDeclaration;
 pub use factory::{Constructed, Factories, LintPassFactory, Loaded, Plugin, construct, factory};
-pub use fingerprint::{Shape, fingerprint, seeded_fingerprint, stable_fingerprint};
+pub use fingerprint::stable_fingerprint;
 
 /// The version of the plugin declaration protocol itself
 ///
@@ -126,10 +126,11 @@ pub const RUSTC_VERSION: &CStr = c_str(concat!(env!("WHISKER_RUSTC_VERSION"), "\
 /// the whole cost of shipping rules as plugins. This hashes what the two
 /// images must actually agree on instead.
 ///
-/// A type that stabby lays out contributes the identity stabby derives
-/// from its report. That is a hash over the type's name, its module, and
-/// the name and type of every field, recursively. It refuses a field that
-/// moved, and a field whose type changed to another of the same size.
+/// Stabby lays out every type that crosses, and each contributes the
+/// identity stabby derives from its report. That is a hash over the
+/// type's name, its module, and the name and type of every field,
+/// recursively. It refuses a field that moved, and a field whose type
+/// changed to another of the same size.
 ///
 /// The list names every value that crosses, and nothing else. A pass
 /// receives a [`DecoratedNode`], which reaches its file and its

--- a/crates/whisker-types/src/plugin/fingerprint.rs
+++ b/crates/whisker-types/src/plugin/fingerprint.rs
@@ -1,151 +1,3 @@
-use std::mem::{align_of, size_of};
-
-/// One type's contribution to a boundary fingerprint
-///
-/// A plugin and its host agree on a type when they place it in memory
-/// identically. Size and alignment catch a type that grew, shrank, or
-/// changed its alignment; the offsets a caller supplies catch fields that
-/// swapped places without changing either. Nothing here reads a field's
-/// name or its type, so renaming a private field costs nothing and moving
-/// one is refused.
-#[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug)]
-pub struct Shape {
-    size: usize,
-    align: usize,
-    offsets: &'static [usize],
-}
-
-impl Shape {
-    /// Returns the shape of `T`, with no field offsets recorded
-    ///
-    /// Use this for a type that crosses the boundary whole, such as an
-    /// enum the host only ever matches on, and [`Shape::of_fields`] for one
-    /// whose fields both images address.
-    ///
-    /// # Examples
-    ///
-    /// ```
-    /// use whisker_types::plugin::Shape;
-    ///
-    /// const SHAPE: Shape = Shape::of::<u64>();
-    ///
-    /// assert_eq!(SHAPE.size(), 8);
-    /// ```
-    pub const fn of<T>() -> Self {
-        Self {
-            size: size_of::<T>(),
-            align: align_of::<T>(),
-            offsets: &[],
-        }
-    }
-
-    /// Returns the shape of `T` together with the offsets of its fields
-    ///
-    /// Pass every offset the two images depend on, in a fixed order. The
-    /// caller supplies them because [`offset_of`] only reaches fields its
-    /// own crate can name.
-    ///
-    /// # Examples
-    ///
-    /// ```
-    /// use std::mem::offset_of;
-    ///
-    /// use whisker_types::plugin::Shape;
-    ///
-    /// struct Pair {
-    ///     first: u32,
-    ///     second: u32,
-    /// }
-    ///
-    /// const SHAPE: Shape = Shape::of_fields::<Pair>(&[offset_of!(Pair, first)]);
-    ///
-    /// assert_eq!(SHAPE.size(), 8);
-    /// ```
-    ///
-    /// [`offset_of`]: std::mem::offset_of
-    pub const fn of_fields<T>(offsets: &'static [usize]) -> Self {
-        Self {
-            size: size_of::<T>(),
-            align: align_of::<T>(),
-            offsets,
-        }
-    }
-
-    /// Returns the size this type occupies
-    ///
-    /// # Examples
-    ///
-    /// ```
-    /// use whisker_types::plugin::Shape;
-    ///
-    /// assert_eq!(Shape::of::<u32>().size(), 4);
-    /// ```
-    pub const fn size(&self) -> usize {
-        self.size
-    }
-}
-
-/// Combines the shapes of every type that crosses the boundary into one hash
-///
-/// The result stands in for "these two images lay the boundary out the
-/// same way". It is FNV-1a, chosen because it is a handful of const
-/// operations rather than because it resists anything: the fingerprint
-/// detects drift between two builds of the same project, and a plugin that
-/// wants to lie about its layout can simply report the host's number.
-///
-/// # Examples
-///
-/// ```
-/// use whisker_types::plugin::{Shape, fingerprint};
-///
-/// const A: u64 = fingerprint(&[Shape::of::<u32>()]);
-/// const B: u64 = fingerprint(&[Shape::of::<u64>()]);
-///
-/// assert_ne!(A, B);
-/// ```
-pub const fn fingerprint(shapes: &[Shape]) -> u64 {
-    seeded_fingerprint(0xcbf2_9ce4_8422_2325, shapes)
-}
-
-/// Combines shapes with a value that is already a hash of something else
-///
-/// A language crate has more than layouts to answer for: whisker-rust
-/// generates its lint pass trait from a grammar, and the generated source
-/// is hashed at build time. This folds that hash in alongside the layouts
-/// rather than leaving the two to be combined by hand.
-///
-/// # Examples
-///
-/// ```
-/// use whisker_types::plugin::{Shape, seeded_fingerprint};
-///
-/// const A: u64 = seeded_fingerprint(1, &[Shape::of::<u32>()]);
-/// const B: u64 = seeded_fingerprint(2, &[Shape::of::<u32>()]);
-///
-/// assert_ne!(A, B);
-/// ```
-pub const fn seeded_fingerprint(seed: u64, shapes: &[Shape]) -> u64 {
-    let mut hash = mix(0xcbf2_9ce4_8422_2325, seed);
-
-    let mut index = 0;
-    while index < shapes.len() {
-        let shape = shapes[index];
-        hash = mix(hash, shape.size as u64);
-        hash = mix(hash, shape.align as u64);
-
-        let mut field = 0;
-        while field < shape.offsets.len() {
-            hash = mix(hash, shape.offsets[field] as u64);
-            field += 1;
-        }
-
-        hash = mix(hash, shape.offsets.len() as u64);
-        index += 1;
-    }
-
-    mix(hash, shapes.len() as u64)
-}
-
 /// Combines the identities stabby derived for a list of types
 ///
 /// A type that stabby lays out carries [`IStable::ID`], a hash over its
@@ -155,6 +7,10 @@ pub const fn seeded_fingerprint(seed: u64, shapes: &[Shape]) -> u64 {
 /// in first and the order matters, so two lists holding the same
 /// identities in another order hash apart, as do a list and its own
 /// prefix.
+///
+/// The fold is FNV-1a, a handful of const operations. It detects drift
+/// between two builds of the same project, and a plugin that misreports
+/// its layout can report the host's number.
 ///
 /// # Examples
 ///
@@ -201,72 +57,6 @@ mod tests {
     use super::*;
 
     #[test]
-    fn fingerprint_distinguishes_reordered_fields() {
-        let before = fingerprint(&[Shape::of_fields::<u64>(&[0, 4])]);
-
-        let after = fingerprint(&[Shape::of_fields::<u64>(&[4, 0])]);
-
-        assert_ne!(before, after);
-    }
-
-    #[test]
-    fn fingerprint_distinguishes_shapes_of_equal_size() {
-        let one = fingerprint(&[Shape::of_fields::<u64>(&[0])]);
-
-        let other = fingerprint(&[Shape::of_fields::<u64>(&[0, 0])]);
-
-        assert_ne!(one, other);
-    }
-
-    #[test]
-    fn fingerprint_of_the_same_shapes_is_stable() {
-        let shapes = [Shape::of::<u32>(), Shape::of_fields::<u64>(&[0, 4])];
-
-        let repeated = fingerprint(&shapes);
-
-        assert_eq!(fingerprint(&shapes), repeated);
-    }
-
-    #[test]
-    fn fingerprint_matches_its_default_seed() {
-        let seeded = seeded_fingerprint(0xcbf2_9ce4_8422_2325, &[Shape::of::<u32>()]);
-
-        let plain = fingerprint(&[Shape::of::<u32>()]);
-
-        assert_eq!(plain, seeded);
-    }
-
-    #[test]
-    fn fingerprint_of_the_empty_boundary_is_not_zero() {
-        let empty = fingerprint(&[]);
-
-        assert_ne!(empty, 0);
-    }
-
-    #[test]
-    fn fingerprint_orders_its_shapes() {
-        let one = fingerprint(&[Shape::of::<u32>(), Shape::of::<u64>()]);
-
-        let other = fingerprint(&[Shape::of::<u64>(), Shape::of::<u32>()]);
-
-        assert_ne!(one, other);
-    }
-
-    #[test]
-    fn of_fields_records_the_offsets_it_is_given() {
-        let shape = Shape::of_fields::<u64>(&[0, 4]);
-
-        assert_eq!(shape.offsets, &[0, 4]);
-    }
-
-    #[test]
-    fn of_records_no_offsets() {
-        let shape = Shape::of::<u64>();
-
-        assert!(shape.offsets.is_empty());
-    }
-
-    #[test]
     fn stable_fingerprint_distinguishes_a_changed_id() {
         let one = stable_fingerprint(&[1, 2]);
 
@@ -283,6 +73,15 @@ mod tests {
     }
 
     #[test]
+    fn stable_fingerprint_of_the_same_ids_is_stable() {
+        let ids = [1, 2, 3];
+
+        let repeated = stable_fingerprint(&ids);
+
+        assert_eq!(stable_fingerprint(&ids), repeated);
+    }
+
+    #[test]
     fn stable_fingerprint_orders_its_ids() {
         let one = stable_fingerprint(&[1, 2]);
 
@@ -292,20 +91,11 @@ mod tests {
     }
 
     #[test]
-    fn trait_send() {
-        fn assert_send<T: Send>() {}
-        assert_send::<Shape>();
-    }
+    fn stable_fingerprint_separates_a_list_from_its_prefix() {
+        let short = stable_fingerprint(&[1]);
 
-    #[test]
-    fn trait_sync() {
-        fn assert_sync<T: Sync>() {}
-        assert_sync::<Shape>();
-    }
+        let long = stable_fingerprint(&[1, 0]);
 
-    #[test]
-    fn trait_unpin() {
-        fn assert_unpin<T: Unpin>() {}
-        assert_unpin::<Shape>();
+        assert_ne!(short, long);
     }
 }


### PR DESCRIPTION
stabby now lays out every type that crosses the plugin boundary, and each type contributes the identity that stabby derives from its report. The hash of sizes, alignments, and field offsets that guarded the boundary before has nothing left to guard. This pull request removes `Shape` and the two functions that folded shapes. It keeps the one function that folds identities. The value of the fingerprint does not change, so every plugin that was built against the previous commit still loads.

Part of https://github.com/aonyx-ai/whisker/issues/343.
