### PR TITLE
Build the configured lints against a whisker of the project's choosing

### DIFF
--- a/.config/whisker.toml
+++ b/.config/whisker.toml
@@ -4,6 +4,12 @@
 # purpose.
 ignore = ["/examples/", "crates/whisker-rust/tests/fixtures/"]
 
+# Every lint builds against the whisker in this directory, not against the
+# whisker its own manifest names. The rules repository pins a whisker commit
+# so that it can build on its own, and this overrides that pin, so a check
+# here runs the rules against the working tree.
+whisker-source = "."
+
 # Whisker's rules live in their own repository, pinned to one commit. Bumping
 # this is how whisker adopts a new rule or a changed one; until it moves, a
 # check here runs exactly the rules it ran yesterday.

--- a/crates/whisker/src/config.rs
+++ b/crates/whisker/src/config.rs
@@ -1,5 +1,5 @@
 use std::collections::BTreeMap;
-use std::path::Path;
+use std::path::{Path, PathBuf};
 
 use anyhow::Context as _;
 use kawauso_project::project::ProjectRoot;
@@ -50,6 +50,7 @@ pub struct WhiskerConfig {
     lints: Vec<LintSource>,
     rules: RuleFilter,
     options: RuleOptions,
+    whisker_source: Option<PathBuf>,
 }
 
 impl WhiskerConfig {
@@ -89,6 +90,7 @@ impl WhiskerConfig {
             lints,
             rules,
             options,
+            whisker_source: None,
         }
     }
 
@@ -161,6 +163,7 @@ impl WhiskerConfig {
             ignore,
             lints,
             rules,
+            whisker_source,
         }) = project.configuration()
         else {
             return Ok(Self::new(root, Vec::new(), Vec::new()));
@@ -191,7 +194,32 @@ impl WhiskerConfig {
             .collect::<anyhow::Result<Vec<_>>>()
             .with_context(|| format!("failed to read {}", project.configuration_path()))?;
 
-        Ok(Self::with_rules(root, ignore, lints, rules, options))
+        let whisker_source = whisker_source
+            .as_ref()
+            .map(|directory| root.get().join(directory));
+
+        Ok(Self {
+            root,
+            ignore,
+            lints,
+            rules,
+            options,
+            whisker_source,
+        })
+    }
+
+    /// Returns the whisker source that every configured lint builds against
+    ///
+    /// A lint package names a whisker of its own, and that name decides
+    /// which whisker the plugin is laid out by. This overrides it, so a
+    /// plugin is built against the whisker that loads it and the two
+    /// fingerprints match by construction.
+    ///
+    /// Only a project that holds whisker's own source sets this. A project
+    /// that does not leaves it unset and pins a lint source that names a
+    /// whisker revision, which is what the handshake checks.
+    pub fn whisker_source(&self) -> Option<&Path> {
+        self.whisker_source.as_deref()
     }
 
     /// Returns the project directory that anchors the ignore patterns
@@ -271,6 +299,9 @@ struct ConfigTable {
 
     #[serde(default)]
     rules: RulesTable,
+
+    #[serde(default, rename = "whisker-source")]
+    whisker_source: Option<String>,
 }
 
 /// The `[rules]` table as written on disk
@@ -491,6 +522,39 @@ mod tests {
             std::fs::canonicalize(&inner).expect("the inner project should resolve")
         );
         assert_eq!(config.ignore(), vec![IgnorePattern::new("inner/")]);
+    }
+
+    #[test]
+    fn load_with_a_whisker_source_anchors_it_at_the_root() {
+        let project = tempfile::tempdir().expect("temporary directory should be created");
+        std::fs::create_dir_all(project.path().join(".config"))
+            .expect("the config directory should be created");
+        std::fs::write(
+            project.path().join(".config").join("whisker.toml"),
+            "whisker-source = \"vendor/whisker\"\n",
+        )
+        .expect("the config should be written");
+
+        let config = WhiskerConfig::load(project.path()).expect("the config should load");
+
+        let expected = config.root().get().join("vendor").join("whisker");
+        assert_eq!(config.whisker_source(), Some(expected.as_path()));
+    }
+
+    #[test]
+    fn load_without_a_whisker_source_returns_none() {
+        let project = tempfile::tempdir().expect("temporary directory should be created");
+        std::fs::create_dir_all(project.path().join(".config"))
+            .expect("the config directory should be created");
+        std::fs::write(
+            project.path().join(".config").join("whisker.toml"),
+            "ignore = []\n",
+        )
+        .expect("the config should be written");
+
+        let config = WhiskerConfig::load(project.path()).expect("the config should load");
+
+        assert!(config.whisker_source().is_none());
     }
 
     #[test]

--- a/crates/whisker/src/custom_lints.rs
+++ b/crates/whisker/src/custom_lints.rs
@@ -57,10 +57,12 @@ impl CustomLints {
         } in configured_sources(config, &AbiTag::host())?
         {
             let loaded = match contents {
-                Contents::Sources(locking) => load_sources(&directory, locking, &host)
-                    .with_context(|| {
-                        format!("failed to load the custom lints at {}", directory.display())
-                    }),
+                Contents::Sources(locking) => {
+                    { load_sources(&directory, locking, config.whisker_source(), &host) }
+                        .with_context(|| {
+                            format!("failed to load the custom lints at {}", directory.display())
+                        })
+                }
                 Contents::Libraries => load_prebuilt(&directory, &host).with_context(|| {
                     format!(
                         "failed to load the prebuilt lints at {}",
@@ -154,6 +156,18 @@ enum Contents {
     Libraries,
 }
 
+/// The git URL a lint package names when it depends on whisker
+///
+/// A patch entry is keyed by the source it replaces, so this must be
+/// spelled the way a lint package spells it.
+const WHISKER_GIT_URL: &str = "https://github.com/aonyx-ai/whisker.git";
+
+/// The whisker crates a lint package can depend on
+///
+/// Each one is patched to the local source, so a package that names any
+/// of them builds against the whisker that loads it.
+const WHISKER_CRATES: [&str; 3] = ["whisker-types", "whisker-rust", "whisker-testing"];
+
 /// Whether a build may change the lockfile it finds
 ///
 /// A path source belongs to the person running whisker, and cargo updating
@@ -161,6 +175,10 @@ enum Contents {
 /// pin is only worth as much as the dependency versions behind it, so its
 /// build refuses to resolve anything the committed lockfile did not
 /// already settle.
+///
+/// A patched build is the exception. Replacing the whisker a package
+/// names changes the graph the lockfile settled, so cargo has to resolve
+/// again and `--locked` would refuse the build.
 #[derive(Copy, Clone, Eq, PartialEq, Debug)]
 enum Locking {
     Locked,
@@ -275,8 +293,13 @@ fn resolve_git(source: &GitLintSource, tag: &AbiTag) -> anyhow::Result<(PathBuf,
 /// A directory may hold one package or a workspace of them, so every
 /// dynamic library the build produced is loaded, each with its own
 /// handshake.
-fn load_sources(directory: &Path, locking: Locking, host: &AbiIdentity) -> anyhow::Result<Loaded> {
-    let libraries = build(directory, locking)?;
+fn load_sources(
+    directory: &Path,
+    locking: Locking,
+    whisker_source: Option<&Path>,
+    host: &AbiIdentity,
+) -> anyhow::Result<Loaded> {
+    let libraries = build(directory, locking, whisker_source)?;
 
     load_libraries(&libraries, host)
 }
@@ -336,7 +359,11 @@ struct Loaded {
 ///
 /// Returns an error if cargo cannot be run, exits unsuccessfully, or
 /// produces no dynamic library.
-fn build(directory: &Path, locking: Locking) -> anyhow::Result<Vec<PathBuf>> {
+fn build(
+    directory: &Path,
+    locking: Locking,
+    whisker_source: Option<&Path>,
+) -> anyhow::Result<Vec<PathBuf>> {
     let cargo = std::env::var_os("CARGO").unwrap_or_else(|| OsString::from("cargo"));
 
     let mut command = Command::new(cargo);
@@ -346,11 +373,20 @@ fn build(directory: &Path, locking: Locking) -> anyhow::Result<Vec<PathBuf>> {
         "--message-format=json-render-diagnostics",
     ]);
 
-    match locking {
-        Locking::Locked => {
+    match (locking, whisker_source) {
+        (Locking::Locked, None) => {
             command.arg("--locked");
         }
-        Locking::Unlocked => {}
+        (Locking::Locked, Some(_)) | (Locking::Unlocked, _) => {}
+    }
+
+    if let Some(source) = whisker_source {
+        for crate_name in WHISKER_CRATES {
+            command.arg("--config").arg(format!(
+                "patch.'{WHISKER_GIT_URL}'.{crate_name}.path='{}'",
+                source.join("crates").join(crate_name).display()
+            ));
+        }
     }
 
     let output = command


### PR DESCRIPTION
A lint package names a whisker of its own, and that name decided which whisker laid the plugin out. Whisker's own check therefore pinned a rules commit whose manifest pinned whisker back. A change to a boundary type needed both pins to move together, through scratch branches that existed only to give each side a hash to name. The stacked boundary work paid that cost eight times.

This pull request adds a `whisker-source` key to the configuration. When a project sets it, every configured lint builds against the whisker source in that directory rather than the one its own manifest names. The two fingerprints then match by construction, so a boundary change and the rules that read it can move in one commit.

Whisker's own configuration sets the key to `.`, and nothing else should. A project that does not hold whisker's source leaves the key unset and keeps the pin it had. That pin is what the handshake checks, and the handshake is unchanged.

A patched build cannot pass `--locked`. Replacing a dependency changes the graph that the lockfile settled, so cargo resolves again, and `--locked` refuses the build with a clear message. The build therefore drops the flag when it patches, and only then. A git source without a patch keeps the strict behavior, which is what makes a pinned commit worth pinning.

I checked the claim rather than argued it. With the key set, I added a field to `Plugin`, which is a boundary type inside `TYPES_FINGERPRINT`. The self check passed, because the rules rebuilt against the changed tree. The same change on main refuses all fourteen plugins until both pins move.
