### PR TITLE
State why every unsafe block is sound

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -339,6 +339,26 @@ for entry in entries {
 - No TODO comments (use issue tracker)
 - No commented-out code (use version control)
 
+The one exception is `unsafe`. Every `unsafe` block and every `unsafe
+impl` carries a `// SAFETY:` comment that says why it is sound, and
+`clippy::undocumented_unsafe_blocks` enforces this. Say what the caller
+or the surrounding code guarantees, not what the block does.
+
+```rust
+// DO
+// SAFETY: nextest runs each test in its own process, so no other thread
+// reads the environment while this writes it.
+unsafe {
+    std::env::set_var("GIT_DIR", &git_dir);
+}
+
+// DON'T
+// SAFETY: sets an environment variable.
+unsafe {
+    std::env::set_var("GIT_DIR", &git_dir);
+}
+```
+
 ```rust
 // DON'T
 // Check if user is valid

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,6 +17,8 @@ license = "Apache-2.0 OR MIT"
 repository = "https://github.com/aonyx-ai/whisker.git"
 
 [workspace.lints.clippy]
+# Every `unsafe` block states the reason it is sound, next to the block.
+undocumented_unsafe_blocks = "warn"
 missing_errors_doc = "warn"
 missing_panics_doc = "warn"
 

--- a/crates/whisker-types/src/decorated_node.rs
+++ b/crates/whisker-types/src/decorated_node.rs
@@ -59,6 +59,9 @@ impl<'a> DecoratedNode<'a> {
     /// `#[repr(C)]` struct, so the bytes the host wrote read back as the
     /// same node under any compiler.
     fn inner(&self) -> tree_sitter::Node<'a> {
+        // SAFETY: `TsNode` is a copy of `TSNode`'s layout, checked for
+        // size and alignment where `StableLike::new` builds the wrapper,
+        // and `tree_sitter::Node` is `#[repr(transparent)]` over `TSNode`.
         unsafe { *self.node.as_ref_unchecked() }
     }
 

--- a/crates/whisker-types/src/ts_node.rs
+++ b/crates/whisker-types/src/ts_node.rs
@@ -28,7 +28,12 @@ pub struct TsNode {
     tree: *const c_void,
 }
 
+// SAFETY: nothing constructs a `TsNode`, so no value of it is ever sent
+// or shared. The implementations exist so that the `PhantomData` inside
+// `StableLike` does not strip `Send` and `Sync` from `DecoratedNode`,
+// which `tree_sitter::Node` has.
 unsafe impl Send for TsNode {}
+// SAFETY: as for `Send` above.
 unsafe impl Sync for TsNode {}
 
 #[cfg(test)]

--- a/crates/whisker/src/custom_lints.rs
+++ b/crates/whisker/src/custom_lints.rs
@@ -399,10 +399,17 @@ fn build(directory: &Path, locking: Locking) -> anyhow::Result<Vec<PathBuf>> {
 ///
 /// [`RuleId`]: whisker_types::RuleId
 fn load_library(library: &Path, host: &AbiIdentity) -> anyhow::Result<Loaded> {
+    // SAFETY: opening a library runs its initializers, which is unsound
+    // for any library whose initializers are. Whisker opens only what a
+    // project's configuration names, which the project already trusts to
+    // run as a lint.
     let library = unsafe { Library::new(library) }
         .with_context(|| format!("failed to open {}", library.display()))?;
 
     let declaration =
+        // SAFETY: the symbol's type is checked before the value is used.
+        // `abi_version` reads the first field, and the handshake refuses
+        // the library unless the whole declaration matches this binary.
         unsafe { library.get::<*const PluginDeclaration>(b"whisker_plugin_declaration\0") }
             .context(
                 "the library is not a whisker lint plugin; export its lints with \
@@ -410,6 +417,8 @@ fn load_library(library: &Path, host: &AbiIdentity) -> anyhow::Result<Loaded> {
             )?;
     let declaration: *const PluginDeclaration = *declaration;
 
+    // SAFETY: `declaration` is the address `dlsym` gave for the loaded
+    // library's `whisker_plugin_declaration` static.
     let plugin_abi_version = unsafe { abi_version(declaration) };
     if !handshake::supported(plugin_abi_version) {
         return Err(handshake::HandshakeMismatch::AbiVersion {
@@ -422,11 +431,17 @@ fn load_library(library: &Path, host: &AbiIdentity) -> anyhow::Result<Loaded> {
 
     let plugin = AbiIdentity {
         abi_version: plugin_abi_version,
+        // SAFETY: the protocol is one this binary knows, so the plugin
+        // lays both fields out where this binary reads them.
         types_fingerprint: unsafe { (&raw const (*declaration).types_fingerprint).read() },
+        // SAFETY: as for `types_fingerprint` above.
         language_fingerprint: unsafe { (&raw const (*declaration).language_fingerprint).read() },
     };
     handshake::validate(host, &plugin)?;
 
+    // SAFETY: the handshake passed, so the plugin lays the declaration
+    // out the way this binary does, and `load` holds a function this
+    // binary can call.
     let load = unsafe { (&raw const (*declaration).load).read() };
     let loaded: Result<_, Panic> = load().into();
     let loaded = loaded.context("the plugin panicked while listing what it exports")?;
@@ -457,6 +472,9 @@ fn load_library(library: &Path, host: &AbiIdentity) -> anyhow::Result<Loaded> {
 /// `declaration` must be the address of a loaded library's
 /// `whisker_plugin_declaration` static.
 unsafe fn abi_version(declaration: *const PluginDeclaration) -> u32 {
+    // SAFETY: every protocol puts `abi_version` first, which the
+    // `abi_version_sits_at_offset_zero` test pins, so the first four
+    // bytes of any declaration are this field.
     unsafe { declaration.cast::<u32>().read_unaligned() }
 }
 
@@ -499,6 +517,8 @@ mod tests {
         }
         let truncated = Truncated { abi_version: 7 };
 
+        // SAFETY: `Truncated` holds the one field `abi_version` reads,
+        // which is what this test pins about a shorter declaration.
         let version = unsafe { abi_version((&raw const truncated).cast::<PluginDeclaration>()) };
 
         assert_eq!(version, 7);

--- a/crates/whisker/tests/git_lints.rs
+++ b/crates/whisker/tests/git_lints.rs
@@ -120,6 +120,8 @@ fn fixture_repository_ignores_an_ambient_git_environment() {
     let index_before = std::fs::read(git_dir.join("index")).expect("the index should be readable");
     let config_before =
         std::fs::read(git_dir.join("config")).expect("the config should be readable");
+    // SAFETY: nextest runs each test in its own process, so no other
+    // thread reads the environment while this writes it.
     unsafe {
         std::env::set_var("GIT_DIR", &git_dir);
         std::env::set_var("GIT_INDEX_FILE", git_dir.join("index"));
@@ -127,6 +129,7 @@ fn fixture_repository_ignores_an_ambient_git_environment() {
 
     let rules = repository_with_one_lint("fixture.no-todo");
 
+    // SAFETY: as for the two `set_var` calls above.
     unsafe {
         std::env::remove_var("GIT_DIR");
         std::env::remove_var("GIT_INDEX_FILE");


### PR DESCRIPTION
Whisker had no safety comments. A reader who wanted to check an `unsafe` block had to reconstruct the invariant from the code around it. A reviewer had no way to tell a block whose reason someone considered from one whose reason someone assumed.

This pull request turns on `clippy::undocumented_unsafe_blocks` and writes the thirteen comments it asks for. Each one says what the caller or the surrounding code guarantees, because that is the part a reader cannot see. A comment that restates the operation is not a safety comment, and the guidance says so.

The loader carries eight of the thirteen. They cover `dlopen`, the symbol lookup, the three raw field reads, and `abi_version`. The rest cover the node wrapper, its `Send` and `Sync` pair, and the two environment writes in the git tests.

`CLAUDE.md` forbids inline comments and allows doc comments alone, so it now carves out the exception this lint requires. The carve-out covers `unsafe` and nothing else.

The lint warns, and CI denies warnings. It is a restriction lint, so it reports only the blocks it is pointed at, and a new `unsafe` block fails the build until someone writes its reason.

This stacks on https://github.com/aonyx-ai/whisker/pull/367, which removes most of the `unsafe` that this repository used to carry.
