### PR TITLE
Pin the rules to a commit on their main branch

### DIFF
--- a/.config/whisker.toml
+++ b/.config/whisker.toml
@@ -9,4 +9,4 @@ ignore = ["/examples/", "crates/whisker-rust/tests/fixtures/"]
 # check here runs exactly the rules it ran yesterday.
 [[lints]]
 git = "https://github.com/aonyx-ai/whisker-aonyx-rules"
-rev = "3bba66677f5e67b422ca4a02d37af053c6f48112"
+rev = "f0bc41c1506025cc769a2d5fd7f52edbd7bed89d"

--- a/justfile
+++ b/justfile
@@ -22,6 +22,7 @@ pre-commit-inner:
 
 pre-commit:
     just pre-commit-inner
+    just check-self
 
 # Check that dependencies have compatible open-source licenses and trusted sources
 check-dependencies:


### PR DESCRIPTION
Whisker pointed at a rules commit that only the `abi/stable-layouts` branch reached. That commit existed so that the rules could name a whisker commit before whisker named them back. The stacked boundary work needed that order.

Both sides are merged now, so the pin moves to a commit on the rules main branch. That commit pins this repository's main in turn, so no scratch branch is left in the path. The `abi/*-pin` branches can go once this lands.

The second commit runs `check-self` at the end of `pre-commit`. The recipe formatted, linted, and tested, but it never loaded a lint plugin, so a change that broke the plugin boundary passed every local check. That is not a theory: it happened during the boundary work, when the export macro named a crate that plugin crates do not depend on, and only the tests that build a real library caught it.

The recipe reaches the network and builds the rules in release, which is why it stays out of `cargo test`. It runs after the fast checks, so a formatting mistake still fails in seconds. A commit costs about a minute more once the cache is warm, and more when the pin moves.
